### PR TITLE
Only publish if access type is 'mount', not 'block'

### DIFF
--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -64,6 +64,10 @@ func (d *Driver) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolu
 		return nil, status.Error(codes.InvalidArgument, "Volume capability not supported")
 	}
 
+	if volCap.GetMount() == nil {
+		return nil, status.Error(codes.InvalidArgument, "Volume capability access type must be mount")
+	}
+
 	// TODO when CreateVolume is implemented, it must use the same key names
 	subpath := "/"
 	volContext := req.GetVolumeContext()

--- a/pkg/driver/node_test.go
+++ b/pkg/driver/node_test.go
@@ -348,6 +348,26 @@ func TestNodePublishVolume(t *testing.T) {
 			},
 		},
 		{
+			name: "fail: unsupported volume access type",
+			req: &csi.NodePublishVolumeRequest{
+				VolumeId: volumeId,
+				VolumeCapability: &csi.VolumeCapability{
+					AccessType: &csi.VolumeCapability_Block{
+						Block: &csi.VolumeCapability_BlockVolume{},
+					},
+					AccessMode: &csi.VolumeCapability_AccessMode{
+						Mode: csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER,
+					},
+				},
+				TargetPath: targetPath,
+			},
+			expectMakeDir: false,
+			expectError: errtyp{
+				code:    "InvalidArgument",
+				message: "Volume capability access type must be mount",
+			},
+		},
+		{
 			name: "fail: mounter failed to MakeDir",
 			req: &csi.NodePublishVolumeRequest{
 				VolumeId:         volumeId,


### PR DESCRIPTION
**Is this a bug fix or adding new feature?** fix

**What is this PR about? / Why do we need it?** It's possible for a user to specify an EFS volume in their pod's `volumeDevices` in which case kubelet will call `MapVolume` on the volume and pass access type 'block' in NodePublish. Since it doesn't make sense to consume EFS as a block volume, the driver should return a clear error in this case instead of unnecessarily mounting the volume.

This is exercised by the test case "should fail to create pod by failing to mount volume." Right now the driver passes the test because AttachFileDevice fails and then subsequent mounts fail with 'mount already exists' errors. Ideally the driver should pass the test by "fast failing" and there should be a FailedMapVolume event.

**What testing is done?**  FailedMapVolume shows up on the pod:
```
  Warning  FailedMapVolume  2s (x8 over 66s)  kubelet, ip-192-168-115-67.us-west-2.compute.internal  MapVolume.SetUp failed for volume "pvk29ck" : kubernetes.io/csi: blockMapper.publishVolumeForBlock failed: rpc error: code = InvalidArgument desc = Volume capability access type must be mount
```