### PR TITLE
Add example for Access Points

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -84,6 +84,7 @@ Before the example, you need to:
 * [Accessing the filesystem from multiple pods](../examples/kubernetes/multiple_pods/README.md)
 * [Consume EFS in StatefulSets](../examples/kubernetes/statefulset/README.md)
 * [Mount subpath](../examples/kubernetes/volume_path/README.md)
+* [Use Access Points](../examples/kubernetes/access_points/README.md)
 
 ## Development
 Please go through [CSI Spec](https://github.com/container-storage-interface/spec/blob/master/spec.md) and [Kubernetes CSI Developer Documentation](https://kubernetes-csi.github.io/docs) to get some basic understanding of CSI driver before you start.

--- a/examples/kubernetes/access_points/README.md
+++ b/examples/kubernetes/access_points/README.md
@@ -6,7 +6,10 @@ In this case, the separation is managed on the EFS side rather than the kubernet
 
 ### Create Access Points (in EFS)
 Following [this doc](https://docs.aws.amazon.com/efs/latest/ug/create-access-point.html), create a separate access point for each independent data store you wish to expose in your cluster, tailoring the ownership and permissions as desired.
-Note that there's no need to use different EFS volumes.
+There is no need to use different EFS volumes.
+
+**Note**: Although it is possible to [configure IAM policies for access points](https://docs.aws.amazon.com/efs/latest/ug/efs-access-points.html#access-points-iam-policy), by default no additional IAM permissions are necessary.
+
 This example assumes you are using two access points.
 
 ### Edit [Persistent Volume Spec](./specs/example.yaml)

--- a/examples/kubernetes/access_points/README.md
+++ b/examples/kubernetes/access_points/README.md
@@ -1,0 +1,78 @@
+## EFS Access Points
+Like [volume path mounts](../volume_path), mounting [EFS access points](https://docs.aws.amazon.com/efs/latest/ug/efs-access-points.html) allows you to expose separate data stores with independent ownership and permissions from a single EFS volume.
+In this case, the separation is managed on the EFS side rather than the kubernetes side.
+
+**Note**: Because access point mounts require TLS, this is not supported in driver versions at or before `0.3`.
+
+### Create Access Points (in EFS)
+Following [this doc](https://docs.aws.amazon.com/efs/latest/ug/create-access-point.html), create a separate access point for each independent data store you wish to expose in your cluster, tailoring the ownership and permissions as desired.
+Note that there's no need to use different EFS volumes.
+This example assumes you are using two access points.
+
+### Edit [Persistent Volume Spec](./specs/example.yaml)
+```
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: efs-pv1
+spec:
+  capacity:
+    storage: 5Gi
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: efs-sc
+  mountOptions:
+    - tls
+    - accesspoint=[AccessPointId]
+  csi:
+    driver: efs.csi.aws.com
+    volumeHandle: [FileSystemId]
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: efs-pv2
+spec:
+  capacity:
+    storage: 5Gi
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: efs-sc
+  mountOptions:
+    - tls
+    - accesspoint=[AccessPointId]
+  csi:
+    driver: efs.csi.aws.com
+    volumeHandle: [FileSystemId]
+```
+In each PersistentVolume, replace both the `[FileSystemId]` in `spec.csi.volumeHandle` and the `[AccessPointId]` value of the `accesspoint` option in `spec.mountOptions`.
+You can find these values using the AWS CLI:
+```sh
+>> aws efs describe-access-points --query 'AccessPoints[*].{"FileSystemId": FileSystemId, "AccessPointId": AccessPointId}'
+```
+If you are using the same underlying EFS volume, the `FileSystemId` will be the same in both PersistentVolume specs, but the `AccessPointId` will differ.
+
+### Deploy the Example Application
+Create PVs, persistent volume claims (PVCs), and storage class:
+```sh
+>> kubectl apply -f examples/kubernetes/volume_path/specs/example.yaml
+```
+
+### Check EFS filesystem is used
+After the objects are created, verify the pod is running:
+
+```sh
+>> kubectl get pods
+```
+
+Also you can verify that data is written into the EFS filesystems:
+
+```sh
+>> kubectl exec -ti efs-app -- tail -f /data-dir1/out.txt
+>> kubectl exec -ti efs-app -- ls /data-dir2
+```

--- a/examples/kubernetes/access_points/specs/example.yaml
+++ b/examples/kubernetes/access_points/specs/example.yaml
@@ -1,0 +1,90 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: efs-sc
+provisioner: efs.csi.aws.com
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: efs-pv1
+spec:
+  capacity:
+    storage: 5Gi
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: efs-sc
+  mountOptions:
+    - tls
+    - accespoint=fsap-068c22f0246419f75
+  csi:
+    driver: efs.csi.aws.com
+    volumeHandle: fs-e8a95a42
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: efs-pv2
+spec:
+  capacity:
+    storage: 5Gi
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: efs-sc
+  mountOptions:
+    - tls
+    - accesspoint=fsap-19f752f0068c22464
+  csi:
+    driver: efs.csi.aws.com
+    volumeHandle: fs-e8a95a42
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: efs-claim1
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: efs-sc
+  resources:
+    requests:
+      storage: 5Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: efs-claim2
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: efs-sc
+  resources:
+    requests:
+      storage: 5Gi
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: efs-app
+spec:
+  containers:
+  - name: app
+    image: centos
+    command: ["/bin/sh"]
+    args: ["-c", "while true; do echo $(date -u) >> /data-dir1/out.txt; sleep 5; done"]
+    volumeMounts:
+    - name: efs-volume-1
+      mountPath: /data-dir1
+    - name: efs-volume-2
+      mountPath: /data-dir2
+  volumes:
+  - name: efs-volume-1
+    persistentVolumeClaim:
+      claimName: efs-claim1
+  - name: efs-volume-2
+    persistentVolumeClaim:
+      claimName: efs-claim2


### PR DESCRIPTION
Adds a README and sample specs for exposing multiple independent data
sources on the same EFS volume by creating and mounting access points.

**Is this a bug fix or adding new feature?**
Neither, really. It's adding docs for a thing that already works.

**What is this PR about? / Why do we need it?**
There are questions about how to manage the permissions of the mounts, which by default are inaccessible because they're owned by `root:root` with 755 permissions. Changing permissions of the root export and creating subdirectories both require manual intervention by a powerful user. This provides an alternative that does not (though it does require the ability to administer EFS itself).

**What testing is done?** 
Well, this is a doc, so it's not tested per se. But I've been using the outlined procedure under OpenShift Dedicated 4.3.