### PR TITLE
Force use of AWS nameservers

### DIFF
--- a/deploy/kubernetes/base/node.yaml
+++ b/deploy/kubernetes/base/node.yaml
@@ -17,6 +17,10 @@ spec:
       nodeSelector:
         beta.kubernetes.io/os: linux
       hostNetwork: true
+      dnsPolicy: "None"
+      dnsConfig:
+        nameservers:
+          - 169.254.169.253
       priorityClassName: system-node-critical
       tolerations:
         - key: CriticalAddonsOnly


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Bug fix/suggestion. Unsure if it's applicable for all parties (ie. if someone expects this CSI driver to work on non-EC2 instances), but might be a solid default.

**What is this PR about? / Why do we need it?**
Depending on your default DNS configuration, the EFS DNS names may or may not be resolvable, whereas they will always be resolvable on the AWS DNS resolver. This change hardcodes DNS resolution for the efs plugin daemonset to the AWS resolver on the link-local address.

**What testing is done?** 
Tested on our own setup where DNS forwards to a non-AWS resolver where EFS domains did not resolve until this change.