### PR TITLE
Updated node.yaml to update deprecated node selectors

### DIFF
--- a/deploy/kubernetes/base/node.yaml
+++ b/deploy/kubernetes/base/node.yaml
@@ -15,8 +15,8 @@ spec:
         app: efs-csi-node
     spec:
       nodeSelector:
-        beta.kubernetes.io/os: linux
-        beta.kubernetes.io/arch: amd64
+        kubernetes.io/os: linux
+        kubernetes.io/arch: amd64
       hostNetwork: true
       priorityClassName: system-node-critical
       tolerations:


### PR DESCRIPTION
Updated node.yaml to remove deprecated labels

**Is this a bug fix or adding new feature?** 

**What is this PR about? / Why do we need it?**
As per documentation, `kubernetes-io-arch` and `kubernetes.io/os` node selectors are deprecated.
https://v1-14.docs.kubernetes.io/docs/reference/kubernetes-api/labels-annotations-taints/#beta-kubernetes-io-arch-deprecated. Removed deprecated node selectors. 

**What testing is done?** 
N/A