### PR TITLE
Add hostNetwork: true to daemonset yamls

### DIFF
--- a/deploy/kubernetes/base/node.yaml
+++ b/deploy/kubernetes/base/node.yaml
@@ -17,6 +17,7 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
         kubernetes.io/arch: amd64
+      hostNetwork: true
       priorityClassName: system-node-critical
       tolerations:
         - operator: Exists

--- a/helm/templates/daemonset.yaml
+++ b/helm/templates/daemonset.yaml
@@ -22,6 +22,7 @@ spec:
     spec:
       nodeSelector:
         beta.kubernetes.io/os: linux
+      hostNetwork: true
       priorityClassName: system-node-critical
       tolerations:
         - operator: Exists


### PR DESCRIPTION
**Is this a bug fix or adding new feature?** bug fix

**What is this PR about? / Why do we need it?**
1. On some kubernetes installations (openshift) AWS metadata is not reachable from pod network. (Ideally the driver would not need to retrieve AWS metadata at all, but right now it sets node identity to instance ID and it needs to get that from metadata).
2. There is a bug described here https://github.com/kubernetes-sigs/aws-efs-csi-driver/pull/187 where restarting the driver causes mounts to hang. I *think* there is a way to get around it while keeping hostNetwork false, but it's probably not worth investigating at the moment.

**What testing is done?** 
I would expect the test added by https://github.com/kubernetes-sigs/aws-efs-csi-driver/pull/187 to pass after this change.