### PR TITLE
fix namespace in csi-node clusterrole

### DIFF
--- a/deploy/kubernetes/manifest.yaml
+++ b/deploy/kubernetes/manifest.yaml
@@ -13,7 +13,7 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: csi-node
-  namespace: default
+  namespace: kube-system
 rules:
   - apiGroups: [""]
     resources: ["secrets"]


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
bug fix

**What is this PR about? / Why do we need it?**
there was a mistake in the example manifest file provided for the EFS driver. Specifically ClusterRole declaration for the CSI Node had the wrong namespace `default`. 

**What testing is done?** 
Tested the full flow with both eksctl tool and Pulumi code base using this [example](https://github.com/pulumi/docs/blob/master/content/blog/persisting-kubernetes-workloads-with-amazon-efscsi-volumes-using-pulumi-sdks/index.md)
