### PR TITLE
Preserve efs state file across efs driver recycle

### DIFF
--- a/deploy/kubernetes/base/node.yaml
+++ b/deploy/kubernetes/base/node.yaml
@@ -39,6 +39,8 @@ spec:
               mountPropagation: "Bidirectional"
             - name: plugin-dir
               mountPath: /csi
+            - name: efs-state-dir
+              mountPath: /var/run/efs
           ports:
             - containerPort: 9809
               name: healthz
@@ -92,6 +94,10 @@ spec:
         - name: plugin-dir
           hostPath:
             path: /var/lib/kubelet/plugins/efs.csi.aws.com/
+            type: DirectoryOrCreate
+        - name: efs-state-dir
+          hostPath:
+            path: /var/run/efs
             type: DirectoryOrCreate
 
 


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
bug fix

**What is this PR about? / Why do we need it?**
Fixes: #130 
This change preserves efs state across efs driver recycle so that the stunnel processes are reconstructed after efs driver crashes/upgrades
