### PR TITLE
Remove service account for node service

### DIFF
--- a/deploy/kubernetes/manifest.yaml
+++ b/deploy/kubernetes/manifest.yaml
@@ -1,13 +1,5 @@
 ---
-
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: efs-csi-node-sa
-  namespace: kube-system
-
----
-
+# Node Service
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:
@@ -24,8 +16,11 @@ spec:
     spec:
       nodeSelector:
         beta.kubernetes.io/os: linux
-      serviceAccount: efs-csi-node-sa
       hostNetwork: true
+      priorityClassName: system-node-critical
+      tolerations:
+        - key: CriticalAddonsOnly
+          operator: Exists
       containers:
         - name: efs-plugin
           securityContext:
@@ -50,13 +45,13 @@ spec:
               name: healthz
               protocol: TCP
           livenessProbe:
-            failureThreshold: 5
             httpGet:
               path: /healthz
               port: healthz
             initialDelaySeconds: 10
             timeoutSeconds: 3
             periodSeconds: 2
+            failureThreshold: 5
         - name: csi-driver-registrar
           image: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0
           args:


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Remove service account for node service since node service doesn't need any permission to access API server. Also added `priorityClassName` and `tolerations`.

/cc @wongma7 