### PR TITLE
Revert "Persisted private key genereated by efs-util to host"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,15 @@ RUN make aws-efs-csi-driver
 FROM amazonlinux:2.0.20200406.0
 RUN yum install util-linux-2.30.2-2.amzn2.0.4.x86_64 amazon-efs-utils-1.24-4.amzn2.noarch -y
 
+# Default client source is k8s which can be overriden with –build-arg when building the Docker image
+ARG client_source=k8s
+RUN echo "client_source:${client_source}"
+RUN printf "\n\
+\n\
+[client-info] \n\
+source=${client_source} \n\
+" >> /etc/amazon/efs/efs-utils.conf
+
 COPY --from=builder /go/src/github.com/kubernetes-sigs/aws-efs-csi-driver/bin/aws-efs-csi-driver /bin/aws-efs-csi-driver
 COPY THIRD-PARTY /
 

--- a/Makefile
+++ b/Makefile
@@ -18,11 +18,7 @@ IMAGE?=amazon/aws-efs-csi-driver
 VERSION=v0.4.0-dirty
 GIT_COMMIT?=$(shell git rev-parse HEAD)
 BUILD_DATE?=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
-EFS_CLIENT_SOURCE?=k8s
-LDFLAGS?="-X ${PKG}/pkg/driver.driverVersion=${VERSION} \
-		  -X ${PKG}/pkg/driver.gitCommit=${GIT_COMMIT} \
-		  -X ${PKG}/pkg/driver.buildDate=${BUILD_DATE} \
-		  -X ${PKG}/pkg/driver.efsClientSource=${EFS_CLIENT_SOURCE}"
+LDFLAGS?="-X ${PKG}/pkg/driver.driverVersion=${VERSION} -X ${PKG}/pkg/driver.gitCommit=${GIT_COMMIT} -X ${PKG}/pkg/driver.buildDate=${BUILD_DATE}"
 GO111MODULE=on
 GOPROXY=direct
 GOPATH=$(shell go env GOPATH)
@@ -33,13 +29,6 @@ GOPATH=$(shell go env GOPATH)
 aws-efs-csi-driver:
 	mkdir -p bin
 	CGO_ENABLED=0 GOOS=linux go build -ldflags ${LDFLAGS} -o bin/aws-efs-csi-driver ./cmd/
-
-build-darwin:
-	mkdir -p bin/darwin/
-	CGO_ENABLED=0 GOOS=darwin go build -ldflags ${LDFLAGS} -o bin/darwin/aws-efs-csi-driver ./cmd/
-
-run-darwin: build-darwin
-	bin/darwin/aws-efs-csi-driver --version
 
 .PHONY: verify
 verify:

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -27,9 +27,8 @@ import (
 
 func main() {
 	var (
-		endpoint        = flag.String("endpoint", "unix://tmp/csi.sock", "CSI Endpoint")
-		version         = flag.Bool("version", false, "Print the version and exit")
-		efsUtilsCfgPath = flag.String("efs-utils-config-path", "/etc/amazon/efs/efs-utils.conf", "The path to efs-utils config")
+		endpoint = flag.String("endpoint", "unix://tmp/csi.sock", "CSI Endpoint")
+		version  = flag.Bool("version", false, "Print the version and exit")
 	)
 	klog.InitFlags(nil)
 	flag.Parse()
@@ -43,7 +42,7 @@ func main() {
 		os.Exit(0)
 	}
 
-	drv := driver.NewDriver(*endpoint, *efsUtilsCfgPath)
+	drv := driver.NewDriver(*endpoint)
 	if err := drv.Run(); err != nil {
 		klog.Fatalln(err)
 	}

--- a/deploy/kubernetes/base/node.yaml
+++ b/deploy/kubernetes/base/node.yaml
@@ -41,8 +41,6 @@ spec:
               mountPath: /csi
             - name: efs-state-dir
               mountPath: /var/run/efs
-            - name: efs-utils-config
-              mountPath: /etc/amazon/efs
           ports:
             - containerPort: 9809
               name: healthz
@@ -100,8 +98,5 @@ spec:
           hostPath:
             path: /var/run/efs
             type: DirectoryOrCreate
-        - name: efs-utils-config
-          hostPath:
-            path: /etc/amazon/efs
-            type: DirectoryOrCreate
+
 

--- a/helm/templates/daemonset.yaml
+++ b/helm/templates/daemonset.yaml
@@ -49,8 +49,6 @@ spec:
               mountPath: /csi
             - name: efs-state-dir
               mountPath: /var/run/efs
-            - name: efs-utils-config
-              mountPath: /etc/amazon/efs
           ports:
             - name: healthz
               containerPort: 9809
@@ -61,7 +59,7 @@ spec:
               port: healthz
             initialDelaySeconds: 10
             timeoutSeconds: 3
-            periodSeconds: 2
+            periodSeconds: 2 
             failureThreshold: 5
         - name: cs-driver-registrar
           image: {{ printf "%s:%s" .Values.sidecars.nodeDriverRegistrarImage.repository .Values.sidecars.nodeDriverRegistrarImage.tag }}
@@ -107,8 +105,4 @@ spec:
         - name: efs-state-dir
           hostPath:
             path: /var/run/efs
-            type: DirectoryOrCreate
-        - name: efs-utils-config
-          hostPath:
-            path: /etc/amazon/efs
             type: DirectoryOrCreate

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -21,11 +21,10 @@ import (
 	"net"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
-	"google.golang.org/grpc"
-	"k8s.io/klog"
-
 	"github.com/kubernetes-sigs/aws-efs-csi-driver/pkg/cloud"
 	"github.com/kubernetes-sigs/aws-efs-csi-driver/pkg/util"
+	"google.golang.org/grpc"
+	"k8s.io/klog"
 )
 
 const (
@@ -43,13 +42,13 @@ type Driver struct {
 	efsWatchdog Watchdog
 }
 
-func NewDriver(endpoint, efsUtilsCfgPath string) *Driver {
+func NewDriver(endpoint string) *Driver {
 	cloud, err := cloud.NewCloud()
 	if err != nil {
 		klog.Fatalln(err)
 	}
 
-	watchdog := newExecWatchdog(efsUtilsCfgPath, "amazon-efs-mount-watchdog")
+	watchdog := newExecWatchdog("amazon-efs-mount-watchdog")
 	return &Driver{
 		endpoint:    endpoint,
 		nodeID:      cloud.GetMetadata().GetInstanceID(),
@@ -85,9 +84,7 @@ func (d *Driver) Run() error {
 	csi.RegisterNodeServer(d.srv, d)
 
 	klog.Info("Starting watchdog")
-	if err := d.efsWatchdog.start(); err != nil {
-		return err
-	}
+	d.efsWatchdog.start()
 
 	reaper := newReaper()
 	klog.Info("Staring subreaper")

--- a/pkg/driver/efs_watch_dog.go
+++ b/pkg/driver/efs_watch_dog.go
@@ -15,72 +15,16 @@ package driver
 
 import (
 	"fmt"
-	"os"
 	"os/exec"
 	"sync"
-	"text/template"
 
 	"k8s.io/klog"
 )
 
-// https://github.com/aws/efs-utils/blob/master/dist/efs-utils.conf
-const efsUtilsConfigTemplate = `
-[DEFAULT]
-logging_level = INFO
-logging_max_bytes = 1048576
-logging_file_count = 10
-# mode for /var/run/efs and subdirectories in octal
-state_file_dir_mode = 750
-
-[mount]
-dns_name_format = {fs_id}.efs.{region}.{dns_name_suffix}
-dns_name_suffix = amazonaws.com
-#The region of the file system when mounting from on-premises or cross region.
-#region = us-east-1
-stunnel_debug_enabled = true
-#Uncomment the below option to save all stunnel logs for a file system to the same file
-stunnel_logs_file = /var/log/amazon/efs/{fs_id}.stunnel.log
-# RootCA on AmazonLinux2/CentOS. https://golang.org/src/crypto/x509/root_linux.go
-stunnel_cafile = /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
-
-# Validate the certificate hostname on mount. This option is not supported by certain stunnel versions.
-stunnel_check_cert_hostname = true
-
-# Use OCSP to check certificate validity. This option is not supported by certain stunnel versions.
-stunnel_check_cert_validity = false
-
-# Define the port range that the TLS tunnel will choose from
-port_range_lower_bound = 20049
-port_range_upper_bound = 20449
-
-[mount.cn-north-1]
-dns_name_suffix = amazonaws.com.cn
-
-[mount.cn-northwest-1]
-dns_name_suffix = amazonaws.com.cn
-
-[mount.us-iso-east-1]
-dns_name_suffix = c2s.ic.gov
-
-[mount.us-isob-east-1]
-dns_name_suffix = sc2s.sgov.gov
-
-[mount-watchdog]
-enabled = true
-poll_interval_sec = 1
-unmount_grace_period_sec = 30
-
-# Set client auth/access point certificate renewal rate. Minimum value is 1 minute.
-tls_cert_renewal_interval_min = 60
-
-[client-info] 
-source={{.EfsClientSource}}
-`
-
 // Watchdog defines the interface for process monitoring and supervising
 type Watchdog interface {
 	// start starts the watch dog along with the process
-	start() error
+	start()
 
 	// stop stops the watch dog along with the process
 	stop()
@@ -95,49 +39,22 @@ type execWatchdog struct {
 	execArg []string
 	// the cmd that is running
 	cmd *exec.Cmd
-	// efs-utils config file path
-	efsUtilsCfgPath string
 	// stopCh indicates if it should be stopped
 	stopCh chan struct{}
 
 	mu sync.Mutex
 }
 
-type efsUtilsConfig struct {
-	EfsClientSource string
-}
-
-func newExecWatchdog(efsUtilsCfgPath, cmd string, arg ...string) Watchdog {
+func newExecWatchdog(cmd string, arg ...string) Watchdog {
 	return &execWatchdog{
-		efsUtilsCfgPath: efsUtilsCfgPath,
-		execCmd:         cmd,
-		execArg:         arg,
-		stopCh:          make(chan struct{}),
+		execCmd: cmd,
+		execArg: arg,
+		stopCh:  make(chan struct{}),
 	}
 }
 
-func (w *execWatchdog) start() error {
-	if err := w.updateConfig(GetVersion().EfsClientSource); err != nil {
-		return err
-	}
-
+func (w *execWatchdog) start() {
 	go w.runLoop(w.stopCh)
-
-	return nil
-}
-
-func (w *execWatchdog) updateConfig(efsClientSource string) error {
-	efsCfgTemplate := template.Must(template.New("efs-utils-config").Parse(efsUtilsConfigTemplate))
-	f, err := os.Create(w.efsUtilsCfgPath)
-	if err != nil {
-		return fmt.Errorf("cannot create config file %s for efs-utils. Error: %v", w.efsUtilsCfgPath, err)
-	}
-	defer f.Close()
-	efsCfg := efsUtilsConfig{EfsClientSource: efsClientSource}
-	if err = efsCfgTemplate.Execute(f, efsCfg); err != nil {
-		return fmt.Errorf("cannot update config %s for efs-utils. Error: %v", w.efsUtilsCfgPath, err)
-	}
-	return nil
 }
 
 // stop kills the underlying process and stops the watchdog

--- a/pkg/driver/efs_watch_dog_test.go
+++ b/pkg/driver/efs_watch_dog_test.go
@@ -14,107 +14,13 @@ limitations under the License.
 package driver
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 	"time"
 )
 
-const expectedEfsUtilsConfig = `
-[DEFAULT]
-logging_level = INFO
-logging_max_bytes = 1048576
-logging_file_count = 10
-# mode for /var/run/efs and subdirectories in octal
-state_file_dir_mode = 750
-
-[mount]
-dns_name_format = {fs_id}.efs.{region}.{dns_name_suffix}
-dns_name_suffix = amazonaws.com
-#The region of the file system when mounting from on-premises or cross region.
-#region = us-east-1
-stunnel_debug_enabled = true
-#Uncomment the below option to save all stunnel logs for a file system to the same file
-stunnel_logs_file = /var/log/amazon/efs/{fs_id}.stunnel.log
-# RootCA on AmazonLinux2/CentOS. https://golang.org/src/crypto/x509/root_linux.go
-stunnel_cafile = /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
-
-# Validate the certificate hostname on mount. This option is not supported by certain stunnel versions.
-stunnel_check_cert_hostname = true
-
-# Use OCSP to check certificate validity. This option is not supported by certain stunnel versions.
-stunnel_check_cert_validity = false
-
-# Define the port range that the TLS tunnel will choose from
-port_range_lower_bound = 20049
-port_range_upper_bound = 20449
-
-[mount.cn-north-1]
-dns_name_suffix = amazonaws.com.cn
-
-[mount.cn-northwest-1]
-dns_name_suffix = amazonaws.com.cn
-
-[mount.us-iso-east-1]
-dns_name_suffix = c2s.ic.gov
-
-[mount.us-isob-east-1]
-dns_name_suffix = sc2s.sgov.gov
-
-[mount-watchdog]
-enabled = true
-poll_interval_sec = 1
-unmount_grace_period_sec = 30
-
-# Set client auth/access point certificate renewal rate. Minimum value is 1 minute.
-tls_cert_renewal_interval_min = 60
-
-[client-info] 
-source=k8s
-`
-
 func TestExecWatchdog(t *testing.T) {
-	f := createEmptyConfigFile(t)
-	defer os.Remove(f.Name())
-
-	w := newExecWatchdog(f.Name(), "sleep", "300")
-	if err := w.start(); err != nil {
-		t.Fatalf("Failed to start %v", err)
-	}
+	w := newExecWatchdog("sleep", "300")
+	w.start()
 	time.Sleep(time.Second)
 	w.stop()
-}
-
-func createEmptyConfigFile(t *testing.T) *os.File {
-	f, err := ioutil.TempFile("", "")
-	if err != nil {
-		t.Fatalf("couldn't create temp file %v, %v", f, err)
-	}
-	return f
-}
-
-func TestUpdateConfig(t *testing.T) {
-	f := createEmptyConfigFile(t)
-	defer os.Remove(f.Name())
-
-	w := newExecWatchdog(f.Name(), "sleep", "300").(*execWatchdog)
-	efsClient := "k8s"
-	if err := w.updateConfig(efsClient); err != nil {
-		t.Fatalf("Failed to update config file %v, %v", f, err)
-	}
-	bytes, err := ioutil.ReadAll(f)
-	if err != nil {
-		t.Fatalf("Failed to read config file %v, %v", f, err)
-	}
-	actualConfig := string(bytes)
-	if actualConfig != expectedEfsUtilsConfig {
-		t.Errorf("Unexpected efs-utils config content: want %s\nactual:%s", expectedEfsUtilsConfig, actualConfig)
-	}
-}
-
-func TestWrite(t *testing.T) {
-	redirect := newInfoRedirect("info")
-	if _, err := redirect.Write([]byte("abc")); err != nil {
-		t.Errorf("Failed to Write in redirect: %v", err)
-	}
 }

--- a/pkg/driver/sanity_test.go
+++ b/pkg/driver/sanity_test.go
@@ -31,8 +31,7 @@ import (
 type mockWatchdog struct {
 }
 
-func (w *mockWatchdog) start() error {
-	return nil
+func (w *mockWatchdog) start() {
 }
 
 func (w *mockWatchdog) stop() {

--- a/pkg/driver/version.go
+++ b/pkg/driver/version.go
@@ -19,31 +19,28 @@ import (
 )
 
 var (
-	driverVersion   string
-	gitCommit       string
-	buildDate       string
-	efsClientSource string
+	driverVersion string
+	gitCommit     string
+	buildDate     string
 )
 
 type VersionInfo struct {
-	DriverVersion   string `json:"driverVersion"`
-	GitCommit       string `json:"gitCommit"`
-	BuildDate       string `json:"buildDate"`
-	EfsClientSource string `json:"efsClientSource"`
-	GoVersion       string `json:"goVersion"`
-	Compiler        string `json:"compiler"`
-	Platform        string `json:"platform"`
+	DriverVersion string `json:"driverVersion"`
+	GitCommit     string `json:"gitCommit"`
+	BuildDate     string `json:"buildDate"`
+	GoVersion     string `json:"goVersion"`
+	Compiler      string `json:"compiler"`
+	Platform      string `json:"platform"`
 }
 
 func GetVersion() VersionInfo {
 	return VersionInfo{
-		DriverVersion:   driverVersion,
-		GitCommit:       gitCommit,
-		BuildDate:       buildDate,
-		EfsClientSource: efsClientSource,
-		GoVersion:       runtime.Version(),
-		Compiler:        runtime.Compiler,
-		Platform:        fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+		DriverVersion: driverVersion,
+		GitCommit:     gitCommit,
+		BuildDate:     buildDate,
+		GoVersion:     runtime.Version(),
+		Compiler:      runtime.Compiler,
+		Platform:      fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
 	}
 }
 func GetVersionJSON() (string, error) {

--- a/pkg/driver/version_test.go
+++ b/pkg/driver/version_test.go
@@ -23,13 +23,12 @@ func TestGetVersion(t *testing.T) {
 	version := GetVersion()
 
 	expected := VersionInfo{
-		DriverVersion:   "",
-		GitCommit:       "",
-		BuildDate:       "",
-		EfsClientSource: "",
-		GoVersion:       runtime.Version(),
-		Compiler:        runtime.Compiler,
-		Platform:        fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+		DriverVersion: "",
+		GitCommit:     "",
+		BuildDate:     "",
+		GoVersion:     runtime.Version(),
+		Compiler:      runtime.Compiler,
+		Platform:      fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
 	}
 
 	if !reflect.DeepEqual(version, expected) {
@@ -45,7 +44,6 @@ func TestGetVersionJSON(t *testing.T) {
   "driverVersion": "",
   "gitCommit": "",
   "buildDate": "",
-  "efsClientSource": "",
   "goVersion": "%s",
   "compiler": "%s",
   "platform": "%s"


### PR DESCRIPTION
Reverts kubernetes-sigs/aws-efs-csi-driver#179

https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/191

We are still discussing a solution to maintaining *stability* of the *stable* overlay. In meantime, let's revert.