### PR TITLE
Persisted private key genereated by efs-util to host

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,15 +27,6 @@ RUN make aws-efs-csi-driver
 FROM amazonlinux:2
 RUN yum install util-linux amazon-efs-utils -y
 
-# Default client source is k8s which can be overriden with –build-arg when building the Docker image
-ARG client_source=k8s
-RUN echo "client_source:${client_source}"
-RUN printf "\n\
-\n\
-[client-info] \n\
-source=${client_source} \n\
-" >> /etc/amazon/efs/efs-utils.conf
-
 COPY --from=builder /go/src/github.com/kubernetes-sigs/aws-efs-csi-driver/bin/aws-efs-csi-driver /bin/aws-efs-csi-driver
 COPY THIRD-PARTY /
 

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,11 @@ IMAGE?=amazon/aws-efs-csi-driver
 VERSION=v0.4.0-dirty
 GIT_COMMIT?=$(shell git rev-parse HEAD)
 BUILD_DATE?=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
-LDFLAGS?="-X ${PKG}/pkg/driver.driverVersion=${VERSION} -X ${PKG}/pkg/driver.gitCommit=${GIT_COMMIT} -X ${PKG}/pkg/driver.buildDate=${BUILD_DATE}"
+EFS_CLIENT_SOURCE?=k8s
+LDFLAGS?="-X ${PKG}/pkg/driver.driverVersion=${VERSION} \
+		  -X ${PKG}/pkg/driver.gitCommit=${GIT_COMMIT} \
+		  -X ${PKG}/pkg/driver.buildDate=${BUILD_DATE} \
+		  -X ${PKG}/pkg/driver.efsClientSource=${EFS_CLIENT_SOURCE}"
 GO111MODULE=on
 GOPROXY=direct
 GOPATH=$(shell go env GOPATH)
@@ -29,6 +33,13 @@ GOPATH=$(shell go env GOPATH)
 aws-efs-csi-driver:
 	mkdir -p bin
 	CGO_ENABLED=0 GOOS=linux go build -ldflags ${LDFLAGS} -o bin/aws-efs-csi-driver ./cmd/
+
+build-darwin:
+	mkdir -p bin/darwin/
+	CGO_ENABLED=0 GOOS=darwin go build -ldflags ${LDFLAGS} -o bin/darwin/aws-efs-csi-driver ./cmd/
+
+run-darwin: build-darwin
+	bin/darwin/aws-efs-csi-driver --version
 
 .PHONY: verify
 verify:

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -27,8 +27,9 @@ import (
 
 func main() {
 	var (
-		endpoint = flag.String("endpoint", "unix://tmp/csi.sock", "CSI Endpoint")
-		version  = flag.Bool("version", false, "Print the version and exit")
+		endpoint        = flag.String("endpoint", "unix://tmp/csi.sock", "CSI Endpoint")
+		version         = flag.Bool("version", false, "Print the version and exit")
+		efsUtilsCfgPath = flag.String("efs-utils-config-path", "/etc/amazon/efs/efs-utils.conf", "The path to efs-utils config")
 	)
 	klog.InitFlags(nil)
 	flag.Parse()
@@ -42,7 +43,7 @@ func main() {
 		os.Exit(0)
 	}
 
-	drv := driver.NewDriver(*endpoint)
+	drv := driver.NewDriver(*endpoint, *efsUtilsCfgPath)
 	if err := drv.Run(); err != nil {
 		klog.Fatalln(err)
 	}

--- a/deploy/kubernetes/base/node.yaml
+++ b/deploy/kubernetes/base/node.yaml
@@ -40,6 +40,8 @@ spec:
               mountPath: /csi
             - name: efs-state-dir
               mountPath: /var/run/efs
+            - name: efs-utils-config
+              mountPath: /etc/amazon/efs
           ports:
             - containerPort: 9809
               name: healthz
@@ -97,5 +99,8 @@ spec:
           hostPath:
             path: /var/run/efs
             type: DirectoryOrCreate
-
+        - name: efs-utils-config
+          hostPath:
+            path: /etc/amazon/efs
+            type: DirectoryOrCreate
 

--- a/helm/templates/daemonset.yaml
+++ b/helm/templates/daemonset.yaml
@@ -48,6 +48,8 @@ spec:
               mountPath: /csi
             - name: efs-state-dir
               mountPath: /var/run/efs
+            - name: efs-utils-config
+              mountPath: /etc/amazon/efs
           ports:
             - name: healthz
               containerPort: 9809
@@ -58,7 +60,7 @@ spec:
               port: healthz
             initialDelaySeconds: 10
             timeoutSeconds: 3
-            periodSeconds: 2 
+            periodSeconds: 2
             failureThreshold: 5
         - name: cs-driver-registrar
           image: {{ printf "%s:%s" .Values.sidecars.nodeDriverRegistrarImage.repository .Values.sidecars.nodeDriverRegistrarImage.tag }}
@@ -104,4 +106,8 @@ spec:
         - name: efs-state-dir
           hostPath:
             path: /var/run/efs
+            type: DirectoryOrCreate
+        - name: efs-utils-config
+          hostPath:
+            path: /etc/amazon/efs
             type: DirectoryOrCreate

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -21,10 +21,11 @@ import (
 	"net"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
-	"github.com/kubernetes-sigs/aws-efs-csi-driver/pkg/cloud"
-	"github.com/kubernetes-sigs/aws-efs-csi-driver/pkg/util"
 	"google.golang.org/grpc"
 	"k8s.io/klog"
+
+	"github.com/kubernetes-sigs/aws-efs-csi-driver/pkg/cloud"
+	"github.com/kubernetes-sigs/aws-efs-csi-driver/pkg/util"
 )
 
 const (
@@ -42,13 +43,13 @@ type Driver struct {
 	efsWatchdog Watchdog
 }
 
-func NewDriver(endpoint string) *Driver {
+func NewDriver(endpoint, efsUtilsCfgPath string) *Driver {
 	cloud, err := cloud.NewCloud()
 	if err != nil {
 		klog.Fatalln(err)
 	}
 
-	watchdog := newExecWatchdog("amazon-efs-mount-watchdog")
+	watchdog := newExecWatchdog(efsUtilsCfgPath, "amazon-efs-mount-watchdog")
 	return &Driver{
 		endpoint:    endpoint,
 		nodeID:      cloud.GetMetadata().GetInstanceID(),
@@ -84,7 +85,9 @@ func (d *Driver) Run() error {
 	csi.RegisterNodeServer(d.srv, d)
 
 	klog.Info("Starting watchdog")
-	d.efsWatchdog.start()
+	if err := d.efsWatchdog.start(); err != nil {
+		return err
+	}
 
 	reaper := newReaper()
 	klog.Info("Staring subreaper")

--- a/pkg/driver/efs_watch_dog_test.go
+++ b/pkg/driver/efs_watch_dog_test.go
@@ -98,7 +98,8 @@ func TestUpdateConfig(t *testing.T) {
 	defer os.Remove(f.Name())
 
 	w := newExecWatchdog(f.Name(), "sleep", "300").(*execWatchdog)
-	if err := w.updateConfig(); err != nil {
+	efsClient := "k8s"
+	if err := w.updateConfig(efsClient); err != nil {
 		t.Fatalf("Failed to update config file %v, %v", f, err)
 	}
 	bytes, err := ioutil.ReadAll(f)

--- a/pkg/driver/efs_watch_dog_test.go
+++ b/pkg/driver/efs_watch_dog_test.go
@@ -14,13 +14,106 @@ limitations under the License.
 package driver
 
 import (
+	"io/ioutil"
+	"os"
 	"testing"
 	"time"
 )
 
+const expectedEfsUtilsConfig = `
+[DEFAULT]
+logging_level = INFO
+logging_max_bytes = 1048576
+logging_file_count = 10
+# mode for /var/run/efs and subdirectories in octal
+state_file_dir_mode = 750
+
+[mount]
+dns_name_format = {fs_id}.efs.{region}.{dns_name_suffix}
+dns_name_suffix = amazonaws.com
+#The region of the file system when mounting from on-premises or cross region.
+#region = us-east-1
+stunnel_debug_enabled = true
+#Uncomment the below option to save all stunnel logs for a file system to the same file
+stunnel_logs_file = /var/log/amazon/efs/{fs_id}.stunnel.log
+# RootCA on AmazonLinux2/CentOS. https://golang.org/src/crypto/x509/root_linux.go
+stunnel_cafile = /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+
+# Validate the certificate hostname on mount. This option is not supported by certain stunnel versions.
+stunnel_check_cert_hostname = true
+
+# Use OCSP to check certificate validity. This option is not supported by certain stunnel versions.
+stunnel_check_cert_validity = false
+
+# Define the port range that the TLS tunnel will choose from
+port_range_lower_bound = 20049
+port_range_upper_bound = 20449
+
+[mount.cn-north-1]
+dns_name_suffix = amazonaws.com.cn
+
+[mount.cn-northwest-1]
+dns_name_suffix = amazonaws.com.cn
+
+[mount.us-iso-east-1]
+dns_name_suffix = c2s.ic.gov
+
+[mount.us-isob-east-1]
+dns_name_suffix = sc2s.sgov.gov
+
+[mount-watchdog]
+enabled = true
+poll_interval_sec = 1
+unmount_grace_period_sec = 30
+
+# Set client auth/access point certificate renewal rate. Minimum value is 1 minute.
+tls_cert_renewal_interval_min = 60
+
+[client-info] 
+source=k8s
+`
+
 func TestExecWatchdog(t *testing.T) {
-	w := newExecWatchdog("sleep", "300")
-	w.start()
+	f := createEmptyConfigFile(t)
+	defer os.Remove(f.Name())
+
+	w := newExecWatchdog(f.Name(), "sleep", "300")
+	if err := w.start(); err != nil {
+		t.Fatalf("Failed to start %v", err)
+	}
 	time.Sleep(time.Second)
 	w.stop()
+}
+
+func createEmptyConfigFile(t *testing.T) *os.File {
+	f, err := ioutil.TempFile("", "")
+	if err != nil {
+		t.Fatalf("couldn't create temp file %v, %v", f, err)
+	}
+	return f
+}
+
+func TestUpdateConfig(t *testing.T) {
+	f := createEmptyConfigFile(t)
+	defer os.Remove(f.Name())
+
+	w := newExecWatchdog(f.Name(), "sleep", "300").(*execWatchdog)
+	if err := w.updateConfig(); err != nil {
+		t.Fatalf("Failed to update config file %v, %v", f, err)
+	}
+	bytes, err := ioutil.ReadAll(f)
+	if err != nil {
+		t.Fatalf("Failed to read config file %v, %v", f, err)
+	}
+	actualConfig := string(bytes)
+	if actualConfig != expectedEfsUtilsConfig {
+		t.Errorf("Unexpected efs-utils config content: want %s\nactual:%s", expectedEfsUtilsConfig, actualConfig)
+	}
+}
+
+func TestWrite(t *testing.T) {
+	redirect := newInfoRedirect("info")
+	if _, err := redirect.Write([]byte("abc")); err != nil {
+		t.Errorf("Failed to Write in redirect: %v", err)
+	}
 }

--- a/pkg/driver/sanity_test.go
+++ b/pkg/driver/sanity_test.go
@@ -31,7 +31,8 @@ import (
 type mockWatchdog struct {
 }
 
-func (w *mockWatchdog) start() {
+func (w *mockWatchdog) start() error {
+	return nil
 }
 
 func (w *mockWatchdog) stop() {

--- a/pkg/driver/version.go
+++ b/pkg/driver/version.go
@@ -19,28 +19,31 @@ import (
 )
 
 var (
-	driverVersion string
-	gitCommit     string
-	buildDate     string
+	driverVersion   string
+	gitCommit       string
+	buildDate       string
+	efsClientSource string
 )
 
 type VersionInfo struct {
-	DriverVersion string `json:"driverVersion"`
-	GitCommit     string `json:"gitCommit"`
-	BuildDate     string `json:"buildDate"`
-	GoVersion     string `json:"goVersion"`
-	Compiler      string `json:"compiler"`
-	Platform      string `json:"platform"`
+	DriverVersion   string `json:"driverVersion"`
+	GitCommit       string `json:"gitCommit"`
+	BuildDate       string `json:"buildDate"`
+	EfsClientSource string `json:"efsClientSource"`
+	GoVersion       string `json:"goVersion"`
+	Compiler        string `json:"compiler"`
+	Platform        string `json:"platform"`
 }
 
 func GetVersion() VersionInfo {
 	return VersionInfo{
-		DriverVersion: driverVersion,
-		GitCommit:     gitCommit,
-		BuildDate:     buildDate,
-		GoVersion:     runtime.Version(),
-		Compiler:      runtime.Compiler,
-		Platform:      fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+		DriverVersion:   driverVersion,
+		GitCommit:       gitCommit,
+		BuildDate:       buildDate,
+		EfsClientSource: efsClientSource,
+		GoVersion:       runtime.Version(),
+		Compiler:        runtime.Compiler,
+		Platform:        fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
 	}
 }
 func GetVersionJSON() (string, error) {

--- a/pkg/driver/version_test.go
+++ b/pkg/driver/version_test.go
@@ -23,12 +23,13 @@ func TestGetVersion(t *testing.T) {
 	version := GetVersion()
 
 	expected := VersionInfo{
-		DriverVersion: "",
-		GitCommit:     "",
-		BuildDate:     "",
-		GoVersion:     runtime.Version(),
-		Compiler:      runtime.Compiler,
-		Platform:      fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+		DriverVersion:   "",
+		GitCommit:       "",
+		BuildDate:       "",
+		EfsClientSource: "",
+		GoVersion:       runtime.Version(),
+		Compiler:        runtime.Compiler,
+		Platform:        fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
 	}
 
 	if !reflect.DeepEqual(version, expected) {
@@ -44,6 +45,7 @@ func TestGetVersionJSON(t *testing.T) {
   "driverVersion": "",
   "gitCommit": "",
   "buildDate": "",
+  "efsClientSource": "",
   "goVersion": "%s",
   "compiler": "%s",
   "platform": "%s"


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Fix https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/178

**What is this PR about? / Why do we need it?**
This PR persists the private key generated by efs-utils at https://github.com/aws/efs-utils/blob/7b1f2d0f90afc5a6bfdf5522d5231eb8a91c184d/src/mount_efs/__init__.py#L1046.

An side-effect of making `/etc/amazon/efs` folder  a hostpath is it cleans up the content written to that folder when installing efs-utils, including `efs-utils.conf` and `efs-utils-crt` (https://github.com/aws/efs-utils/blob/7b1f2d0f90afc5a6bfdf5522d5231eb8a91c184d/dist/efs-utils.conf and https://github.com/aws/efs-utils/blob/7b1f2d0f90afc5a6bfdf5522d5231eb8a91c184d/dist/efs-utils.crt), because hostpath added a new layer on top of the image that's built from Dockerfile. 

The workaround is 
1) Having EFS driver create the `efs-utils.conf` directly, which is the right thing to do anyway. 
2) Pointing stunnel to use a pre-existing root CA from the image, `/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem`, which is where Golang looks up Root CA in CentOS. 

**What testing is done?** 
Killed the driver process and updates to EFS mount request still went through right after a new container is launched. 

```
$kubectl exec -ti efs-app -- tail -f /data/out.txt

Sat Jun 6 01:02:50 UTC 2020
Sat Jun 6 01:02:55 UTC 2020 # killed the driver process which terminated the old container
Sat Jun 6 01:03:06 UTC 2020
Sat Jun 6 01:03:11 UTC 2020
Sat Jun 6 01:03:16 UTC 2020
```

`kubectl exec` into the driver container. 

```
sh-4.2# aws-efs-csi-driver --version
{
  "driverVersion": "v0.4.0-dirty",
  "gitCommit": "5741533ed37c0bc44c3a639de50acb2fdf9f78a2",
  "buildDate": "2020-06-10T21:52:08Z",
  "efsClientSource": "k8s",
  "goVersion": "go1.13.4",
  "compiler": "gc",
  "platform": "linux/amd64"
}

sh-4.2# cat /etc/amazon/efs/efs-utils.conf 
[DEFAULT]
logging_level = INFO
... 
tls_cert_renewal_interval_min = 60

[client-info] 
source=k8s
```