### PR TITLE
Fix bug when unpublishing already unmounted file system

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -62,3 +62,5 @@ replace k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.0.0-20191003001538
 replace k8s.io/sample-cli-plugin => k8s.io/sample-cli-plugin v0.0.0-20191003002540-40951731b79f
 
 replace k8s.io/sample-controller => k8s.io/sample-controller v0.0.0-20191003001734-27680fba8268
+
+go 1.13

--- a/pkg/driver/mocks/mock_mount.go
+++ b/pkg/driver/mocks/mock_mount.go
@@ -33,6 +33,22 @@ func (m *MockMounter) EXPECT() *MockMounterMockRecorder {
 	return m.recorder
 }
 
+// GetDeviceName mocks base method
+func (m *MockMounter) GetDeviceName(arg0 string) (string, int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDeviceName", arg0)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(int)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetDeviceName indicates an expected call of GetDeviceName
+func (mr *MockMounterMockRecorder) GetDeviceName(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeviceName", reflect.TypeOf((*MockMounter)(nil).GetDeviceName), arg0)
+}
+
 // GetMountRefs mocks base method
 func (m *MockMounter) GetMountRefs(arg0 string) ([]string, error) {
 	m.ctrl.T.Helper()

--- a/pkg/driver/mounter.go
+++ b/pkg/driver/mounter.go
@@ -23,6 +23,7 @@ import (
 type Mounter interface {
 	mount.Interface
 	MakeDir(pathname string) error
+	GetDeviceName(mountPath string) (string, int, error)
 }
 
 type NodeMounter struct {
@@ -43,4 +44,8 @@ func (m *NodeMounter) MakeDir(pathname string) error {
 		}
 	}
 	return nil
+}
+
+func (m *NodeMounter) GetDeviceName(mountPath string) (string, int, error) {
+	return mount.GetDeviceNameFromMount(m, mountPath)
 }


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
/kind bug

**What is this PR about? / Why do we need it?**
Fix bug when unpublishing already unmounted file system. This happens when lingering EFS mount is found on the node such as:

```
  volumesInUse:
  - kubernetes.io/csi/efs.csi.aws.com^fs-26e5fe8d
  - kubernetes.io/csi/efs.csi.aws.com^fs-e8a95a42
```

This will cause kubelet to keep unmounting the volume with no success since the volume is already unmounted.

The lingering volume in node object could be caused when the EFS filesystem is unmounted out of band or bugs.

**What testing is done?** 
