### PR TITLE
Replace deprecated Recycle policy with Retain

### DIFF
--- a/examples/kubernetes/encryption_in_transit/README.md
+++ b/examples/kubernetes/encryption_in_transit/README.md
@@ -16,7 +16,7 @@ spec:
   volumeMode: Filesystem
   accessModes:
     - ReadWriteOnce
-  persistentVolumeReclaimPolicy: Recycle
+  persistentVolumeReclaimPolicy: Retain
   storageClassName: efs-sc
   mountOptions:
     - tls

--- a/examples/kubernetes/encryption_in_transit/specs/pv.yaml
+++ b/examples/kubernetes/encryption_in_transit/specs/pv.yaml
@@ -8,7 +8,7 @@ spec:
   volumeMode: Filesystem
   accessModes:
     - ReadWriteOnce
-  persistentVolumeReclaimPolicy: Recycle
+  persistentVolumeReclaimPolicy: Retain
   storageClassName: efs-sc
   mountOptions:
     - tls

--- a/examples/kubernetes/multiple_pods/README.md
+++ b/examples/kubernetes/multiple_pods/README.md
@@ -14,7 +14,7 @@ spec:
   volumeMode: Filesystem
   accessModes:
     - ReadWriteMany
-  persistentVolumeReclaimPolicy: Recycle
+  persistentVolumeReclaimPolicy: Retain
   storageClassName: efs-sc
   csi:
     driver: efs.csi.aws.com

--- a/examples/kubernetes/multiple_pods/specs/pv.yaml
+++ b/examples/kubernetes/multiple_pods/specs/pv.yaml
@@ -8,7 +8,7 @@ spec:
   volumeMode: Filesystem
   accessModes:
     - ReadWriteMany
-  persistentVolumeReclaimPolicy: Recycle
+  persistentVolumeReclaimPolicy: Retain
   storageClassName: efs-sc
   csi:
     driver: efs.csi.aws.com

--- a/examples/kubernetes/static_provisioning/README.md
+++ b/examples/kubernetes/static_provisioning/README.md
@@ -14,7 +14,7 @@ spec:
   volumeMode: Filesystem
   accessModes:
     - ReadWriteOnce
-  persistentVolumeReclaimPolicy: Recycle
+  persistentVolumeReclaimPolicy: Retain
   storageClassName: efs-sc
   csi:
     driver: efs.csi.aws.com

--- a/examples/kubernetes/static_provisioning/specs/pv.yaml
+++ b/examples/kubernetes/static_provisioning/specs/pv.yaml
@@ -8,7 +8,7 @@ spec:
   volumeMode: Filesystem
   accessModes:
     - ReadWriteOnce
-  persistentVolumeReclaimPolicy: Recycle
+  persistentVolumeReclaimPolicy: Retain
   storageClassName: efs-sc
   csi:
     driver: efs.csi.aws.com


### PR DESCRIPTION
**Is this a bug fix or adding new feature?** bug

**What is this PR about? / Why do we need it?** Recycle policy is deprecated https://kubernetes.io/docs/concepts/storage/persistent-volumes/#recycle, unmaintained and buggy. For now, it's a bit safer to recommend Retain in examples. When CreateVolume is implemented, we can recommend Delete.

**What testing is done?** PV creation works
