### PR TITLE
Bump stable overlay to 0.3.0

### DIFF
--- a/deploy/kubernetes/overlays/stable/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/kustomization.yaml
@@ -5,7 +5,7 @@ bases:
 images:
 - name: amazon/aws-efs-csi-driver
   newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/aws-efs-csi-driver
-  newTag: v0.2.0
+  newTag: v0.3.0
 - name: quay.io/k8scsi/livenessprobe
   newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-liveness-probe
   newTag: v1.1.0


### PR DESCRIPTION
**Is this a bug fix or adding new feature?** bug

**What is this PR about? / Why do we need it?** This overlay still points to 0.2.0 in ECR but 0.3.0 is out. And the helm chart already points to 0.3.0 in docker hub. Fix the inconsistency. The reason overlay got out of date is the image was not made available in ECR at the same time as in docker hub.

In the future, there will always be a little bit of lag because docker hub gets the image soonest via github action and ECR must follow. Should consider just using docker hub here.

**What testing is done?** apply works, can pull from 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/aws-efs-csi-driver:v0.3.0
