### PR TITLE
Add linux nodeSelector to manifest.yaml

### DIFF
--- a/deploy/kubernetes/manifest.yaml
+++ b/deploy/kubernetes/manifest.yaml
@@ -22,6 +22,8 @@ spec:
       labels:
         app: efs-csi-node
     spec:
+      nodeSelector:
+        beta.kubernetes.io/os: linux
       serviceAccount: csi-node-sa
       hostNetwork: true
       containers:


### PR DESCRIPTION
**Is this a bug fix or adding new feature?** fix

**What is this PR about? / Why do we need it?** fixes https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/58 to ensure the daemonset's pods only land on linux nodes

**What testing is done?** created it on mixed node cluster (1 linux 1 windows) and 1 pod was created on linux node, as expected
