### PR TITLE
Update daemonset tolerations to run on all nodes

### DIFF
--- a/deploy/kubernetes/base/node.yaml
+++ b/deploy/kubernetes/base/node.yaml
@@ -19,8 +19,7 @@ spec:
       hostNetwork: true
       priorityClassName: system-node-critical
       tolerations:
-        - key: CriticalAddonsOnly
-          operator: Exists
+        - operator: Exists
       containers:
         - name: efs-plugin
           securityContext:


### PR DESCRIPTION
Update to base daemonset config to set tolerations to allow all nodes. 

Fixes issue described in [Issue 122](https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/122)