### PR TITLE
Update stable overlay to use public images

### DIFF
--- a/deploy/kubernetes/overlays/stable/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/kustomization.yaml
@@ -4,12 +4,9 @@ bases:
 - ../../base
 images:
 - name: amazon/aws-efs-csi-driver
-  newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/aws-efs-csi-driver
   newTag: v0.3.0
 - name: quay.io/k8scsi/livenessprobe
-  newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-liveness-probe
   newTag: v1.1.0
 - name: quay.io/k8scsi/csi-node-driver-registrar
-  newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-node-driver-registrar
   newTag: v1.1.0
 


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Update stable overlay to use public images