### PR TITLE
Add encryptInTransit volume attribute

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@
 
 ## Amazon EFS CSI Driver
 
-The [Amazon Elastic File System](https://aws.amazon.com/efs/) Container Storage Interface (CSI) Driver implements the [CSI](https://github.com/container-storage-interface/spec/blob/master/spec.md) specification for container orchestrators to manage the lifecycle of Amazon EFS filesystems.
+The [Amazon Elastic File System](https://aws.amazon.com/efs/) Container Storage Interface (CSI) Driver implements the [CSI](https://github.com/container-storage-interface/spec/blob/master/spec.md) specification for container orchestrators to manage the lifecycle of Amazon EFS file systems.
 
 ### CSI Specification Compatibility Matrix
 | AWS EFS CSI Driver \ CSI Spec Version  | v0.3.0| v1.1.0 | v1.2.0 |
@@ -15,7 +15,7 @@ The [Amazon Elastic File System](https://aws.amazon.com/efs/) Container Storage 
 | v0.1.0                                 | yes   | no     | no     |
 
 ## Features
-Currently only static provisioning is supported. This means an AWS EFS filesystem needs to be created manually on AWS first. After that it can be mounted inside a container as a volume using the driver.
+Currently only static provisioning is supported. This means an AWS EFS file system needs to be created manually on AWS first. After that it can be mounted inside a container as a volume using the driver.
 
 The following CSI interfaces are implemented:
 * Node Service: NodePublishVolume, NodeUnpublishVolume, NodeGetCapabilities, NodeGetInfo, NodeGetId
@@ -24,7 +24,7 @@ The following CSI interfaces are implemented:
 ### Encryption In Transit
 One of the advantages of using EFS is that it provides [encryption in transit](https://aws.amazon.com/blogs/aws/new-encryption-of-data-in-transit-for-amazon-efs/) support using TLS. Using encryption in transit, data will be encrypted during its transition over the network to the EFS service. This provides an extra layer of defence-in-depth for applications that requires strict security compliance.
 
-To enable encryption in transit, `tls` needs to be set in the `NodePublishVolumeRequest.VolumeCapability.MountVolume` object's `MountFlags` fields. For an example of using it in kubernetes, see the persistence volume manifest in [Encryption in Transit Example](../examples/kubernetes/encryption_in_transit/specs/pv.yaml)
+Encryption in transit is enabled by default in the master branch version of the driver. To disable it and mount volumes using plain NFSv4, set `volumeAttributes` field `encryptInTransit` to `"false"` in your persistent volume manifest. For an example manifest, see [Encryption in Transit Example](../examples/kubernetes/encryption_in_transit/specs/pv.yaml).
 
 **Note** Kubernetes version 1.13+ is required if you are using this feature in Kubernetes.
 
@@ -48,11 +48,12 @@ The following sections are Kubernetes specific. If you are a Kubernetes user, us
 |v0.1.0                     |amazon/aws-efs-csi-driver:v0.1.0     |
 
 ### Features
-* Static provisioning - EFS filesystem needs to be created manually first, then it could be mounted inside container as a persistent volume (PV) using the driver.
-* Mount Options - Mount options can be specified in the persistence volume (PV) to define how the volume should be mounted. Aside from normal mount options, you can also specify `tls` as a mount option to enable encryption in transit of the EFS filesystem.
+* Static provisioning - EFS file system needs to be created manually first, then it could be mounted inside container as a persistent volume (PV) using the driver.
+* Mount Options - Mount options can be specified in the persistent volume (PV) to define how the volume should be mounted.
+* Encryption of data in transit - EFS file systems are mounted with encryption in transit enabled by default in the master branch version of the driver.
 
 **Notes**:
-* Since EFS is an elastic filesystem it doesn't really enforce any filesystem capacity. The actual storage capacity value in persistence volume and persistence volume claim is not used when creating the filesystem. However, since the storage capacity is a required field by Kubernetes, you must specify the value and you can use any valid value for the capacity.
+* Since EFS is an elastic file system it doesn't really enforce any file system capacity. The actual storage capacity value in persistent volume and persistent volume claim is not used when creating the file system. However, since the storage capacity is a required field by Kubernetes, you must specify the value and you can use any valid value for the capacity.
 
 ### Installation
 Deploy the driver:
@@ -75,14 +76,14 @@ helm install aws-efs-csi-driver aws-efs-csi-driver/aws-efs-csi-driver
 
 ### Examples
 Before the example, you need to:
-* Get yourself familiar with how to setup Kubernetes on AWS and how to [create EFS filesystem](https://docs.aws.amazon.com/efs/latest/ug/getting-started.html).
-* When creating EFS filesystem, make sure it is accessible from Kuberenetes cluster. This can be achieved by creating the filesystem inside the same VPC as Kubernetes cluster or using VPC peering.
+* Get yourself familiar with how to setup Kubernetes on AWS and how to [create EFS file system](https://docs.aws.amazon.com/efs/latest/ug/getting-started.html).
+* When creating EFS file system, make sure it is accessible from Kuberenetes cluster. This can be achieved by creating the file system inside the same VPC as Kubernetes cluster or using VPC peering.
 * Install EFS CSI driver following the [Installation](README.md#Installation) steps.
 
 #### Example links
 * [Static provisioning](../examples/kubernetes/static_provisioning/README.md)
 * [Encryption in transit](../examples/kubernetes/encryption_in_transit/README.md)
-* [Accessing the filesystem from multiple pods](../examples/kubernetes/multiple_pods/README.md)
+* [Accessing the file system from multiple pods](../examples/kubernetes/multiple_pods/README.md)
 * [Consume EFS in StatefulSets](../examples/kubernetes/statefulset/README.md)
 * [Mount subpath](../examples/kubernetes/volume_path/README.md)
 * [Use Access Points](../examples/kubernetes/access_points/README.md)

--- a/examples/kubernetes/encryption_in_transit/README.md
+++ b/examples/kubernetes/encryption_in_transit/README.md
@@ -1,7 +1,7 @@
 ## Encryption in Transit
-This example shows how to make a static provisioned EFS persistence volume (PV) mounted inside container with encryption in transit enabled.
+This example shows how to make a static provisioned EFS persistent volume (PV) mounted inside container with encryption in transit configured.
 
-**Note**: this example requires Kubernetes v1.13+
+**Note**: this example requires Kubernetes v1.13+ and driver version > 0.3. For driver versions <= 0.3, encryption in transit is enabled (or disabled) by adding (or omitting) mountOption "tls" to (or from) a PV.
 
 ### Edit [Persistence Volume Spec](./specs/pv.yaml) 
 
@@ -18,13 +18,13 @@ spec:
     - ReadWriteOnce
   persistentVolumeReclaimPolicy: Retain
   storageClassName: efs-sc
-  mountOptions:
-    - tls
   csi:
     driver: efs.csi.aws.com
     volumeHandle: [FileSystemId] 
+    volumeAttributes:
+      encryptInTransit: "true"
 ```
-Note that encryption in transit is enabled using mount option `tls`. Replace `VolumeHandle` value with `FileSystemId` of the EFS filesystem that needs to be mounted.
+Note that encryption in transit is configured using volume attribute `encryptInTransit`. By default, encryption in transit is enabled and there is no need to set `encryptInTransit` true. Replace `VolumeHandle` value with `FileSystemId` of the EFS filesystem that needs to be mounted.
 
 You can find it using AWS CLI:
 ```sh
@@ -32,7 +32,7 @@ You can find it using AWS CLI:
 ```
 
 ### Deploy the Example
-Create PV, persistence volume claim (PVC) and storage class:
+Create PV, persistent volume claim (PVC) and storage class:
 ```sh
 >> kubectl apply -f examples/kubernetes/encryption_in_transit/specs/storageclass.yaml
 >> kubectl apply -f examples/kubernetes/encryption_in_transit/specs/pv.yaml

--- a/examples/kubernetes/encryption_in_transit/README.md
+++ b/examples/kubernetes/encryption_in_transit/README.md
@@ -24,7 +24,14 @@ spec:
     volumeAttributes:
       encryptInTransit: "true"
 ```
-Note that encryption in transit is configured using volume attribute `encryptInTransit`. By default, encryption in transit is enabled and there is no need to set `encryptInTransit` true. Replace `VolumeHandle` value with `FileSystemId` of the EFS filesystem that needs to be mounted.
+Replace `VolumeHandle` value with `FileSystemId` of the EFS filesystem that
+needs to be mounted. The following table illustrates how the setting of
+`encryptInTransit` determines whether encryption in transit is enabled or not:
+
+|  | encryptInTransit is unset | encryptInTransit is true | encryptInTransit is false |
+| ------------- | ------------- | ------------- | ------------- |
+| "tls" is in mountOptions  | encryption + deprecation warning  | encryption + deprecation warning | error |
+| "tls" isn't in mountOptions | encryption  | encryption | NO encryption |
 
 You can find it using AWS CLI:
 ```sh

--- a/examples/kubernetes/encryption_in_transit/specs/pv.yaml
+++ b/examples/kubernetes/encryption_in_transit/specs/pv.yaml
@@ -10,8 +10,8 @@ spec:
     - ReadWriteOnce
   persistentVolumeReclaimPolicy: Retain
   storageClassName: efs-sc
-  mountOptions:
-    - tls
   csi:
     driver: efs.csi.aws.com
     volumeHandle: fs-4af69aab
+    volumeAttributes:
+      encryptInTransit: "true"

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -150,8 +150,8 @@ func (d *Driver) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolu
 
 			if f == "tls" {
 				klog.Warning(
-					"Use of 'tls' under mountOptions is deprecated with this driver. " +
-						"Set encrypt in transit in the volumeContext instead, e.g. 'encryptInTransit: true'")
+					"Use of 'tls' under mountOptions is deprecated with this driver since tls is enabled by default. " +
+						"To disable it, set encrypt in transit in the volumeContext, e.g. 'encryptInTransit: true'")
 				// If they set tls and encryptInTransit is true, let it slide; otherwise, fail.
 				if !encryptInTransit {
 					return nil, status.Errorf(codes.InvalidArgument,

--- a/pkg/driver/node_test.go
+++ b/pkg/driver/node_test.go
@@ -104,7 +104,7 @@ func TestNodePublishVolume(t *testing.T) {
 				TargetPath:       targetPath,
 			},
 			expectMakeDir: true,
-			mountArgs:     []interface{}{volumeId + ":/", targetPath, "efs", gomock.Any()},
+			mountArgs:     []interface{}{volumeId + ":/", targetPath, "efs", []string{"tls"}},
 			mountSuccess:  true,
 		},
 		{
@@ -115,7 +115,7 @@ func TestNodePublishVolume(t *testing.T) {
 				TargetPath:       targetPath,
 			},
 			expectMakeDir: true,
-			mountArgs:     []interface{}{volumeId + ":/", targetPath, "efs", gomock.Any()},
+			mountArgs:     []interface{}{volumeId + ":/", targetPath, "efs", []string{"tls"}},
 			mountSuccess:  true,
 		},
 		{
@@ -126,7 +126,7 @@ func TestNodePublishVolume(t *testing.T) {
 				TargetPath:       targetPath,
 			},
 			expectMakeDir: true,
-			mountArgs:     []interface{}{volumeId + ":/", targetPath, "efs", gomock.Any()},
+			mountArgs:     []interface{}{volumeId + ":/", targetPath, "efs", []string{"tls"}},
 			mountSuccess:  true,
 		},
 		{
@@ -138,7 +138,7 @@ func TestNodePublishVolume(t *testing.T) {
 				Readonly:         true,
 			},
 			expectMakeDir: true,
-			mountArgs:     []interface{}{volumeId + ":/", targetPath, "efs", []string{"ro"}},
+			mountArgs:     []interface{}{volumeId + ":/", targetPath, "efs", []string{"tls", "ro"}},
 			mountSuccess:  true,
 		},
 		{
@@ -171,7 +171,7 @@ func TestNodePublishVolume(t *testing.T) {
 				VolumeContext:    map[string]string{"path": "/a/b"},
 			},
 			expectMakeDir: true,
-			mountArgs:     []interface{}{volumeId + ":/a/b", targetPath, "efs", gomock.Any()},
+			mountArgs:     []interface{}{volumeId + ":/a/b", targetPath, "efs", []string{"tls"}},
 			mountSuccess:  true,
 		},
 		{
@@ -197,7 +197,7 @@ func TestNodePublishVolume(t *testing.T) {
 				TargetPath:       targetPath,
 			},
 			expectMakeDir: true,
-			mountArgs:     []interface{}{volumeId + ":/a/b", targetPath, "efs", gomock.Any()},
+			mountArgs:     []interface{}{volumeId + ":/a/b", targetPath, "efs", []string{"tls"}},
 			mountSuccess:  true,
 		},
 		{
@@ -209,7 +209,7 @@ func TestNodePublishVolume(t *testing.T) {
 				TargetPath:       targetPath,
 			},
 			expectMakeDir: true,
-			mountArgs:     []interface{}{volumeId + ":a/b", targetPath, "efs", gomock.Any()},
+			mountArgs:     []interface{}{volumeId + ":a/b", targetPath, "efs", []string{"tls"}},
 			mountSuccess:  true,
 		},
 		{
@@ -221,7 +221,7 @@ func TestNodePublishVolume(t *testing.T) {
 				VolumeContext:    map[string]string{"path": "/c/d"},
 			},
 			expectMakeDir: true,
-			mountArgs:     []interface{}{volumeId + ":/a/b", targetPath, "efs", gomock.Any()},
+			mountArgs:     []interface{}{volumeId + ":/a/b", targetPath, "efs", []string{"tls"}},
 			mountSuccess:  true,
 		},
 		{
@@ -266,6 +266,30 @@ func TestNodePublishVolume(t *testing.T) {
 			},
 			expectMakeDir: true,
 			mountArgs:     []interface{}{volumeId + ":/", targetPath, "efs", []string{"accesspoint=" + accessPointID, "tls"}},
+			mountSuccess:  true,
+		},
+		{
+			name: "success: normal with encryptInTransit true volume context",
+			req: &csi.NodePublishVolumeRequest{
+				VolumeId:         volumeId,
+				VolumeCapability: stdVolCap,
+				TargetPath:       targetPath,
+				VolumeContext:    map[string]string{"encryptInTransit": "true"},
+			},
+			expectMakeDir: true,
+			mountArgs:     []interface{}{volumeId + ":/", targetPath, "efs", []string{"tls"}},
+			mountSuccess:  true,
+		},
+		{
+			name: "success: normal with encryptInTransit false volume context",
+			req: &csi.NodePublishVolumeRequest{
+				VolumeId:         volumeId,
+				VolumeCapability: stdVolCap,
+				TargetPath:       targetPath,
+				VolumeContext:    map[string]string{"encryptInTransit": "false"},
+			},
+			expectMakeDir: true,
+			mountArgs:     []interface{}{volumeId + ":/", targetPath, "efs", []string{}},
 			mountSuccess:  true,
 		},
 		{
@@ -389,7 +413,7 @@ func TestNodePublishVolume(t *testing.T) {
 				TargetPath:       targetPath,
 			},
 			expectMakeDir: true,
-			mountArgs:     []interface{}{volumeId + ":/", targetPath, "efs", gomock.Any()},
+			mountArgs:     []interface{}{volumeId + ":/", targetPath, "efs", []string{"tls"}},
 			mountSuccess:  false,
 			expectError: errtyp{
 				code:    "Internal",

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -279,7 +279,8 @@ var _ = ginkgo.Describe("[efs-csi] EFS CSI", func() {
 			// to mount.efs is the server is 127.0.0.1
 			// (stunnel proxy running on localhost)
 			// instead of the EFS DNS name
-			// (file-system-id.efs.aws-region.amazonaws.com)
+			// (file-system-id.efs.aws-region.amazonaws.com).
+			// Call `mount` alone first to print it for debugging.
 			command := "mount && mount | grep /mnt/volume1 | grep 127.0.0.1"
 			if encryptInTransit != nil {
 				if !*encryptInTransit {

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -184,7 +184,7 @@ var _ = ginkgo.Describe("[efs-csi] EFS CSI", func() {
 	ginkgo.Context(testsuites.GetDriverNameWithFeatureTags(driver), func() {
 		ginkgo.It("should mount different paths on same volume on same node", func() {
 			ginkgo.By(fmt.Sprintf("Creating efs pvc & pv with no subpath"))
-			pvcRoot, pvRoot, err := createEFSPVCPV(f.ClientSet, f.Namespace.Name, f.Namespace.Name+"-root", "/")
+			pvcRoot, pvRoot, err := createEFSPVCPV(f.ClientSet, f.Namespace.Name, f.Namespace.Name+"-root", "/", map[string]string{})
 			framework.ExpectNoError(err, "creating efs pvc & pv with no subpath")
 			defer func() { _ = f.ClientSet.CoreV1().PersistentVolumes().Delete(pvRoot.Name, &metav1.DeleteOptions{}) }()
 
@@ -195,12 +195,12 @@ var _ = ginkgo.Describe("[efs-csi] EFS CSI", func() {
 			framework.ExpectNoError(e2epod.WaitForPodSuccessInNamespace(f.ClientSet, pod.Name, f.Namespace.Name), "waiting for pod success")
 
 			ginkgo.By(fmt.Sprintf("Creating efs pvc & pv with subpath /a"))
-			pvcA, pvA, err := createEFSPVCPV(f.ClientSet, f.Namespace.Name, f.Namespace.Name+"-a", "/a")
+			pvcA, pvA, err := createEFSPVCPV(f.ClientSet, f.Namespace.Name, f.Namespace.Name+"-a", "/a", map[string]string{})
 			framework.ExpectNoError(err, "creating efs pvc & pv with subpath /a")
 			defer func() { _ = f.ClientSet.CoreV1().PersistentVolumes().Delete(pvA.Name, &metav1.DeleteOptions{}) }()
 
 			ginkgo.By(fmt.Sprintf("Creating efs pvc & pv with subpath /b"))
-			pvcB, pvB, err := createEFSPVCPV(f.ClientSet, f.Namespace.Name, f.Namespace.Name+"-b", "/b")
+			pvcB, pvB, err := createEFSPVCPV(f.ClientSet, f.Namespace.Name, f.Namespace.Name+"-b", "/b", map[string]string{})
 			framework.ExpectNoError(err, "creating efs pvc & pv with subpath /b")
 			defer func() { _ = f.ClientSet.CoreV1().PersistentVolumes().Delete(pvB.Name, &metav1.DeleteOptions{}) }()
 
@@ -213,7 +213,7 @@ var _ = ginkgo.Describe("[efs-csi] EFS CSI", func() {
 
 		ginkgo.It("should continue reading/writing without hanging after the driver pod is restarted", func() {
 			ginkgo.By(fmt.Sprintf("Creating efs pvc & pv"))
-			pvc, pv, err := createEFSPVCPV(f.ClientSet, f.Namespace.Name, f.Namespace.Name, "")
+			pvc, pv, err := createEFSPVCPV(f.ClientSet, f.Namespace.Name, f.Namespace.Name, "", map[string]string{})
 			framework.ExpectNoError(err, "creating efs pvc & pv")
 			defer func() { _ = f.ClientSet.CoreV1().PersistentVolumes().Delete(pv.Name, &metav1.DeleteOptions{}) }()
 
@@ -258,11 +258,64 @@ var _ = ginkgo.Describe("[efs-csi] EFS CSI", func() {
 				framework.Failf("timed out verifying exec in pod succeeded")
 			}
 		})
+
+		testEncryptInTransit := func(f *framework.Framework, encryptInTransit *bool) {
+			ginkgo.By("Creating efs pvc & pv")
+			volumeAttributes := map[string]string{}
+			if encryptInTransit != nil {
+				if *encryptInTransit {
+					volumeAttributes["encryptInTransit"] = "true"
+				} else {
+					volumeAttributes["encryptInTransit"] = "false"
+				}
+			}
+			pvc, pv, err := createEFSPVCPV(f.ClientSet, f.Namespace.Name, f.Namespace.Name, "/", volumeAttributes)
+			framework.ExpectNoError(err, "creating efs pvc & pv with no subpath")
+			defer func() { _ = f.ClientSet.CoreV1().PersistentVolumes().Delete(pv.Name, &metav1.DeleteOptions{}) }()
+
+			// If mount.efs is passed option tls, the mount table entry should be...
+			// 127.0.0.1:/ on /mnt/volume1 type nfs4 (rw,relatime,vers=4.1,rsize=1048576,wsize=1048576,namlen=255,hard,noresvport,proto=tcp,port=20052,timeo=600,retrans=2,sec=sys,clientaddr=127.0.0.1,local_lock=none,addr=127.0.0.1)
+			// Note the tls option is not actually there. The proof that tls is passed
+			// to mount.efs is the server is 127.0.0.1
+			// (stunnel proxy running on localhost)
+			// instead of the EFS DNS name
+			// (file-system-id.efs.aws-region.amazonaws.com)
+			command := "mount && mount | grep /mnt/volume1 | grep 127.0.0.1"
+			if encryptInTransit != nil {
+				if !*encryptInTransit {
+					command = fmt.Sprintf("mount && mount | grep /mnt/volume1 | grep %v", FileSystemId)
+				}
+			}
+			ginkgo.By(fmt.Sprintf("Creating pod to mount pvc %q and run %q", pvc.Name, command))
+			pod := e2epod.MakePod(f.Namespace.Name, nil, []*v1.PersistentVolumeClaim{pvc}, false, command)
+			pod.Spec.RestartPolicy = v1.RestartPolicyNever
+			pod, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(pod)
+			framework.ExpectNoError(err, "creating pod")
+
+			err = e2epod.WaitForPodSuccessInNamespace(f.ClientSet, pod.Name, f.Namespace.Name)
+			logs, _ := e2epod.GetPodLogs(f.ClientSet, f.Namespace.Name, pod.Name, "write-pod")
+			framework.Logf("pod %q logs:\n %v", pod.Name, logs)
+			framework.ExpectNoError(err, "waiting for pod success")
+		}
+
+		ginkgo.It("should mount with option tls when encryptInTransit unset", func() {
+			testEncryptInTransit(f, nil)
+		})
+
+		ginkgo.It("should mount with option tls when encryptInTransit set true", func() {
+			encryptInTransit := true
+			testEncryptInTransit(f, &encryptInTransit)
+		})
+
+		ginkgo.It("should mount without option tls when encryptInTransit set false", func() {
+			encryptInTransit := false
+			testEncryptInTransit(f, &encryptInTransit)
+		})
 	})
 })
 
-func createEFSPVCPV(c clientset.Interface, namespace, name, path string) (*v1.PersistentVolumeClaim, *v1.PersistentVolume, error) {
-	pvc, pv := makeEFSPVCPV(namespace, name, path)
+func createEFSPVCPV(c clientset.Interface, namespace, name, path string, volumeAttributes map[string]string) (*v1.PersistentVolumeClaim, *v1.PersistentVolume, error) {
+	pvc, pv := makeEFSPVCPV(namespace, name, path, volumeAttributes)
 	pvc, err := c.CoreV1().PersistentVolumeClaims(namespace).Create(pvc)
 	if err != nil {
 		return nil, nil, err
@@ -274,9 +327,9 @@ func createEFSPVCPV(c clientset.Interface, namespace, name, path string) (*v1.Pe
 	return pvc, pv, nil
 }
 
-func makeEFSPVCPV(namespace, name, path string) (*v1.PersistentVolumeClaim, *v1.PersistentVolume) {
+func makeEFSPVCPV(namespace, name, path string, volumeAttributes map[string]string) (*v1.PersistentVolumeClaim, *v1.PersistentVolume) {
 	pvc := makeEFSPVC(namespace, name)
-	pv := makeEFSPV(name, path)
+	pv := makeEFSPV(name, path, volumeAttributes)
 	pvc.Spec.VolumeName = pv.Name
 	pv.Spec.ClaimRef = &v1.ObjectReference{
 		Namespace: pvc.Namespace,
@@ -304,7 +357,7 @@ func makeEFSPVC(namespace, name string) *v1.PersistentVolumeClaim {
 	}
 }
 
-func makeEFSPV(name, path string) *v1.PersistentVolume {
+func makeEFSPV(name, path string, volumeAttributes map[string]string) *v1.PersistentVolume {
 	volumeHandle := FileSystemId
 	if path != "" {
 		volumeHandle += ":" + path
@@ -320,8 +373,9 @@ func makeEFSPV(name, path string) *v1.PersistentVolume {
 			},
 			PersistentVolumeSource: v1.PersistentVolumeSource{
 				CSI: &v1.CSIPersistentVolumeSource{
-					Driver:       "efs.csi.aws.com",
-					VolumeHandle: volumeHandle,
+					Driver:           "efs.csi.aws.com",
+					VolumeHandle:     volumeHandle,
+					VolumeAttributes: volumeAttributes,
 				},
 			},
 			AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteMany},


### PR DESCRIPTION
**Is this a bug fix or adding new feature?** new feature

**What is this PR about? / Why do we need it?** We would like encryption of data in transit to be the default. Currently, encryption is turned on/off by adding/omitting the "tls" mount option to/from PV spec.mountOptions. With this PR the value of `encryptInTransit` will determine whether encryption in transit is on, i.e. whether the *final* mount.efs command contains the "tls" mount option or not.

Intended behavior:


|  | encryptInTransit is unset | encryptInTransit is true | encryptInTransit is false |
| ------------- | ------------- | ------------- | ------------- |
| "tls" is in mountOptions  | encryption + deprecation warning  | encryption + deprecation warning | error |
| "tls" isn't in mountOptions | encryption  | encryption | NO encryption |


**What testing is done?**  the unit tests I added pass. The e2e tests I added pass on EKS and will be run on kops by PR CI.
