### PR TITLE
fix (helm): honor imagePullPolicy setting

### DIFF
--- a/deploy/kubernetes/base/node.yaml
+++ b/deploy/kubernetes/base/node.yaml
@@ -25,7 +25,8 @@ spec:
         - name: efs-plugin
           securityContext:
             privileged: true
-          image: amazon/aws-efs-csi-driver:latest
+          image: amazon/aws-efs-csi-driver:v0.3.0
+          imagePullPolicy: IfNotPresent
           args:
             - --endpoint=$(CSI_ENDPOINT)
             - --logtostderr
@@ -57,6 +58,7 @@ spec:
             failureThreshold: 5
         - name: csi-driver-registrar
           image: quay.io/k8scsi/csi-node-driver-registrar:v1.3.0
+          imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)
             - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
@@ -77,6 +79,7 @@ spec:
               mountPath: /registration
         - name: liveness-probe
           image: quay.io/k8scsi/livenessprobe:v2.0.0
+          imagePullPolicy: IfNotPresent
           args:
             - --csi-address=/csi/csi.sock
             - --health-port=9809

--- a/deploy/kubernetes/overlays/stable/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/kustomization.yaml
@@ -2,11 +2,3 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 bases:
 - ../../base
-images:
-- name: amazon/aws-efs-csi-driver
-  newTag: v0.3.0
-- name: quay.io/k8scsi/livenessprobe
-  newTag: v2.0.0
-- name: quay.io/k8scsi/csi-node-driver-registrar
-  newTag: v1.3.0
-

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.3.0"
 name: aws-efs-csi-driver
 description: A Helm chart for AWS EFS CSI Driver
-version: 0.1.0
+version: 0.2.0
 kubeVersion: ">=1.14.0-0"
 home: https://github.com/kubernetes-sigs/aws-efs-csi-driver
 sources:

--- a/helm/templates/daemonset.yaml
+++ b/helm/templates/daemonset.yaml
@@ -33,7 +33,8 @@ spec:
         - name: efs-plugin
           securityContext:
             privileged: true
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: {{ printf "%s:%s" .Values.image.repository .Values.image.tag }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - --endpoint=$(CSI_ENDPOINT)
             - --logtostderr
@@ -65,6 +66,7 @@ spec:
             failureThreshold: 5
         - name: cs-driver-registrar
           image: {{ printf "%s:%s" .Values.sidecars.nodeDriverRegistrarImage.repository .Values.sidecars.nodeDriverRegistrarImage.tag }}
+          imagePullPolicy: {{ .Values.sidecars.nodeDriverRegistrarImage.pullPolicy }}
           args:
             - --csi-address=$(ADDRESS)
             - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
@@ -85,6 +87,7 @@ spec:
               mountPath: /registration
         - name: liveness-probe
           image: {{ printf "%s:%s" .Values.sidecars.livenessProbeImage.repository .Values.sidecars.livenessProbeImage.tag }}
+          imagePullPolicy: {{ .Values.sidecars.livenessProbeImage.pullPolicy }}
           args:
             - --csi-address=/csi/csi.sock
             - --health-port=9809

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -13,9 +13,11 @@ sidecars:
   livenessProbeImage:
     repository: quay.io/k8scsi/livenessprobe
     tag: "v2.0.0"
+    pullPolicy: IfNotPresent
   nodeDriverRegistrarImage:
     repository: quay.io/k8scsi/csi-node-driver-registrar
     tag: "v1.3.0"
+    pullPolicy: IfNotPresent
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

bug fix, see #192 

**What is this PR about? / Why do we need it?**

_what is this PR?_

This change does the following:

 * (bug fix) `image.pullPolicy` is threaded to the `efs-plugin` container
 * (feature) added `pullPolicy` to the side car containers and threaded them through to their containers in the DaemonSet
 * (refactor) standardized on `print "%s:%s"` for generating image:tag in the DaemonSet template.

_why do we need it?_

The community of users of this chart have started to recommend the use of the `:latest` docker image. See #192. However if you specify `image.tag: "latest"` when using helm you are locked in at the version of `:latest` at the time of installation. Kubernetes provides the `imagePullPolicy` setting to work around this - but the helm chart prior to this change does not honor that value. This change will allow users of the helm chart to use `:latest` and get the desired outcome. It also adds the same `pullPolicy` options to the side car containers.

**What testing is done?** 

I've run this successfully on our production cluster. The salient work here is merely updating the helm chart to honor values in `helm/values.yaml` so the main test is that changing `pullPolicy` reflects the correct value in kubernetes.