### PR TITLE
Move EFS tests into e2e.go so that they can be imported from elsewhere

### DIFF
--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -1,0 +1,119 @@
+package e2e
+
+import (
+	"fmt"
+
+	"github.com/onsi/ginkgo"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/kubernetes/test/e2e/framework"
+	"k8s.io/kubernetes/test/e2e/storage/testpatterns"
+	"k8s.io/kubernetes/test/e2e/storage/testsuites"
+)
+
+var (
+	ClusterName  string
+	Region       string
+	fileSystemId string
+)
+
+type efsDriver struct {
+	driverInfo testsuites.DriverInfo
+}
+
+var _ testsuites.TestDriver = &efsDriver{}
+
+// TODO implement Inline (unless it's redundant) and DynamicPV
+// var _ testsuites.InlineVolumeTestDriver = &efsDriver{}
+var _ testsuites.PreprovisionedPVTestDriver = &efsDriver{}
+
+func InitEFSCSIDriver() testsuites.TestDriver {
+	return &efsDriver{
+		driverInfo: testsuites.DriverInfo{
+			Name:                 "efs.csi.aws.com",
+			SupportedFsType:      sets.NewString(""),
+			SupportedMountOption: sets.NewString("tls", "ro"),
+			Capabilities: map[testsuites.Capability]bool{
+				testsuites.CapPersistence: true,
+				testsuites.CapExec:        true,
+				testsuites.CapMultiPODs:   true,
+				testsuites.CapRWX:         true,
+			},
+		},
+	}
+}
+
+func (e *efsDriver) GetDriverInfo() *testsuites.DriverInfo {
+	return &e.driverInfo
+}
+
+func (e *efsDriver) SkipUnsupportedTest(testpatterns.TestPattern) {}
+
+func (e *efsDriver) PrepareTest(f *framework.Framework) (*testsuites.PerTestConfig, func()) {
+	ginkgo.By("Deploying EFS CSI driver")
+	cancelPodLogs := testsuites.StartPodLogs(f)
+
+	return &testsuites.PerTestConfig{
+			Driver:    e,
+			Prefix:    "efs",
+			Framework: f,
+		}, func() {
+			ginkgo.By("Cleaning up EFS CSI driver")
+			cancelPodLogs()
+		}
+}
+
+func (e *efsDriver) CreateVolume(config *testsuites.PerTestConfig, volType testpatterns.TestVolType) testsuites.TestVolume {
+	return nil
+}
+
+func (e *efsDriver) GetPersistentVolumeSource(readOnly bool, fsType string, volume testsuites.TestVolume) (*v1.PersistentVolumeSource, *v1.VolumeNodeAffinity) {
+	pvSource := v1.PersistentVolumeSource{
+		CSI: &v1.CSIPersistentVolumeSource{
+			Driver:       e.driverInfo.Name,
+			VolumeHandle: fileSystemId,
+		},
+	}
+	return &pvSource, nil
+}
+
+// List of testSuites to be executed in below loop
+var csiTestSuites = []func() testsuites.TestSuite{
+	testsuites.InitVolumesTestSuite,
+	testsuites.InitVolumeIOTestSuite,
+	testsuites.InitVolumeModeTestSuite,
+	testsuites.InitSubPathTestSuite,
+	testsuites.InitProvisioningTestSuite,
+	testsuites.InitMultiVolumeTestSuite,
+}
+
+var _ = ginkgo.BeforeSuite(func() {
+	ginkgo.By(fmt.Sprintf("Creating EFS filesystem in region %q for cluster %q", Region, ClusterName))
+	if Region == "" || ClusterName == "" {
+		ginkgo.Fail("failed to create EFS filesystem: both Region and ClusterName must be non-empty")
+	}
+	c := NewCloud(Region)
+	id, err := c.CreateFileSystem(ClusterName)
+	if err != nil {
+		ginkgo.Fail(fmt.Sprintf("failed to create EFS filesystem: %s", err))
+	}
+	fileSystemId = id
+})
+
+var _ = ginkgo.AfterSuite(func() {
+	ginkgo.By(fmt.Sprintf("Deleting EFS filesystem %s", fileSystemId))
+	if len(fileSystemId) != 0 {
+		c := NewCloud(Region)
+		err := c.DeleteFileSystem(fileSystemId)
+		if err != nil {
+			ginkgo.Fail(fmt.Sprintf("failed to delete EFS filesystem: %s", err))
+		}
+	}
+})
+
+var _ = ginkgo.Describe("[efs-csi] EFS CSI", func() {
+	driver := InitEFSCSIDriver()
+	ginkgo.Context(testsuites.GetDriverNameWithFeatureTags(driver), func() {
+		testsuites.DefineTestSuite(driver, csiTestSuites)
+	})
+})

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -29,22 +29,12 @@ import (
 	"github.com/onsi/ginkgo/config"
 	"github.com/onsi/ginkgo/reporters"
 	"github.com/onsi/gomega"
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/kubernetes/test/e2e/framework"
 	frameworkconfig "k8s.io/kubernetes/test/e2e/framework/config"
 	"k8s.io/kubernetes/test/e2e/framework/testfiles"
-	"k8s.io/kubernetes/test/e2e/storage/testpatterns"
-	"k8s.io/kubernetes/test/e2e/storage/testsuites"
 )
 
 const kubeconfigEnvVar = "KUBECONFIG"
-
-var (
-	clusterName  = flag.String("cluster-name", "", "the cluster name")
-	region       = flag.String("region", "us-west-2", "the region")
-	fileSystemId string
-)
 
 func init() {
 	testing.Init()
@@ -62,6 +52,10 @@ func init() {
 	frameworkconfig.CopyFlags(frameworkconfig.Flags, flag.CommandLine)
 	framework.RegisterCommonFlags(flag.CommandLine)
 	framework.RegisterClusterFlags(flag.CommandLine)
+
+	flag.StringVar(&ClusterName, "cluster-name", "", "the cluster name")
+	flag.StringVar(&Region, "region", "us-west-2", "the region")
+
 	flag.Parse()
 }
 
@@ -81,101 +75,3 @@ func TestEFSCSI(t *testing.T) {
 
 	ginkgo.RunSpecsWithDefaultAndCustomReporters(t, "EFS CSI Suite", r)
 }
-
-type efsDriver struct {
-	driverInfo testsuites.DriverInfo
-}
-
-var _ testsuites.TestDriver = &efsDriver{}
-
-// TODO implement Inline (unless it's redundant) and DynamicPV
-// var _ testsuites.InlineVolumeTestDriver = &efsDriver{}
-var _ testsuites.PreprovisionedPVTestDriver = &efsDriver{}
-
-func InitEFSCSIDriver() testsuites.TestDriver {
-	return &efsDriver{
-		driverInfo: testsuites.DriverInfo{
-			Name:                 "efs.csi.aws.com",
-			SupportedFsType:      sets.NewString(""),
-			SupportedMountOption: sets.NewString("tls", "ro"),
-			Capabilities: map[testsuites.Capability]bool{
-				testsuites.CapPersistence: true,
-				testsuites.CapExec:        true,
-				testsuites.CapMultiPODs:   true,
-				testsuites.CapRWX:         true,
-			},
-		},
-	}
-}
-
-func (e *efsDriver) GetDriverInfo() *testsuites.DriverInfo {
-	return &e.driverInfo
-}
-
-func (e *efsDriver) SkipUnsupportedTest(testpatterns.TestPattern) {}
-
-func (e *efsDriver) PrepareTest(f *framework.Framework) (*testsuites.PerTestConfig, func()) {
-	ginkgo.By("Deploying EFS CSI driver")
-	cancelPodLogs := testsuites.StartPodLogs(f)
-
-	return &testsuites.PerTestConfig{
-			Driver:    e,
-			Prefix:    "efs",
-			Framework: f,
-		}, func() {
-			ginkgo.By("Cleaning up EFS CSI driver")
-			cancelPodLogs()
-		}
-}
-
-func (e *efsDriver) CreateVolume(config *testsuites.PerTestConfig, volType testpatterns.TestVolType) testsuites.TestVolume {
-	return nil
-}
-
-func (e *efsDriver) GetPersistentVolumeSource(readOnly bool, fsType string, volume testsuites.TestVolume) (*v1.PersistentVolumeSource, *v1.VolumeNodeAffinity) {
-	pvSource := v1.PersistentVolumeSource{
-		CSI: &v1.CSIPersistentVolumeSource{
-			Driver:       e.driverInfo.Name,
-			VolumeHandle: fileSystemId,
-		},
-	}
-	return &pvSource, nil
-}
-
-// List of testSuites to be executed in below loop
-var csiTestSuites = []func() testsuites.TestSuite{
-	testsuites.InitVolumesTestSuite,
-	testsuites.InitVolumeIOTestSuite,
-	testsuites.InitVolumeModeTestSuite,
-	testsuites.InitSubPathTestSuite,
-	testsuites.InitProvisioningTestSuite,
-	testsuites.InitMultiVolumeTestSuite,
-}
-
-var _ = ginkgo.BeforeSuite(func() {
-	ginkgo.By(fmt.Sprintf("Creating EFS filesystem at %s on %s", *region, *clusterName))
-	c := NewCloud(*region)
-	id, err := c.CreateFileSystem(*clusterName)
-	if err != nil {
-		ginkgo.Fail(fmt.Sprintf("failed to create EFS filesystem: %s", err))
-	}
-	fileSystemId = id
-})
-
-var _ = ginkgo.AfterSuite(func() {
-	ginkgo.By(fmt.Sprintf("Deleting EFS filesystem %s", fileSystemId))
-	if len(fileSystemId) != 0 {
-		c := NewCloud(*region)
-		err := c.DeleteFileSystem(fileSystemId)
-		if err != nil {
-			ginkgo.Fail(fmt.Sprintf("failed to delete EFS filesystem: %s", err))
-		}
-	}
-})
-
-var _ = ginkgo.Describe("[efs-csi] EFS CSI", func() {
-	driver := InitEFSCSIDriver()
-	ginkgo.Context(testsuites.GetDriverNameWithFeatureTags(driver), func() {
-		testsuites.DefineTestSuite(driver, csiTestSuites)
-	})
-})


### PR DESCRIPTION
**Is this a bug fix or adding new feature?** bug fix

**What is this PR about? / Why do we need it?** This is a small refactor to move the test code to e2e.go away from the test entrypoint code e2e_test.go. Slightly cleaner and enables the use-case where I import package test/e2e in another package to access InitEFSCSIDriver, ClusterName, and Region.

**What testing is done?** go test command still works and still accepts cluster-name/region flags.
```
 go test ./test/e2e/ -v -timeout=0 -kubeconfig=$HOME/.kube/config --cluster-name=asdf --region=us-west-2 --report-dir=./ARTIFACTS -ginkgo.focus="\[efs-csi\]" -ginkgo.skip="\[Disruptive\]"

W0420 17:40:20.768014   43285 test_context.go:418] Unable to find in-cluster config, using default host : http://127.0.0.1:8080
Apr 20 17:40:20.768: INFO: The --provider flag is not set. Continuing as if --provider=skeleton had been used.
=== RUN   TestEFSCSI
2020-04-20 17:40:20.768572 I | Starting e2e run "f5a3c398-be21-4e4e-b49c-0ae849bde957" on Ginkgo node 1
Running Suite: EFS CSI Suite
============================
Random Seed: 1587429620 - Will randomize all specs
Will run 151 of 371 specs

STEP: Creating EFS filesystem at us-west-2 on asdf
...
```
