### PR TITLE
Remove hostNetwork from daemonset yamls

### DIFF
--- a/deploy/kubernetes/base/node.yaml
+++ b/deploy/kubernetes/base/node.yaml
@@ -17,7 +17,6 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
         kubernetes.io/arch: amd64
-      hostNetwork: true
       priorityClassName: system-node-critical
       tolerations:
         - operator: Exists

--- a/helm/templates/daemonset.yaml
+++ b/helm/templates/daemonset.yaml
@@ -22,7 +22,6 @@ spec:
     spec:
       nodeSelector:
         beta.kubernetes.io/os: linux
-      hostNetwork: true
       priorityClassName: system-node-critical
       tolerations:
         - operator: Exists


### PR DESCRIPTION
**Is this a bug fix or adding new feature?** fix

**What is this PR about? / Why do we need it?** The node plugin shouldn't need hostNetwork to function. One implication of it being hostNetwork is that the healthz takes up port 9809 on the node. So let's remove it.

**What testing is done?** still works without hostNetwork