### PR TITLE
Bump livenessprobe and node-driver-registrar versions

### DIFF
--- a/deploy/kubernetes/base/node.yaml
+++ b/deploy/kubernetes/base/node.yaml
@@ -54,7 +54,7 @@ spec:
             periodSeconds: 2
             failureThreshold: 5
         - name: csi-driver-registrar
-          image: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0
+          image: quay.io/k8scsi/csi-node-driver-registrar:v1.3.0
           args:
             - --csi-address=$(ADDRESS)
             - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
@@ -75,7 +75,7 @@ spec:
               mountPath: /registration
         - name: liveness-probe
           imagePullPolicy: Always
-          image: quay.io/k8scsi/livenessprobe:v1.1.0
+          image: quay.io/k8scsi/livenessprobe:v2.0.0
           args:
             - --csi-address=/csi/csi.sock
             - --health-port=9809

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -12,10 +12,10 @@ image:
 sidecars:
   livenessProbeImage:
     repository: quay.io/k8scsi/livenessprobe
-    tag: "v1.1.0"
+    tag: "v2.0.0"
   nodeDriverRegistrarImage:
     repository: quay.io/k8scsi/csi-node-driver-registrar
-    tag: "v1.1.0"
+    tag: "v1.3.0"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
**Is this a bug fix or adding new feature?** bugfix

**What is this PR about? / Why do we need it?** these are backwards compatible. Can help avoid issues like https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/128 where e.g. livenessprobe has a bug.

**What testing is done?** quay.io/k8scsi/csi-node-driver-registrar:v1.3.0 & quay.io/k8scsi/livenessprobe:v2.0.0 work for me.
