### PR TITLE
Clean up deploy manifest for 1.14

### DIFF
--- a/deploy/kubernetes/manifest.yaml
+++ b/deploy/kubernetes/manifest.yaml
@@ -1,4 +1,3 @@
-
 ---
 
 apiVersion: v1
@@ -9,51 +8,8 @@ metadata:
 
 ---
 
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: csi-node
-  namespace: kube-system
-rules:
-  - apiGroups: [""]
-    resources: ["secrets"]
-    verbs: ["get", "list"]
-  - apiGroups: [""]
-    resources: ["nodes"]
-    verbs: ["get", "list", "update"]
-  - apiGroups: [""]
-    resources: ["namespaces"]
-    verbs: ["get", "list"]
-  - apiGroups: [""]
-    resources: ["persistentvolumes"]
-    verbs: ["get", "list", "watch", "update"]
-  - apiGroups: ["storage.k8s.io"]
-    resources: ["volumeattachments"]
-    verbs: ["get", "list", "watch", "update"]
-  - apiGroups: ["csi.storage.k8s.io"]
-    resources: ["csinodeinfos"]
-    verbs: ["get", "list", "watch", "update"]
-
----
-
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: csi-node
-  namespace: default
-subjects:
-  - kind: ServiceAccount
-    name: csi-node-sa
-    namespace: default
-roleRef:
-  kind: ClusterRole
-  name: csi-node
-  apiGroup: rbac.authorization.k8s.io
-
----
-
 kind: DaemonSet
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 metadata:
   name: efs-csi-node
   namespace: kube-system
@@ -87,16 +43,10 @@ spec:
               mountPropagation: "Bidirectional"
             - name: plugin-dir
               mountPath: /csi
-            - name: device-dir
-              mountPath: /dev
         - name: csi-driver-registrar
-          image: quay.io/k8scsi/driver-registrar:v0.4.2
-          imagePullPolicy: Always
+          image: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0
           args:
             - --csi-address=$(ADDRESS)
-            - --mode=node-register
-            - --driver-requires-attachment=true
-            - --pod-info-mount-version="v1"
             - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
             - --v=5
           env:
@@ -118,107 +68,20 @@ spec:
           hostPath:
             path: /var/lib/kubelet
             type: Directory
+        - name: registration-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins_registry/
+            type: Directory
         - name: plugin-dir
           hostPath:
             path: /var/lib/kubelet/plugins/efs.csi.aws.com/
             type: DirectoryOrCreate
-        - name: registration-dir
-          hostPath:
-            path: /var/lib/kubelet/plugins/
-            type: Directory
-        - name: device-dir
-          hostPath:
-            path: /dev
-            type: Directory
 
 ---
 
-apiVersion: v1
-kind: ServiceAccount
+apiVersion: storage.k8s.io/v1beta1
+kind: CSIDriver
 metadata:
-  name: csi-controller-sa
-  namespace: kube-system
-
----
-
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: external-attacher-role
-  namespace: default
-rules:
-  - apiGroups: [""]
-    resources: ["persistentvolumes"]
-    verbs: ["get", "list", "watch", "update"]
-  - apiGroups: [""]
-    resources: ["nodes"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["storage.k8s.io"]
-    resources: ["volumeattachments"]
-    verbs: ["get", "list", "watch", "update"]
-
----
-
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: csi-attacher-role
-  namespace: default
-subjects:
-  - kind: ServiceAccount
-    name: csi-controller-sa
-    namespace: kube-system
-roleRef:
-  kind: ClusterRole
-  name: external-attacher-role
-  apiGroup: rbac.authorization.k8s.io
-
----
-
-kind: StatefulSet
-apiVersion: apps/v1beta1
-metadata:
-  name: efs-csi-controller
-  namespace: kube-system
+  name: efs.csi.aws.com
 spec:
-  serviceName: efs-csi-controller 
-  replicas: 1
-  template:
-    metadata:
-      labels:
-        app: efs-csi-controller
-    spec:
-      serviceAccount: csi-controller-sa
-      priorityClassName: system-cluster-critical
-      tolerations:
-        - key: CriticalAddonsOnly
-          operator: Exists
-      containers:
-        - name: efs-plugin
-          image: amazon/aws-efs-csi-driver:latest
-          imagePullPolicy: Always
-          args :
-            - --endpoint=$(CSI_ENDPOINT)
-            - --logtostderr
-            - --v=5
-          env:
-            - name: CSI_ENDPOINT
-              value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
-          volumeMounts:
-            - name: socket-dir
-              mountPath: /var/lib/csi/sockets/pluginproxy/
-        - name: csi-attacher
-          image: quay.io/k8scsi/csi-attacher:v0.4.2
-          imagePullPolicy: Always
-          args:
-            - --csi-address=$(ADDRESS)
-            - --v=5
-          env:
-            - name: ADDRESS
-              value: /var/lib/csi/sockets/pluginproxy/csi.sock
-          volumeMounts:
-            - name: socket-dir
-              mountPath: /var/lib/csi/sockets/pluginproxy/
-      volumes:
-        - name: socket-dir
-          emptyDir: {}
+  attachRequired: false

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/kubernetes-sigs/aws-efs-csi-driver
 
 require (
 	github.com/aws/aws-sdk-go v1.16.5
-	github.com/container-storage-interface/spec v0.3.0
+	github.com/container-storage-interface/spec v1.1.0
 	github.com/golang/mock v1.2.0
 	github.com/spf13/afero v1.2.1 // indirect
 	github.com/stretchr/testify v1.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/aws/aws-sdk-go v1.16.5/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/container-storage-interface/spec v0.3.0 h1:ALxSqFjptj8R5rL+cdyAbwbaLHHXDL5pmp1qIh1b+38=
 github.com/container-storage-interface/spec v0.3.0/go.mod h1:6URME8mwIBbpVyZV93Ce5St17xBiQJQY67NDsuohiy4=
+github.com/container-storage-interface/spec v1.1.0 h1:qPsTqtR1VUPvMPeK0UnCZMtXaKGyyLPG8gj/wG6VqMs=
+github.com/container-storage-interface/spec v1.1.0/go.mod h1:6URME8mwIBbpVyZV93Ce5St17xBiQJQY67NDsuohiy4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"net"
 
-	csi "github.com/container-storage-interface/spec/lib/go/csi/v0"
+	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/kubernetes-sigs/aws-efs-csi-driver/pkg/cloud"
 	"github.com/kubernetes-sigs/aws-efs-csi-driver/pkg/util"
 	"google.golang.org/grpc"
@@ -30,17 +30,6 @@ import (
 
 const (
 	driverName = "efs.csi.aws.com"
-)
-
-var (
-	volumeCaps = []csi.VolumeCapability_AccessMode{
-		{
-			Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
-		},
-		{
-			Mode: csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER,
-		},
-	}
 )
 
 type Driver struct {

--- a/pkg/driver/identity.go
+++ b/pkg/driver/identity.go
@@ -19,7 +19,7 @@ package driver
 import (
 	"context"
 
-	csi "github.com/container-storage-interface/spec/lib/go/csi/v0"
+	"github.com/container-storage-interface/spec/lib/go/csi"
 )
 
 func (d *Driver) GetPluginInfo(ctx context.Context, req *csi.GetPluginInfoRequest) (*csi.GetPluginInfoResponse, error) {

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -21,14 +21,18 @@ import (
 	"fmt"
 	"os"
 
-	csi "github.com/container-storage-interface/spec/lib/go/csi/v0"
+	"github.com/container-storage-interface/spec/lib/go/csi"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"k8s.io/klog"
 )
 
 var (
-	nodeCaps = []csi.NodeServiceCapability_RPC_Type{}
+	nodeCaps             = []csi.NodeServiceCapability_RPC_Type{}
+	volumeCapAccessModes = []csi.VolumeCapability_AccessMode_Mode{
+		csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+		csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER,
+	}
 )
 
 func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRequest) (*csi.NodeStageVolumeResponse, error) {
@@ -110,6 +114,14 @@ func (d *Driver) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpublish
 	return &csi.NodeUnpublishVolumeResponse{}, nil
 }
 
+func (d *Driver) NodeGetVolumeStats(ctx context.Context, req *csi.NodeGetVolumeStatsRequest) (*csi.NodeGetVolumeStatsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "")
+}
+
+func (d *Driver) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandVolumeRequest) (*csi.NodeExpandVolumeResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "")
+}
+
 func (d *Driver) NodeGetCapabilities(ctx context.Context, req *csi.NodeGetCapabilitiesRequest) (*csi.NodeGetCapabilitiesResponse, error) {
 	klog.V(4).Infof("NodeGetCapabilities: called with args %+v", req)
 	var caps []*csi.NodeServiceCapability
@@ -134,17 +146,10 @@ func (d *Driver) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoRequest) (
 	}, nil
 }
 
-func (d *Driver) NodeGetId(ctx context.Context, req *csi.NodeGetIdRequest) (*csi.NodeGetIdResponse, error) {
-	klog.V(4).Infof("NodeGetId: called with args %+v", req)
-	return &csi.NodeGetIdResponse{
-		NodeId: d.nodeID,
-	}, nil
-}
-
 func (d *Driver) isValidVolumeCapabilities(volCaps []*csi.VolumeCapability) bool {
 	hasSupport := func(cap *csi.VolumeCapability) bool {
-		for _, c := range volumeCaps {
-			if c.GetMode() == cap.AccessMode.GetMode() {
+		for _, m := range volumeCapAccessModes {
+			if m == cap.AccessMode.GetMode() {
 				return true
 			}
 		}

--- a/pkg/driver/node_test.go
+++ b/pkg/driver/node_test.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"testing"
 
-	csi "github.com/container-storage-interface/spec/lib/go/csi/v0"
+	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/golang/mock/gomock"
 	"github.com/kubernetes-sigs/aws-efs-csi-driver/pkg/driver/mocks"
 )
@@ -62,7 +62,6 @@ func TestNodePublishVolume(t *testing.T) {
 				ctx := context.Background()
 				req := &csi.NodePublishVolumeRequest{
 					VolumeId:         volumeId,
-					VolumeAttributes: map[string]string{},
 					VolumeCapability: stdVolCap,
 					TargetPath:       targetPath,
 				}
@@ -92,7 +91,6 @@ func TestNodePublishVolume(t *testing.T) {
 				ctx := context.Background()
 				req := &csi.NodePublishVolumeRequest{
 					VolumeId:         volumeId,
-					VolumeAttributes: map[string]string{},
 					VolumeCapability: stdVolCap,
 					TargetPath:       targetPath,
 					Readonly:         true,
@@ -122,8 +120,7 @@ func TestNodePublishVolume(t *testing.T) {
 
 				ctx := context.Background()
 				req := &csi.NodePublishVolumeRequest{
-					VolumeId:         volumeId,
-					VolumeAttributes: map[string]string{},
+					VolumeId: volumeId,
 					VolumeCapability: &csi.VolumeCapability{
 						AccessType: &csi.VolumeCapability_Mount{
 							Mount: &csi.VolumeCapability_MountVolume{
@@ -161,7 +158,6 @@ func TestNodePublishVolume(t *testing.T) {
 				ctx := context.Background()
 				req := &csi.NodePublishVolumeRequest{
 					VolumeId:         volumeId,
-					VolumeAttributes: map[string]string{},
 					VolumeCapability: stdVolCap,
 				}
 
@@ -186,9 +182,8 @@ func TestNodePublishVolume(t *testing.T) {
 
 				ctx := context.Background()
 				req := &csi.NodePublishVolumeRequest{
-					VolumeId:         volumeId,
-					VolumeAttributes: map[string]string{},
-					TargetPath:       targetPath,
+					VolumeId:   volumeId,
+					TargetPath: targetPath,
 				}
 
 				_, err := driver.NodePublishVolume(ctx, req)
@@ -212,8 +207,7 @@ func TestNodePublishVolume(t *testing.T) {
 
 				ctx := context.Background()
 				req := &csi.NodePublishVolumeRequest{
-					VolumeId:         volumeId,
-					VolumeAttributes: map[string]string{},
+					VolumeId: volumeId,
 					VolumeCapability: &csi.VolumeCapability{
 						AccessType: &csi.VolumeCapability_Mount{
 							Mount: &csi.VolumeCapability_MountVolume{},
@@ -247,7 +241,6 @@ func TestNodePublishVolume(t *testing.T) {
 				ctx := context.Background()
 				req := &csi.NodePublishVolumeRequest{
 					VolumeId:         volumeId,
-					VolumeAttributes: map[string]string{},
 					VolumeCapability: stdVolCap,
 					TargetPath:       targetPath,
 				}
@@ -277,7 +270,6 @@ func TestNodePublishVolume(t *testing.T) {
 				ctx := context.Background()
 				req := &csi.NodePublishVolumeRequest{
 					VolumeId:         volumeId,
-					VolumeAttributes: map[string]string{},
 					VolumeCapability: stdVolCap,
 					TargetPath:       targetPath,
 				}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
bug fix+feature
**What is this PR about? / Why do we need it?**
- apps/v1beta2 and apps/v1beta1 are deprecated and will be removed in 1.16 https://github.com/kubernetes/kubernetes/pull/70672
- fix https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/50, update to latest node-driver-registrar. . driver-registrar is deprecated, use node-driver-registrar instead.
- fix https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/36, create a CSIDriver (now in-tree and beta in 1.14) to skip attach
- registration-dir is /var/lib/kubelet/plugins_registry in 1.13+
- remove controller statefulset (can add it back later for CreateVolume)
- remove all unnecessary RBAC rules as the new node-driver-registrar doesn't need any nor does our node driver (can add them back later for CreateVolume)
- depends on https://github.com/kubernetes-sigs/aws-efs-csi-driver/pull/48

**What testing is done?** 
The static_provisioning example works correctly on a 1.14/1.15 cluster.