### PR TITLE
Fix of url to Kubernetes CSI Developer Documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -77,7 +77,7 @@ Before the example, you need to:
 * [Consume EFS in StatefulSets](../examples/kubernetes/statefulset/README.md)
 
 ## Development
-Please go through [CSI Spec](https://github.com/container-storage-interface/spec/blob/master/spec.md) and [General CSI driver development guideline](https://kubernetes-csi.github.io/docs/Development.html) to get some basic understanding of CSI driver before you start.
+Please go through [CSI Spec](https://github.com/container-storage-interface/spec/blob/master/spec.md) and [Kubernetes CSI Developer Documentation](https://kubernetes-csi.github.io/docs) to get some basic understanding of CSI driver before you start.
 
 ### Requirements
 * Golang 1.13.4+


### PR DESCRIPTION
Just fix of incorrect url in documentation
