### PR TITLE
Refactor node tests to be table-driven

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/kubernetes-sigs/aws-efs-csi-driver
 
 require (
 	github.com/aws/aws-sdk-go v1.16.5
-	github.com/container-storage-interface/spec v0.3.0
+	github.com/container-storage-interface/spec v1.1.0
 	github.com/golang/mock v1.2.0
 	github.com/spf13/afero v1.2.1 // indirect
 	github.com/stretchr/testify v1.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/aws/aws-sdk-go v1.16.5/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/container-storage-interface/spec v0.3.0 h1:ALxSqFjptj8R5rL+cdyAbwbaLHHXDL5pmp1qIh1b+38=
 github.com/container-storage-interface/spec v0.3.0/go.mod h1:6URME8mwIBbpVyZV93Ce5St17xBiQJQY67NDsuohiy4=
+github.com/container-storage-interface/spec v1.1.0 h1:qPsTqtR1VUPvMPeK0UnCZMtXaKGyyLPG8gj/wG6VqMs=
+github.com/container-storage-interface/spec v1.1.0/go.mod h1:6URME8mwIBbpVyZV93Ce5St17xBiQJQY67NDsuohiy4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"net"
 
-	csi "github.com/container-storage-interface/spec/lib/go/csi/v0"
+	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/kubernetes-sigs/aws-efs-csi-driver/pkg/cloud"
 	"github.com/kubernetes-sigs/aws-efs-csi-driver/pkg/util"
 	"google.golang.org/grpc"
@@ -30,17 +30,6 @@ import (
 
 const (
 	driverName = "efs.csi.aws.com"
-)
-
-var (
-	volumeCaps = []csi.VolumeCapability_AccessMode{
-		{
-			Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
-		},
-		{
-			Mode: csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER,
-		},
-	}
 )
 
 type Driver struct {

--- a/pkg/driver/identity.go
+++ b/pkg/driver/identity.go
@@ -19,7 +19,7 @@ package driver
 import (
 	"context"
 
-	csi "github.com/container-storage-interface/spec/lib/go/csi/v0"
+	"github.com/container-storage-interface/spec/lib/go/csi"
 )
 
 func (d *Driver) GetPluginInfo(ctx context.Context, req *csi.GetPluginInfoRequest) (*csi.GetPluginInfoResponse, error) {

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -21,14 +21,18 @@ import (
 	"fmt"
 	"os"
 
-	csi "github.com/container-storage-interface/spec/lib/go/csi/v0"
+	"github.com/container-storage-interface/spec/lib/go/csi"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"k8s.io/klog"
 )
 
 var (
-	nodeCaps = []csi.NodeServiceCapability_RPC_Type{}
+	nodeCaps   = []csi.NodeServiceCapability_RPC_Type{}
+	volumeCaps = []csi.VolumeCapability_AccessMode_Mode{
+		csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+		csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER,
+	}
 )
 
 func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRequest) (*csi.NodeStageVolumeResponse, error) {
@@ -110,6 +114,14 @@ func (d *Driver) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpublish
 	return &csi.NodeUnpublishVolumeResponse{}, nil
 }
 
+func (d *Driver) NodeGetVolumeStats(ctx context.Context, req *csi.NodeGetVolumeStatsRequest) (*csi.NodeGetVolumeStatsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "")
+}
+
+func (d *Driver) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandVolumeRequest) (*csi.NodeExpandVolumeResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "")
+}
+
 func (d *Driver) NodeGetCapabilities(ctx context.Context, req *csi.NodeGetCapabilitiesRequest) (*csi.NodeGetCapabilitiesResponse, error) {
 	klog.V(4).Infof("NodeGetCapabilities: called with args %+v", req)
 	var caps []*csi.NodeServiceCapability
@@ -134,17 +146,10 @@ func (d *Driver) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoRequest) (
 	}, nil
 }
 
-func (d *Driver) NodeGetId(ctx context.Context, req *csi.NodeGetIdRequest) (*csi.NodeGetIdResponse, error) {
-	klog.V(4).Infof("NodeGetId: called with args %+v", req)
-	return &csi.NodeGetIdResponse{
-		NodeId: d.nodeID,
-	}, nil
-}
-
 func (d *Driver) isValidVolumeCapabilities(volCaps []*csi.VolumeCapability) bool {
 	hasSupport := func(cap *csi.VolumeCapability) bool {
 		for _, c := range volumeCaps {
-			if c.GetMode() == cap.AccessMode.GetMode() {
+			if c == cap.AccessMode.GetMode() {
 				return true
 			}
 		}

--- a/pkg/driver/node_test.go
+++ b/pkg/driver/node_test.go
@@ -44,253 +44,164 @@ func TestNodePublishVolume(t *testing.T) {
 	)
 
 	testCases := []struct {
-		name     string
-		testFunc func(t *testing.T)
+		name          string
+		readOnly      bool
+		volCap        *csi.VolumeCapability
+		targetPath    string
+		expectMakeDir bool
+		makeDirErr    error
+		expectMount   bool
+		mountErr      error
+		expectFail    bool
 	}{
 		{
-			name: "success: normal",
-			testFunc: func(t *testing.T) {
-				mockCtrl := gomock.NewController(t)
-				mockMounter := mocks.NewMockInterface(mockCtrl)
-				driver := &Driver{
-					endpoint: endpoint,
-					nodeID:   nodeID,
-					mounter:  mockMounter,
-				}
-				source := volumeId + ":/"
-
-				ctx := context.Background()
-				req := &csi.NodePublishVolumeRequest{
-					VolumeId:         volumeId,
-					VolumeCapability: stdVolCap,
-					TargetPath:       targetPath,
-				}
-
-				mockMounter.EXPECT().MakeDir(gomock.Eq(targetPath)).Return(nil)
-				mockMounter.EXPECT().Mount(gomock.Eq(source), gomock.Eq(targetPath), gomock.Eq("efs"), gomock.Any()).Return(nil)
-				_, err := driver.NodePublishVolume(ctx, req)
-				if err != nil {
-					t.Fatalf("NodePublishVolume is failed: %v", err)
-				}
-
-				mockCtrl.Finish()
-			},
+			name:          "success: normal",
+			readOnly:      false,
+			volCap:        stdVolCap,
+			targetPath:    targetPath,
+			expectMakeDir: true,
+			makeDirErr:    nil,
+			expectMount:   true,
+			mountErr:      nil,
+			expectFail:    false,
 		},
 		{
-			name: "success: normal with read only mount",
-			testFunc: func(t *testing.T) {
-				mockCtrl := gomock.NewController(t)
-				mockMounter := mocks.NewMockInterface(mockCtrl)
-				driver := &Driver{
-					endpoint: endpoint,
-					nodeID:   nodeID,
-					mounter:  mockMounter,
-				}
-				source := volumeId + ":/"
-
-				ctx := context.Background()
-				req := &csi.NodePublishVolumeRequest{
-					VolumeId:         volumeId,
-					VolumeCapability: stdVolCap,
-					TargetPath:       targetPath,
-					Readonly:         true,
-				}
-
-				mockMounter.EXPECT().MakeDir(gomock.Eq(targetPath)).Return(nil)
-				mockMounter.EXPECT().Mount(gomock.Eq(source), gomock.Eq(targetPath), gomock.Eq("efs"), gomock.Eq([]string{"ro"})).Return(nil)
-				_, err := driver.NodePublishVolume(ctx, req)
-				if err != nil {
-					t.Fatalf("NodePublishVolume is failed: %v", err)
-				}
-
-				mockCtrl.Finish()
-			},
+			name:          "success: normal with read only mount",
+			readOnly:      true,
+			volCap:        stdVolCap,
+			targetPath:    targetPath,
+			expectMakeDir: true,
+			makeDirErr:    nil,
+			expectMount:   true,
+			mountErr:      nil,
+			expectFail:    false,
 		},
 		{
-			name: "success: normal with tls mount options",
-			testFunc: func(t *testing.T) {
-				mockCtrl := gomock.NewController(t)
-				mockMounter := mocks.NewMockInterface(mockCtrl)
-				driver := &Driver{
-					endpoint: endpoint,
-					nodeID:   nodeID,
-					mounter:  mockMounter,
-				}
-				source := volumeId + ":/"
-
-				ctx := context.Background()
-				req := &csi.NodePublishVolumeRequest{
-					VolumeId: volumeId,
-					VolumeCapability: &csi.VolumeCapability{
-						AccessType: &csi.VolumeCapability_Mount{
-							Mount: &csi.VolumeCapability_MountVolume{
-								MountFlags: []string{"tls"},
-							},
-						},
-						AccessMode: &csi.VolumeCapability_AccessMode{
-							Mode: csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER,
-						},
+			name:     "success: normal with tls mount options",
+			readOnly: false,
+			volCap: &csi.VolumeCapability{
+				AccessType: &csi.VolumeCapability_Mount{
+					Mount: &csi.VolumeCapability_MountVolume{
+						MountFlags: []string{"tls"},
 					},
-					TargetPath: targetPath,
-				}
-
-				mockMounter.EXPECT().MakeDir(gomock.Eq(targetPath)).Return(nil)
-				mockMounter.EXPECT().Mount(gomock.Eq(source), gomock.Eq(targetPath), gomock.Eq("efs"), gomock.Eq([]string{"tls"})).Return(nil)
-				_, err := driver.NodePublishVolume(ctx, req)
-				if err != nil {
-					t.Fatalf("NodePublishVolume is failed: %v", err)
-				}
-
-				mockCtrl.Finish()
+				},
+				AccessMode: &csi.VolumeCapability_AccessMode{
+					Mode: csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER,
+				},
 			},
+			targetPath:    targetPath,
+			expectMakeDir: true,
+			makeDirErr:    nil,
+			expectMount:   true,
+			mountErr:      nil,
+			expectFail:    false,
 		},
 		{
-			name: "fail: missing target path",
-			testFunc: func(t *testing.T) {
-				mockCtrl := gomock.NewController(t)
-				mockMounter := mocks.NewMockInterface(mockCtrl)
-				driver := &Driver{
-					endpoint: endpoint,
-					nodeID:   nodeID,
-					mounter:  mockMounter,
-				}
-
-				ctx := context.Background()
-				req := &csi.NodePublishVolumeRequest{
-					VolumeId:         volumeId,
-					VolumeCapability: stdVolCap,
-				}
-
-				_, err := driver.NodePublishVolume(ctx, req)
-				if err == nil {
-					t.Fatalf("NodePublishVolume is not failed: %v", err)
-				}
-
-				mockCtrl.Finish()
-			},
+			name:          "fail: missing target path",
+			readOnly:      false,
+			volCap:        stdVolCap,
+			targetPath:    "",
+			expectMakeDir: false,
+			makeDirErr:    nil,
+			expectMount:   false,
+			mountErr:      nil,
+			expectFail:    true,
 		},
 		{
-			name: "fail: missing volume capability",
-			testFunc: func(t *testing.T) {
-				mockCtrl := gomock.NewController(t)
-				mockMounter := mocks.NewMockInterface(mockCtrl)
-				driver := &Driver{
-					endpoint: endpoint,
-					nodeID:   nodeID,
-					mounter:  mockMounter,
-				}
-
-				ctx := context.Background()
-				req := &csi.NodePublishVolumeRequest{
-					VolumeId:   volumeId,
-					TargetPath: targetPath,
-				}
-
-				_, err := driver.NodePublishVolume(ctx, req)
-				if err == nil {
-					t.Fatalf("NodePublishVolume is not failed: %v", err)
-				}
-
-				mockCtrl.Finish()
-			},
+			name:          "fail: missing volume capability",
+			readOnly:      false,
+			volCap:        nil,
+			targetPath:    targetPath,
+			expectMakeDir: false,
+			makeDirErr:    nil,
+			expectMount:   false,
+			mountErr:      nil,
+			expectFail:    true,
 		},
 		{
-			name: "fail: unsupported volume capability",
-			testFunc: func(t *testing.T) {
-				mockCtrl := gomock.NewController(t)
-				mockMounter := mocks.NewMockInterface(mockCtrl)
-				driver := &Driver{
-					endpoint: endpoint,
-					nodeID:   nodeID,
-					mounter:  mockMounter,
-				}
-
-				ctx := context.Background()
-				req := &csi.NodePublishVolumeRequest{
-					VolumeId: volumeId,
-					VolumeCapability: &csi.VolumeCapability{
-						AccessType: &csi.VolumeCapability_Mount{
-							Mount: &csi.VolumeCapability_MountVolume{},
-						},
-						AccessMode: &csi.VolumeCapability_AccessMode{
-							Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_READER_ONLY,
-						},
-					},
-					TargetPath: targetPath,
-				}
-
-				_, err := driver.NodePublishVolume(ctx, req)
-				if err == nil {
-					t.Fatalf("NodePublishVolume is not failed: %v", err)
-				}
-
-				mockCtrl.Finish()
+			name:     "fail: unsupported volume capability",
+			readOnly: false,
+			volCap: &csi.VolumeCapability{
+				AccessType: &csi.VolumeCapability_Mount{
+					Mount: &csi.VolumeCapability_MountVolume{},
+				},
+				AccessMode: &csi.VolumeCapability_AccessMode{
+					Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_READER_ONLY,
+				},
 			},
+			targetPath:    targetPath,
+			expectMakeDir: false,
+			makeDirErr:    nil,
+			expectMount:   false,
+			mountErr:      nil,
+			expectFail:    true,
 		},
 		{
-			name: "fail: mounter failed to MakeDir",
-			testFunc: func(t *testing.T) {
-				mockCtrl := gomock.NewController(t)
-				mockMounter := mocks.NewMockInterface(mockCtrl)
-				driver := &Driver{
-					endpoint: endpoint,
-					nodeID:   nodeID,
-					mounter:  mockMounter,
-				}
-
-				ctx := context.Background()
-				req := &csi.NodePublishVolumeRequest{
-					VolumeId:         volumeId,
-					VolumeCapability: stdVolCap,
-					TargetPath:       targetPath,
-				}
-
-				err := fmt.Errorf("failed to MakeDir")
-				mockMounter.EXPECT().MakeDir(gomock.Eq(targetPath)).Return(err)
-
-				_, err = driver.NodePublishVolume(ctx, req)
-				if err == nil {
-					t.Fatalf("NodePublishVolume is not failed: %v", err)
-				}
-
-				mockCtrl.Finish()
-			},
+			name:          "fail: mounter failed to MakeDir",
+			readOnly:      false,
+			volCap:        stdVolCap,
+			targetPath:    targetPath,
+			expectMakeDir: true,
+			makeDirErr:    fmt.Errorf("failed to MakeDir"),
+			expectMount:   false,
+			mountErr:      nil,
+			expectFail:    true,
 		},
 		{
-			name: "fail: mounter failed to Mount",
-			testFunc: func(t *testing.T) {
-				mockCtrl := gomock.NewController(t)
-				mockMounter := mocks.NewMockInterface(mockCtrl)
-				driver := &Driver{
-					endpoint: endpoint,
-					nodeID:   nodeID,
-					mounter:  mockMounter,
-				}
-
-				ctx := context.Background()
-				req := &csi.NodePublishVolumeRequest{
-					VolumeId:         volumeId,
-					VolumeCapability: stdVolCap,
-					TargetPath:       targetPath,
-				}
-				source := volumeId + ":/"
-
-				err := fmt.Errorf("failed to Mount")
-				mockMounter.EXPECT().MakeDir(gomock.Eq(targetPath)).Return(nil)
-				mockMounter.EXPECT().Mount(gomock.Eq(source), gomock.Eq(targetPath), gomock.Eq("efs"), gomock.Any()).Return(err)
-
-				_, err = driver.NodePublishVolume(ctx, req)
-				if err == nil {
-					t.Fatalf("NodePublishVolume is not failed: %v", err)
-				}
-
-				mockCtrl.Finish()
-			},
+			name:          "fail: mounter failed to Mount",
+			readOnly:      false,
+			volCap:        stdVolCap,
+			targetPath:    targetPath,
+			expectMakeDir: true,
+			makeDirErr:    nil,
+			expectMount:   true,
+			mountErr:      fmt.Errorf("failed to Mount"),
+			expectFail:    true,
 		},
 	}
-
 	for _, tc := range testCases {
-		t.Run(tc.name, tc.testFunc)
+		t.Run(tc.name, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			mockMounter := mocks.NewMockInterface(mockCtrl)
+			driver := &Driver{
+				endpoint: endpoint,
+				nodeID:   nodeID,
+				mounter:  mockMounter,
+			}
+			source := volumeId + ":/"
+
+			ctx := context.Background()
+			req := &csi.NodePublishVolumeRequest{
+				VolumeId:         volumeId,
+				VolumeCapability: tc.volCap,
+				TargetPath:       tc.targetPath,
+				Readonly:         tc.readOnly,
+			}
+
+			if tc.expectMakeDir {
+				mockMounter.EXPECT().MakeDir(gomock.Eq(tc.targetPath)).Return(tc.makeDirErr)
+			}
+
+			mountFlags := []string{}
+			if tc.readOnly {
+				mountFlags = append(mountFlags, "ro")
+			}
+			if tc.volCap != nil {
+				mountFlags = append(mountFlags, tc.volCap.AccessType.(*csi.VolumeCapability_Mount).Mount.MountFlags...)
+			}
+			if tc.expectMount {
+				mockMounter.EXPECT().Mount(gomock.Eq(source), gomock.Eq(tc.targetPath), gomock.Eq("efs"), gomock.Eq(mountFlags)).Return(tc.mountErr)
+			}
+
+			_, err := driver.NodePublishVolume(ctx, req)
+			if err != nil && !tc.expectFail {
+				t.Fatalf("NodePublishVolume is failed: %v", err)
+			} else if err == nil && tc.expectFail {
+				t.Fatalf("NodePublishVolume is not failed: %v", err)
+			}
+
+			mockCtrl.Finish()
+		})
 	}
 }
 
@@ -304,84 +215,60 @@ func TestNodeUnpublishVolume(t *testing.T) {
 	)
 
 	testCases := []struct {
-		name     string
-		testFunc func(t *testing.T)
+		name          string
+		targetPath    string
+		expectUnmount bool
+		unmountErr    error
+		expectFail    bool
 	}{
 		{
-			name: "success: normal",
-			testFunc: func(t *testing.T) {
-				mockCtrl := gomock.NewController(t)
-				mockMounter := mocks.NewMockInterface(mockCtrl)
-				driver := &Driver{
-					endpoint: endpoint,
-					nodeID:   nodeID,
-					mounter:  mockMounter,
-				}
-
-				ctx := context.Background()
-				req := &csi.NodeUnpublishVolumeRequest{
-					VolumeId:   volumeId,
-					TargetPath: targetPath,
-				}
-
-				mockMounter.EXPECT().Unmount(gomock.Eq(targetPath)).Return(nil)
-
-				_, err := driver.NodeUnpublishVolume(ctx, req)
-				if err != nil {
-					t.Fatalf("NodeUnpublishVolume is failed: %v", err)
-				}
-			},
+			name:          "success: normal",
+			targetPath:    targetPath,
+			expectUnmount: true,
+			unmountErr:    nil,
+			expectFail:    false,
 		},
 		{
-			name: "fail: targetPath is missing",
-			testFunc: func(t *testing.T) {
-				mockCtrl := gomock.NewController(t)
-				mockMounter := mocks.NewMockInterface(mockCtrl)
-				driver := &Driver{
-					endpoint: endpoint,
-					nodeID:   nodeID,
-					mounter:  mockMounter,
-				}
-
-				ctx := context.Background()
-				req := &csi.NodeUnpublishVolumeRequest{
-					VolumeId: volumeId,
-				}
-
-				_, err := driver.NodeUnpublishVolume(ctx, req)
-				if err == nil {
-					t.Fatalf("NodeUnpublishVolume is not failed: %v", err)
-				}
-			},
+			name:          "fail: targetPath is missing",
+			targetPath:    "",
+			expectUnmount: false,
+			unmountErr:    nil,
+			expectFail:    true,
 		},
 		{
-			name: "fail: mounter failed to umount",
-			testFunc: func(t *testing.T) {
-				mockCtrl := gomock.NewController(t)
-				mockMounter := mocks.NewMockInterface(mockCtrl)
-				driver := &Driver{
-					endpoint: endpoint,
-					nodeID:   nodeID,
-					mounter:  mockMounter,
-				}
-
-				ctx := context.Background()
-				req := &csi.NodeUnpublishVolumeRequest{
-					VolumeId:   volumeId,
-					TargetPath: targetPath,
-				}
-
-				mountErr := fmt.Errorf("Unmount failed")
-				mockMounter.EXPECT().Unmount(gomock.Eq(targetPath)).Return(mountErr)
-
-				_, err := driver.NodeUnpublishVolume(ctx, req)
-				if err == nil {
-					t.Fatalf("NodeUnpublishVolume is not failed: %v", err)
-				}
-			},
+			name:          "fail: mounter failed to umount",
+			targetPath:    targetPath,
+			expectUnmount: true,
+			unmountErr:    fmt.Errorf("Unmount failed"),
+			expectFail:    true,
 		},
 	}
 	for _, tc := range testCases {
-		t.Run(tc.name, tc.testFunc)
+		t.Run(tc.name, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			mockMounter := mocks.NewMockInterface(mockCtrl)
+			driver := &Driver{
+				endpoint: endpoint,
+				nodeID:   nodeID,
+				mounter:  mockMounter,
+			}
+
+			ctx := context.Background()
+			req := &csi.NodeUnpublishVolumeRequest{
+				VolumeId:   volumeId,
+				TargetPath: tc.targetPath,
+			}
+
+			if tc.expectUnmount {
+				mockMounter.EXPECT().Unmount(gomock.Eq(targetPath)).Return(tc.unmountErr)
+			}
+
+			_, err := driver.NodeUnpublishVolume(ctx, req)
+			if err != nil && !tc.expectFail {
+				t.Fatalf("NodeUnpublishVolume is failed: %v", err)
+			} else if err == nil && tc.expectFail {
+				t.Fatalf("NodeUnpublishVolume is not failed: %v", err)
+			}
+		})
 	}
 }

--- a/pkg/driver/node_test.go
+++ b/pkg/driver/node_test.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"testing"
 
-	csi "github.com/container-storage-interface/spec/lib/go/csi/v0"
+	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/golang/mock/gomock"
 	"github.com/kubernetes-sigs/aws-efs-csi-driver/pkg/driver/mocks"
 )
@@ -62,7 +62,6 @@ func TestNodePublishVolume(t *testing.T) {
 				ctx := context.Background()
 				req := &csi.NodePublishVolumeRequest{
 					VolumeId:         volumeId,
-					VolumeAttributes: map[string]string{},
 					VolumeCapability: stdVolCap,
 					TargetPath:       targetPath,
 				}
@@ -92,7 +91,6 @@ func TestNodePublishVolume(t *testing.T) {
 				ctx := context.Background()
 				req := &csi.NodePublishVolumeRequest{
 					VolumeId:         volumeId,
-					VolumeAttributes: map[string]string{},
 					VolumeCapability: stdVolCap,
 					TargetPath:       targetPath,
 					Readonly:         true,
@@ -122,8 +120,7 @@ func TestNodePublishVolume(t *testing.T) {
 
 				ctx := context.Background()
 				req := &csi.NodePublishVolumeRequest{
-					VolumeId:         volumeId,
-					VolumeAttributes: map[string]string{},
+					VolumeId: volumeId,
 					VolumeCapability: &csi.VolumeCapability{
 						AccessType: &csi.VolumeCapability_Mount{
 							Mount: &csi.VolumeCapability_MountVolume{
@@ -161,7 +158,6 @@ func TestNodePublishVolume(t *testing.T) {
 				ctx := context.Background()
 				req := &csi.NodePublishVolumeRequest{
 					VolumeId:         volumeId,
-					VolumeAttributes: map[string]string{},
 					VolumeCapability: stdVolCap,
 				}
 
@@ -186,9 +182,8 @@ func TestNodePublishVolume(t *testing.T) {
 
 				ctx := context.Background()
 				req := &csi.NodePublishVolumeRequest{
-					VolumeId:         volumeId,
-					VolumeAttributes: map[string]string{},
-					TargetPath:       targetPath,
+					VolumeId:   volumeId,
+					TargetPath: targetPath,
 				}
 
 				_, err := driver.NodePublishVolume(ctx, req)
@@ -212,8 +207,7 @@ func TestNodePublishVolume(t *testing.T) {
 
 				ctx := context.Background()
 				req := &csi.NodePublishVolumeRequest{
-					VolumeId:         volumeId,
-					VolumeAttributes: map[string]string{},
+					VolumeId: volumeId,
 					VolumeCapability: &csi.VolumeCapability{
 						AccessType: &csi.VolumeCapability_Mount{
 							Mount: &csi.VolumeCapability_MountVolume{},
@@ -247,7 +241,6 @@ func TestNodePublishVolume(t *testing.T) {
 				ctx := context.Background()
 				req := &csi.NodePublishVolumeRequest{
 					VolumeId:         volumeId,
-					VolumeAttributes: map[string]string{},
 					VolumeCapability: stdVolCap,
 					TargetPath:       targetPath,
 				}
@@ -277,7 +270,6 @@ func TestNodePublishVolume(t *testing.T) {
 				ctx := context.Background()
 				req := &csi.NodePublishVolumeRequest{
 					VolumeId:         volumeId,
-					VolumeAttributes: map[string]string{},
 					VolumeCapability: stdVolCap,
 					TargetPath:       targetPath,
 				}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?** testing

**What is this PR about? / Why do we need it?** makes tests slightly easier to read/add since they're less verbose and you can compare test cases based on their expected inputs and outputs (somewhat subjective: https://github.com/golang/go/wiki/TableDrivenTests)

depends on https://github.com/kubernetes-sigs/aws-efs-csi-driver/pull/48 

**What testing is done?** `make test` still passes with all the same cases
