### PR TITLE
Update dev overlay to correctly set imagePullPolicy

### DIFF
--- a/deploy/kubernetes/overlays/dev/kustomization.yaml
+++ b/deploy/kubernetes/overlays/dev/kustomization.yaml
@@ -2,7 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 bases:
 - ../../base
-images:
-- name: amazon/aws-efs-csi-driver
-  newTag: latest
-  newName: chengpan/aws-efs-csi-driver
+patchesStrategicMerge:
+- latest_image.yaml

--- a/deploy/kubernetes/overlays/dev/latest_image.yaml
+++ b/deploy/kubernetes/overlays/dev/latest_image.yaml
@@ -1,0 +1,12 @@
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: efs-csi-node
+  namespace: kube-system
+spec:
+  template:
+    spec:
+      containers:
+        - name: efs-plugin
+          image: amazon/aws-efs-csi-driver:latest
+          imagePullPolicy: Always


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

bug fix, see #192, related to #193 

**What is this PR about? / Why do we need it?**

_what is this about?_

As per #193 this implements the same change w.r.t setting imagePullPolicy for the dev overlay.

_why do we need it?_

Kubernetes defaulting to an imagePullPolicy is sane, but for users expecting `:latest` to deliver the _actual_ `:latest` container it can be confusing. For users installing `development` they'll now get the correct image and have an updated `imagePullPolicy`.

**What testing is done?** 

There are a handful of ways this can be run:

 1. `kustomize build deploy/kubernetes/overlay/dev | kubectl apply -f`
 2. `kubectl kustomize deploy/kubernetes/overlay/dev | kubectl apply -f` (variant of 1)
 3. `kubectl apply -k deploy/kubernetes/overlay/dev`

I have tested that all three produce the same output without actually applying them to my cluster; as per #193 I use helm. I'm doing this to help out the situation reported in #192 in which @nmtulloch27 has been very helpful in testing and reporting errors.