### PR TITLE
Fix TestNodeUnpublishVolume

### DIFF
--- a/pkg/driver/node_test.go
+++ b/pkg/driver/node_test.go
@@ -448,6 +448,7 @@ func TestNodeUnpublishVolume(t *testing.T) {
 				if err != nil {
 					t.Fatalf("NodeUnpublishVolume is failed: %v", err)
 				}
+				mockCtrl.Finish()
 			},
 		},
 		{
@@ -474,6 +475,7 @@ func TestNodeUnpublishVolume(t *testing.T) {
 				if err != nil {
 					t.Fatalf("NodeUnpublishVolume is failed: %v", err)
 				}
+				mockCtrl.Finish()
 			},
 		},
 		{
@@ -496,6 +498,7 @@ func TestNodeUnpublishVolume(t *testing.T) {
 				if err == nil {
 					t.Fatalf("NodeUnpublishVolume is not failed")
 				}
+				mockCtrl.Finish()
 			},
 		},
 		{
@@ -523,6 +526,7 @@ func TestNodeUnpublishVolume(t *testing.T) {
 				if err == nil {
 					t.Fatalf("NodeUnpublishVolume is not failed")
 				}
+				mockCtrl.Finish()
 			},
 		},
 		{
@@ -550,6 +554,7 @@ func TestNodeUnpublishVolume(t *testing.T) {
 				if err == nil {
 					t.Fatalf("NodeUnpublishVolume is not failed")
 				}
+				mockCtrl.Finish()
 			},
 		},
 	}

--- a/pkg/driver/node_test.go
+++ b/pkg/driver/node_test.go
@@ -469,7 +469,6 @@ func TestNodeUnpublishVolume(t *testing.T) {
 				}
 
 				mockMounter.EXPECT().GetDeviceName(gomock.Eq(targetPath)).Return("", 0, nil)
-				mockMounter.EXPECT().Unmount(gomock.Eq(targetPath)).Return(nil)
 
 				_, err := driver.NodeUnpublishVolume(ctx, req)
 				if err != nil {
@@ -546,9 +545,8 @@ func TestNodeUnpublishVolume(t *testing.T) {
 					TargetPath: targetPath,
 				}
 
-				mounterErr := fmt.Errorf("Unmount failed")
-				mockMounter.EXPECT().GetDeviceName(gomock.Eq(targetPath)).Return("", 1, mounterErr)
-				mockMounter.EXPECT().Unmount(gomock.Eq(targetPath)).Return(nil)
+				gdnErr := fmt.Errorf("GetDeviceName failed")
+				mockMounter.EXPECT().GetDeviceName(gomock.Eq(targetPath)).Return("", 1, gdnErr)
 
 				_, err := driver.NodeUnpublishVolume(ctx, req)
 				if err == nil {


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

Exposes a bug

**What is this PR about? / Why do we need it?**

Turns out a couple of these tests were broken because the finisher
wasn't being called on the mock controller. When the finisher is added:

```
[efried@efried aws-efs-csi-driver]$ go test ./pkg/driver -run TestNodeUnpublishVolume
--- FAIL: TestNodeUnpublishVolume (0.00s)
    --- FAIL: TestNodeUnpublishVolume/success:_unpublish_with_already_unmounted_target (0.00s)
        node_test.go:478: missing call(s) to *mocks.MockMounter.Unmount(is equal to /target/path) /home/efried/go/src/github.com/kubernetes-sigs/aws-efs-csi-driver/pkg/driver/node_test.go:472
        node_test.go:478: aborting test due to missing call(s)
    --- FAIL: TestNodeUnpublishVolume/fail:_mounter_failed_to_GetDeviceName (0.00s)
        node_test.go:557: missing call(s) to *mocks.MockMounter.Unmount(is equal to /target/path) /home/efried/go/src/github.com/kubernetes-sigs/aws-efs-csi-driver/pkg/driver/node_test.go:551
        node_test.go:557: aborting test due to missing call(s)
FAIL
coverage: 7.9% of statements
FAIL	github.com/kubernetes-sigs/aws-efs-csi-driver/pkg/driver	0.005s
FAIL
```

Fix.

**What testing is done?** 

This *is* testing :P