### PR TITLE
Always enabled encryption in transit

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -24,7 +24,9 @@ The following CSI interfaces are implemented:
 ### Encryption In Transit
 One of the advantages of using EFS is that it provides [encryption in transit](https://aws.amazon.com/blogs/aws/new-encryption-of-data-in-transit-for-amazon-efs/) support using TLS. Using encryption in transit, data will be encrypted during its transition over the network to the EFS service. This provides an extra layer of defence-in-depth for applications that requires strict security compliance.
 
-To enable encryption in transit, `tls` needs to be set in the `NodePublishVolumeRequest.VolumeCapability.MountVolume` object's `MountFlags` fields. For an example of using it in kubernetes, see the persistence volume manifest in [Encryption in Transit Example](../examples/kubernetes/encryption_in_transit/specs/pv.yaml)
+For EFS CSI Driver EFS CSI Driver v0.3.0 or earlier releases, this feature is optional. To enable encryption in transit, `tls` needs to be set in the `NodePublishVolumeRequest.VolumeCapability.MountVolume` object's `MountFlags` fields. For an example of using it in kubernetes, see the persistence volume manifest in [Encryption in Transit Example](../examples/kubernetes/encryption_in_transit/specs/pv.yaml)
+
+For new releases starting v0.4.0, encryption in transit is always enabled.
 
 **Note** Kubernetes version 1.13+ is required if you are using this feature in Kubernetes.
 
@@ -32,12 +34,12 @@ To enable encryption in transit, `tls` needs to be set in the `NodePublishVolume
 The following sections are Kubernetes specific. If you are a Kubernetes user, use this for driver features, installation steps and examples.
 
 ### Kubernetes Version Compability Matrix
-| AWS EFS CSI Driver \ Kubernetes Version| maturity | v1.11 | v1.12 | v1.13 | v1.14 | v1.15 |
-|----------------------------------------|----------|-------|-------|-------|-------|-------|
-| master branch                          | beta     | no    | no    | no    | yes   | yes   |
-| v0.3.0                                 | beta     | no    | no    | no    | yes   | yes   |
-| v0.2.0                                 | beta     | no    | no    | no    | yes   | yes   |
-| v0.1.0                                 | alpha    | yes   | yes   | yes   | no    | no    |
+| AWS EFS CSI Driver \ Kubernetes Version (both master and worker node)| maturity | v1.11 | v1.12 | v1.13 | v1.14 | v1.15 |
+|----------------------------------------------------------------------|----------|-------|-------|-------|-------|-------|
+| master branch                                                        | beta     | no    | no    | no    | yes   | yes   |
+| v0.3.0                                                               | beta     | no    | no    | no    | yes   | yes   |
+| v0.2.0                                                               | beta     | no    | no    | no    | yes   | yes   |
+| v0.1.0                                                               | alpha    | yes   | yes   | yes   | no    | no    |
 
 ### Container Images
 |EFS CSI Driver Version     | Image                               |
@@ -49,7 +51,7 @@ The following sections are Kubernetes specific. If you are a Kubernetes user, us
 
 ### Features
 * Static provisioning - EFS filesystem needs to be created manually first, then it could be mounted inside container as a persistent volume (PV) using the driver.
-* Mount Options - Mount options can be specified in the persistence volume (PV) to define how the volume should be mounted. Aside from normal mount options, you can also specify `tls` as a mount option to enable encryption in transit of the EFS filesystem.
+* Mount Options - Mount options can be specified in the persistence volume (PV) to define how the volume should be mounted. Aside from normal mount options, for EFS CSI Driver v0.3.0 or earlier releases, you can also specify `tls` as a mount option to enable encryption in transit of the EFS filesystem (this feature is always enabled starting release 0.4.0).
 
 **Notes**:
 * Since EFS is an elastic filesystem it doesn't really enforce any filesystem capacity. The actual storage capacity value in persistence volume and persistence volume claim is not used when creating the filesystem. However, since the storage capacity is a required field by Kubernetes, you must specify the value and you can use any valid value for the capacity.

--- a/examples/kubernetes/access_points/README.md
+++ b/examples/kubernetes/access_points/README.md
@@ -2,7 +2,7 @@
 Like [volume path mounts](../volume_path), mounting [EFS access points](https://docs.aws.amazon.com/efs/latest/ug/efs-access-points.html) allows you to expose separate data stores with independent ownership and permissions from a single EFS volume.
 In this case, the separation is managed on the EFS side rather than the kubernetes side.
 
-**Note**: Because access point mounts require TLS, this is not supported in driver versions at or before `0.3`.
+**Note**: Because access point mounts require TLS, this is not supported in driver versions at or before `0.3.0`.
 
 ### Create Access Points (in EFS)
 Following [this doc](https://docs.aws.amazon.com/efs/latest/ug/create-access-point.html), create a separate access point for each independent data store you wish to expose in your cluster, tailoring the ownership and permissions as desired.

--- a/examples/kubernetes/encryption_in_transit/README.md
+++ b/examples/kubernetes/encryption_in_transit/README.md
@@ -1,6 +1,8 @@
 ## Encryption in Transit
 This example shows how to make a static provisioned EFS persistence volume (PV) mounted inside container with encryption in transit enabled.
 
+**Note**: this example is being deprecated starting EFS CSI Driver release v0.4.0 since encryption in transit is always enabled without extra setup.
+
 **Note**: this example requires Kubernetes v1.13+
 
 ### Edit [Persistence Volume Spec](./specs/pv.yaml) 

--- a/pkg/driver/node_test.go
+++ b/pkg/driver/node_test.go
@@ -67,7 +67,7 @@ func TestNodePublishVolume(t *testing.T) {
 				}
 
 				mockMounter.EXPECT().MakeDir(gomock.Eq(targetPath)).Return(nil)
-				mockMounter.EXPECT().Mount(gomock.Eq(source), gomock.Eq(targetPath), gomock.Eq("efs"), gomock.Any()).Return(nil)
+				mockMounter.EXPECT().Mount(gomock.Eq(source), gomock.Eq(targetPath), gomock.Eq("efs"), gomock.Eq([]string{"tls"})).Return(nil)
 				_, err := driver.NodePublishVolume(ctx, req)
 				if err != nil {
 					t.Fatalf("NodePublishVolume is failed: %v", err)
@@ -97,7 +97,7 @@ func TestNodePublishVolume(t *testing.T) {
 				}
 
 				mockMounter.EXPECT().MakeDir(gomock.Eq(targetPath)).Return(nil)
-				mockMounter.EXPECT().Mount(gomock.Eq(source), gomock.Eq(targetPath), gomock.Eq("efs"), gomock.Eq([]string{"ro"})).Return(nil)
+				mockMounter.EXPECT().Mount(gomock.Eq(source), gomock.Eq(targetPath), gomock.Eq("efs"), gomock.Eq([]string{"ro", "tls"})).Return(nil)
 				_, err := driver.NodePublishVolume(ctx, req)
 				if err != nil {
 					t.Fatalf("NodePublishVolume is failed: %v", err)
@@ -165,7 +165,7 @@ func TestNodePublishVolume(t *testing.T) {
 				}
 
 				mockMounter.EXPECT().MakeDir(gomock.Eq(targetPath)).Return(nil)
-				mockMounter.EXPECT().Mount(gomock.Eq(source), gomock.Eq(targetPath), gomock.Eq("efs"), gomock.Any()).Return(nil)
+				mockMounter.EXPECT().Mount(gomock.Eq(source), gomock.Eq(targetPath), gomock.Eq("efs"), gomock.Eq([]string{"tls"})).Return(nil)
 				_, err := driver.NodePublishVolume(ctx, req)
 				if err != nil {
 					t.Fatalf("NodePublishVolume is failed: %v", err)
@@ -194,7 +194,7 @@ func TestNodePublishVolume(t *testing.T) {
 				}
 
 				mockMounter.EXPECT().MakeDir(gomock.Eq(targetPath)).Return(nil)
-				mockMounter.EXPECT().Mount(gomock.Eq(source), gomock.Eq(targetPath), gomock.Eq("efs"), gomock.Any()).Return(nil)
+				mockMounter.EXPECT().Mount(gomock.Eq(source), gomock.Eq(targetPath), gomock.Eq("efs"), gomock.Eq([]string{"tls"})).Return(nil)
 				_, err := driver.NodePublishVolume(ctx, req)
 				if err != nil {
 					t.Fatalf("NodePublishVolume is failed: %v", err)


### PR DESCRIPTION
**What is this PR about? / Why do we need it?**
This PR is a feature request to always enable [encryption in transit](https://docs.aws.amazon.com/efs/latest/ug/encryption-in-transit.html) by always passing in `tls` as mount options. 

Using encryption in transit, data will be encrypted during its transition over the network to the EFS service. This provides an extra layer of defence-in-depth for applications that requires strict security compliance.

Encryption in transit was not always enabled in EFS mount helper because EFS can't control the client OS and some versions of Linux don't include a version of stunnel (a service providing TLS tunneling) that supports these TLS features by default. In the EFS CSI Driver case, we have the luxury to always run the driver in Amazon Linux 2 container which includes a newer version of stunnel. 

**What testing is done?** 
1. When running the static provisioner example where `tls` was not set as mount option, verified in EFS CSI Driver log `tls` was set. 
```
I0514 22:09:14.623830       1 node.go:108] NodePublishVolume: mounting fs-b6654c1c:/ at /var/lib/kubelet/pods/9de5c5d3-1a1f-4ecb-b522-2c538dc2709d/volumes/kubernetes.io~csi/efs-pv/mount with options [tls]
```
2. Exec into efs-csi-node pod and verified stunnel process was started. 

```
kubectl exec $(kubectl get po -l app=efs-csi-node -n kube-system -o jsonpath='{.items[0].metadata.name}') -n kube-system -c efs-plugin -it sh

sh-4.2# ps -ef
UID        PID  PPID  C STIME TTY          TIME CMD
root         1     0  0 23:08 ?        00:00:00 /bin/aws-efs-csi-driver --endpoint=unix:/csi/csi.sock --logtostderr --
root        14     1  0 23:08 ?        00:00:00 python /usr/bin/amazon-efs-mount-watchdog
root       102     1  0 23:11 ?        00:00:00 stunnel /var/run/efs/stunnel-config.fs-b6654c1c.var.lib.kubelet.pods.5
```

3. Set up in the efs filesytem to enforce in-transit encryption for all clients and verified the example still works. 