### PR TITLE
Pin dependency library versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ ADD . .
 RUN make aws-efs-csi-driver
 
 FROM amazonlinux:2
-RUN yum install util-linux amazon-efs-utils -y
+RUN yum install util-linux-2.30.2-2.amzn2.0.4.x86_64 amazon-efs-utils-1.24-4.amzn2.noarch -y
 
 # Default client source is k8s which can be overriden with –build-arg when building the Docker image
 ARG client_source=k8s

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN go mod download
 ADD . .
 RUN make aws-efs-csi-driver
 
-FROM amazonlinux:2
+FROM amazonlinux:2.0.20200406.0
 RUN yum install util-linux-2.30.2-2.amzn2.0.4.x86_64 amazon-efs-utils-1.24-4.amzn2.noarch -y
 
 # Default client source is k8s which can be overriden with –build-arg when building the Docker image


### PR DESCRIPTION
To make image builds more predictable, this commit pins the versions of
the two libraries pulled in by the docker build:
- util-linux
- amazon-efs-utils

This way we don't get surprised by changes in the underlying libs -- we
move along explicitly and deliberately.

**Is this a bug fix or adding new feature?**
Neither, just hardening the image build process.

**What is this PR about? / Why do we need it?**

Recently when trying to debug a problem mounting access points (see https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/152) one of our wild goose chases involved figuring out what version of amazon-efs-utils was built into the driver image at various times during our testing. Having the version pinned in the dockerfile for a given driver release would have removed the guesswork.

And in general this is just a good idea.

**What testing is done?** 
Local `make image-release`, run (overriding entrypoint with a shell), verify installed versions with `yum`.