### PR TITLE
Correcting typo in access points example

### DIFF
--- a/examples/kubernetes/access_points/specs/example.yaml
+++ b/examples/kubernetes/access_points/specs/example.yaml
@@ -18,7 +18,7 @@ spec:
   storageClassName: efs-sc
   mountOptions:
     - tls
-    - accespoint=fsap-068c22f0246419f75
+    - accesspoint=fsap-068c22f0246419f75
   csi:
     driver: efs.csi.aws.com
     volumeHandle: fs-e8a95a42


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

Bug fix

**What is this PR about? / Why do we need it?**

Fixes a typo in the Access Points example.

**What testing is done?**

Used the example in my K8 cluster and it doesn't work with this typo.
