### PR TITLE
Post v0.2 release changes

### DIFF
--- a/CHANGELOG-0.x.md
+++ b/CHANGELOG-0.x.md
@@ -1,4 +1,10 @@
 # v0.2.0
+[Documentation](https://github.com/kubernetes-sigs/aws-efs-csi-driver/blob/v0.2.0/docs/README.md)
+
+filename  | sha512 hash
+--------- | ------------
+[v0.2.0.zip](https://github.com/kubernetes-sigs/aws-efs-csi-driver/archive/v0.2.0.zip) | `5be59ba16a2ec379059863f94124d6334602200bc57967e3894b9edc65ffc7f634c6bc6915b649ebaa6879ed410c1a80e724a8c731682ae345765941dad7b339`
+[v0.2.0.tar.gz](https://github.com/kubernetes-sigs/aws-efs-csi-driver/archive/v0.2.0.tar.gz) | `7048c818d7df82101cecc73d3f28c087c5c758a329eabdc847105ce1d4ccd1c0c43d401054b2074e4678bed4969ebdc6fe169f61021d4cfdfa4b10e577fe058c`
 
 ## Changelog
 

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 
 PKG=github.com/kubernetes-sigs/aws-efs-csi-driver
 IMAGE=amazon/aws-efs-csi-driver
-VERSION=0.2.0
+VERSION=0.3.0-dirty
 GIT_COMMIT?=$(shell git rev-parse HEAD)
 BUILD_DATE?=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 LDFLAGS?="-X ${PKG}/pkg/driver.driverVersion=${VERSION} -X ${PKG}/pkg/driver.gitCommit=${GIT_COMMIT} -X ${PKG}/pkg/driver.buildDate=${BUILD_DATE}"

--- a/deploy/kubernetes/manifest.yaml
+++ b/deploy/kubernetes/manifest.yaml
@@ -25,7 +25,7 @@ spec:
         - name: efs-plugin
           securityContext:
             privileged: true
-          image: amazon/aws-efs-csi-driver:v0.2.0
+          image: amazon/aws-efs-csi-driver:latest
           imagePullPolicy: Always
           args:
             - --endpoint=$(CSI_ENDPOINT)

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ The [Amazon Elastic File System](https://aws.amazon.com/efs/) Container Storage 
 | AWS EFS CSI Driver \ CSI Version       | v0.3.0| v1.1.0 |
 |----------------------------------------|-------|--------|
 | master branch                          | no    | yes    |
+| v0.2.0                                 | no    | yes    |
 | v0.1.0                                 | yes   | no     |
 
 ## Features
@@ -41,6 +42,7 @@ The following sections are Kubernetes specific. If you are a Kubernetes user, us
 |EFS CSI Driver Version     | Image                               |
 |---------------------------|-------------------------------------|
 |master branch              |amazon/aws-efs-csi-driver:latest     |
+|v0.2.0                     |amazon/aws-efs-csi-driver:v0.2.0     |
 |v0.1.0                     |amazon/aws-efs-csi-driver:v0.1.0     |
 
 ### Features


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Post v0.2 release changes update docs:

    1. with new driver version in compatibility matrix 
    2. with new driver image tag in docker image table
    3. revert back image tag in deploy/kubernetes/manifest.yaml to latest
    4. bump driver version in Makefile
    5. Update change log with download zip/tar file links and SHAs

