### PR TITLE
added helm repo yaml in docs folder

### DIFF
--- a/docs/index.yaml
+++ b/docs/index.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+entries:
+  aws-efs-csi-driver:
+  - apiVersion: v1
+    appVersion: 0.3.0
+    created: "2020-06-23T13:01:01.395061-06:00"
+    description: A Helm chart for AWS EFS CSI Driver
+    digest: ed4053dbbaf12daa002845031ba774a6a302e2b94e4bece4a46fb8cb4abe4f23
+    home: https://github.com/kubernetes-sigs/aws-efs-csi-driver
+    keywords:
+    - aws
+    - efs
+    - csi
+    kubeVersion: '>=1.14.0-0'
+    maintainers:
+    - name: leakingtapan
+    name: aws-efs-csi-driver
+    sources:
+    - https://github.com/kubernetes-sigs/aws-efs-csi-driver
+    urls:
+    - https://github.com/kubernetes-sigs/aws-efs-csi-driver/releases/download/v0.3.0/helm-chart.tgz
+    version: 0.1.0
+generated: "2020-06-23T13:01:01.394341-06:00"


### PR DESCRIPTION
This will allow helm to add the public docs of this git repo as a helm
repo. The helm tar packages are actually stored in git releases still.

**Is this a bug fix or adding new feature?**
A new feature as this repo did not have a public helm repo and required installing the charts tar.gz directly. 

**What is this PR about? / Why do we need it?**
Not all ways of using helm will allow you to install a chart from a url. Installing charts from a repo always works. For example if you are using FluxCD Helm Operator or AWS CDK, they do not support installing from url directly without a specific repo. . . as far as I know. 

**What testing is done?** 
I have done this before. I can't directly test this repo until the docs folder is made public. 

As long as the docs folder is public on Github Pages then the following command would work:
```sh
helm repo add aws-efs https://kubernetes-sigs.github.io/aws-efs-csi-driver
helm upgrade -i aws-efs-csi-driver aws-efs/aws-efs-csi-driver --namespace kube-system
```

I made this exact repo available on my account to test out. 
Add the repo
```sh
helm repo add aws-efs https://kferrone.github.io/aws-efs-csi-driver
```
Search the repo:
```sh
helm search repo aws-efs
```
which should display:
```
NAME                            CHART VERSION   APP VERSION     DESCRIPTION                        
aws-efs/aws-efs-csi-driver      0.1.0           0.3.0           A Helm chart for AWS EFS CSI Driver
```
Now try a pull and see the download:
```sh
helm pull aws-efs/aws-efs-csi-driver
```

Fixes: #146 
