### PR TITLE
Push image to 7 digit git sha tag instead of latest tag for master branch changes

### DIFF
--- a/.github/workflows/container-image.yaml
+++ b/.github/workflows/container-image.yaml
@@ -15,9 +15,10 @@ jobs:
       run: |
         USER=$(echo $GITHUB_REPOSITORY | cut -d'/' -f1)
         BRANCH=$(echo $GITHUB_REF | cut -d'/' -f3)
+        SHORT_SHA=$(echo $GITHUB_SHA | cut -c -7)
         IMAGE=aws-efs-csi-driver
         if [ "$BRANCH" = "master" ]; then
-          TAG="latest"
+          TAG=$SHORT_SHA
         else
           TAG=$BRANCH
         fi
@@ -27,9 +28,10 @@ jobs:
     - name: Push to Dockerhub registry
       run: |
         BRANCH=$(echo $GITHUB_REF | cut -d'/' -f3)
+        SHORT_SHA=$(echo $GITHUB_SHA | cut -c -7)
         REPO=amazon/aws-efs-csi-driver
         if [ "$BRANCH" = "master" ]; then
-          TAG="latest"
+          TAG=$SHORT_SHA
         else
           TAG=$BRANCH
         fi


### PR DESCRIPTION
**Is this a bug fix or adding new feature?** fix

**What is this PR about? / Why do we need it?**

latest tag is dangerous to use. But releases are infrequent. So push git tag releases so users can take advantage of bugfixes immediately instead of having to wait for a release.

We are working on having more frequent releases starting with the next one. Partly there is the manual effort of compiling changelog (though there is a script), testing (though CI is mostly sufficient), and bottleneck (@leakingtapan may not have time to push out a tag every couple weeks and I/others don't have permissions yet).


**What testing is done?** 

TBH I'm not sure how to test the github workflow but I know HORT_SHA=$(echo $GITHUB_SHA | cut -c -7) works and docs say GITHUB_SHA will be available: https://help.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables
