### PR TITLE
Add support for 'path' field in volumeContext

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/kubernetes-sigs/aws-efs-csi-driver
 
 require (
 	github.com/aws/aws-sdk-go v1.16.5
-	github.com/container-storage-interface/spec v0.3.0
+	github.com/container-storage-interface/spec v1.1.0
 	github.com/golang/mock v1.2.0
 	github.com/spf13/afero v1.2.1 // indirect
 	github.com/stretchr/testify v1.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/aws/aws-sdk-go v1.16.5/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/container-storage-interface/spec v0.3.0 h1:ALxSqFjptj8R5rL+cdyAbwbaLHHXDL5pmp1qIh1b+38=
 github.com/container-storage-interface/spec v0.3.0/go.mod h1:6URME8mwIBbpVyZV93Ce5St17xBiQJQY67NDsuohiy4=
+github.com/container-storage-interface/spec v1.1.0 h1:qPsTqtR1VUPvMPeK0UnCZMtXaKGyyLPG8gj/wG6VqMs=
+github.com/container-storage-interface/spec v1.1.0/go.mod h1:6URME8mwIBbpVyZV93Ce5St17xBiQJQY67NDsuohiy4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"net"
 
-	csi "github.com/container-storage-interface/spec/lib/go/csi/v0"
+	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/kubernetes-sigs/aws-efs-csi-driver/pkg/cloud"
 	"github.com/kubernetes-sigs/aws-efs-csi-driver/pkg/util"
 	"google.golang.org/grpc"
@@ -30,17 +30,6 @@ import (
 
 const (
 	driverName = "efs.csi.aws.com"
-)
-
-var (
-	volumeCaps = []csi.VolumeCapability_AccessMode{
-		{
-			Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
-		},
-		{
-			Mode: csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER,
-		},
-	}
 )
 
 type Driver struct {

--- a/pkg/driver/identity.go
+++ b/pkg/driver/identity.go
@@ -19,7 +19,7 @@ package driver
 import (
 	"context"
 
-	csi "github.com/container-storage-interface/spec/lib/go/csi/v0"
+	"github.com/container-storage-interface/spec/lib/go/csi"
 )
 
 func (d *Driver) GetPluginInfo(ctx context.Context, req *csi.GetPluginInfoRequest) (*csi.GetPluginInfoResponse, error) {

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -21,14 +21,18 @@ import (
 	"fmt"
 	"os"
 
-	csi "github.com/container-storage-interface/spec/lib/go/csi/v0"
+	"github.com/container-storage-interface/spec/lib/go/csi"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"k8s.io/klog"
 )
 
 var (
-	nodeCaps = []csi.NodeServiceCapability_RPC_Type{}
+	nodeCaps             = []csi.NodeServiceCapability_RPC_Type{}
+	volumeCapAccessModes = []csi.VolumeCapability_AccessMode_Mode{
+		csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+		csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER,
+	}
 )
 
 func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRequest) (*csi.NodeStageVolumeResponse, error) {
@@ -110,6 +114,14 @@ func (d *Driver) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpublish
 	return &csi.NodeUnpublishVolumeResponse{}, nil
 }
 
+func (d *Driver) NodeGetVolumeStats(ctx context.Context, req *csi.NodeGetVolumeStatsRequest) (*csi.NodeGetVolumeStatsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "")
+}
+
+func (d *Driver) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandVolumeRequest) (*csi.NodeExpandVolumeResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "")
+}
+
 func (d *Driver) NodeGetCapabilities(ctx context.Context, req *csi.NodeGetCapabilitiesRequest) (*csi.NodeGetCapabilitiesResponse, error) {
 	klog.V(4).Infof("NodeGetCapabilities: called with args %+v", req)
 	var caps []*csi.NodeServiceCapability
@@ -134,17 +146,10 @@ func (d *Driver) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoRequest) (
 	}, nil
 }
 
-func (d *Driver) NodeGetId(ctx context.Context, req *csi.NodeGetIdRequest) (*csi.NodeGetIdResponse, error) {
-	klog.V(4).Infof("NodeGetId: called with args %+v", req)
-	return &csi.NodeGetIdResponse{
-		NodeId: d.nodeID,
-	}, nil
-}
-
 func (d *Driver) isValidVolumeCapabilities(volCaps []*csi.VolumeCapability) bool {
 	hasSupport := func(cap *csi.VolumeCapability) bool {
-		for _, c := range volumeCaps {
-			if c.GetMode() == cap.AccessMode.GetMode() {
+		for _, m := range volumeCapAccessModes {
+			if m == cap.AccessMode.GetMode() {
 				return true
 			}
 		}

--- a/pkg/driver/node_test.go
+++ b/pkg/driver/node_test.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"testing"
 
-	csi "github.com/container-storage-interface/spec/lib/go/csi/v0"
+	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/golang/mock/gomock"
 	"github.com/kubernetes-sigs/aws-efs-csi-driver/pkg/driver/mocks"
 )
@@ -62,7 +62,6 @@ func TestNodePublishVolume(t *testing.T) {
 				ctx := context.Background()
 				req := &csi.NodePublishVolumeRequest{
 					VolumeId:         volumeId,
-					VolumeAttributes: map[string]string{},
 					VolumeCapability: stdVolCap,
 					TargetPath:       targetPath,
 				}
@@ -92,7 +91,6 @@ func TestNodePublishVolume(t *testing.T) {
 				ctx := context.Background()
 				req := &csi.NodePublishVolumeRequest{
 					VolumeId:         volumeId,
-					VolumeAttributes: map[string]string{},
 					VolumeCapability: stdVolCap,
 					TargetPath:       targetPath,
 					Readonly:         true,
@@ -122,8 +120,7 @@ func TestNodePublishVolume(t *testing.T) {
 
 				ctx := context.Background()
 				req := &csi.NodePublishVolumeRequest{
-					VolumeId:         volumeId,
-					VolumeAttributes: map[string]string{},
+					VolumeId: volumeId,
 					VolumeCapability: &csi.VolumeCapability{
 						AccessType: &csi.VolumeCapability_Mount{
 							Mount: &csi.VolumeCapability_MountVolume{
@@ -161,7 +158,6 @@ func TestNodePublishVolume(t *testing.T) {
 				ctx := context.Background()
 				req := &csi.NodePublishVolumeRequest{
 					VolumeId:         volumeId,
-					VolumeAttributes: map[string]string{},
 					VolumeCapability: stdVolCap,
 				}
 
@@ -186,9 +182,8 @@ func TestNodePublishVolume(t *testing.T) {
 
 				ctx := context.Background()
 				req := &csi.NodePublishVolumeRequest{
-					VolumeId:         volumeId,
-					VolumeAttributes: map[string]string{},
-					TargetPath:       targetPath,
+					VolumeId:   volumeId,
+					TargetPath: targetPath,
 				}
 
 				_, err := driver.NodePublishVolume(ctx, req)
@@ -212,8 +207,7 @@ func TestNodePublishVolume(t *testing.T) {
 
 				ctx := context.Background()
 				req := &csi.NodePublishVolumeRequest{
-					VolumeId:         volumeId,
-					VolumeAttributes: map[string]string{},
+					VolumeId: volumeId,
 					VolumeCapability: &csi.VolumeCapability{
 						AccessType: &csi.VolumeCapability_Mount{
 							Mount: &csi.VolumeCapability_MountVolume{},
@@ -247,7 +241,6 @@ func TestNodePublishVolume(t *testing.T) {
 				ctx := context.Background()
 				req := &csi.NodePublishVolumeRequest{
 					VolumeId:         volumeId,
-					VolumeAttributes: map[string]string{},
 					VolumeCapability: stdVolCap,
 					TargetPath:       targetPath,
 				}
@@ -277,7 +270,6 @@ func TestNodePublishVolume(t *testing.T) {
 				ctx := context.Background()
 				req := &csi.NodePublishVolumeRequest{
 					VolumeId:         volumeId,
-					VolumeAttributes: map[string]string{},
 					VolumeCapability: stdVolCap,
 					TargetPath:       targetPath,
 				}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?** feature

**What is this PR about? / Why do we need it?** fixes https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/46.

the path must exist on the filesystem beforehand else mounting will fail.

depends on https://github.com/kubernetes-sigs/aws-efs-csi-driver/pull/48

no docs updates yet--I plan to do document all doc changes in one PR if that's okay.

**What testing is done?** 
on kube master:
```
apiVersion: v1
kind: PersistentVolume
metadata:
  name: efs-pv
spec:
  capacity:
    storage: 5Gi
  volumeMode: Filesystem
  accessModes:
    - ReadWriteOnce
  persistentVolumeReclaimPolicy: Recycle
  storageClassName: efs-sc
  csi:
    driver: efs.csi.aws.com
    volumeHandle: fs-c2a43e69
    volumeAttributes:
      path: "/a/b"
```
```
I0718 20:50:34.587437       1 node.go:49] NodePublishVolume: called with args volume_id:"fs-c2a43e69" target_path:"/var/lib/kubelet/pods/a7d6f292-afd5-469a-93da-b6e46f382e08/volumes/kubernetes.io~csi/efs-pv/mount" volume_capability:<mount:<> access_mode:<mode:SINGLE_NODE_WRITER > > volume_context:<key:"path" value:"/a/b" >
I0718 20:50:34.587497       1 node.go:103] NodePublishVolume: creating dir /var/lib/kubelet/pods/a7d6f292-afd5-469a-93da-b6e46f382e08/volumes/kubernetes.io~csi/efs-pv/mount
I0718 20:50:34.587524       1 node.go:108] NodePublishVolume: mounting fs-c2a43e69:/a/b at /var/lib/kubelet/pods/a7d6f292-afd5-469a-93da-b6e46f382e08/volumes/kubernetes.io~csi/efs-pv/mount with options []
I0718 20:50:34.587534       1 mount_linux.go:146] Mounting cmd (mount) with arguments ([-t efs fs-c2a43e69:/a/b /var/lib/kubelet/pods/a7d6f292-afd5-469a-93da-b6e46f382e08/volumes/kubernetes.io~csi/efs-pv/mount])
...
I0718 20:53:28.621904       1 node.go:118] NodeUnpublishVolume: called with args volume_id:"fs-c2a43e69" target_path:"/var/lib/kubelet/pods/a7d6f292-afd5-469a-93da-b6e46f382e08/volumes/kubernetes.io~csi/efs-pv/mount"
I0718 20:53:28.621963       1 node.go:125] NodeUnpublishVolume: unmounting /var/lib/kubelet/pods/a7d6f292-afd5-469a-93da-b6e46f382e08/volumes/kubernetes.io~csi/efs-pv/mount
I0718 20:53:28.621969       1 mount_linux.go:211] Unmounting /var/lib/kubelet/pods/a7d6f292-afd5-469a-93da-b6e46f382e08/volumes/kubernetes.io~csi/efs-pv/mount
```