### PR TITLE
Started branching yaml install files

### DIFF
--- a/deploy/k8s/dev/csidriver.yaml
+++ b/deploy/k8s/dev/csidriver.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: storage.k8s.io/v1beta1
+kind: CSIDriver
+metadata:
+  name: efs.csi.aws.com
+spec:
+  attachRequired: false

--- a/deploy/k8s/dev/kustomization.yaml
+++ b/deploy/k8s/dev/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kube-system
+resources:
+- node.yaml
+- csidriver.yaml

--- a/deploy/k8s/dev/node.yaml
+++ b/deploy/k8s/dev/node.yaml
@@ -1,7 +1,5 @@
 ---
-# The `deploy/kubernetes` directory has been deprecated in favor of `deploy/k8s`.
-# New changes won't be made in this folder.
-# `deploy/kubernetes` is subject to removal in a future release.
+# Node Service
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:

--- a/deploy/k8s/v0.3.0/base/csidriver.yaml
+++ b/deploy/k8s/v0.3.0/base/csidriver.yaml
@@ -1,0 +1,8 @@
+---
+
+apiVersion: storage.k8s.io/v1beta1
+kind: CSIDriver
+metadata:
+  name: efs.csi.aws.com
+spec:
+  attachRequired: false

--- a/deploy/k8s/v0.3.0/base/kustomization.yaml
+++ b/deploy/k8s/v0.3.0/base/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kube-system
+resources:
+- node.yaml
+- csidriver.yaml

--- a/deploy/k8s/v0.3.0/base/node.yaml
+++ b/deploy/k8s/v0.3.0/base/node.yaml
@@ -1,7 +1,5 @@
 ---
-# The `deploy/kubernetes` directory has been deprecated in favor of `deploy/k8s`.
-# New changes won't be made in this folder.
-# `deploy/kubernetes` is subject to removal in a future release.
+# Node Service
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:

--- a/deploy/k8s/v0.3.0/overlays/dockerhub/kustomization.yaml
+++ b/deploy/k8s/v0.3.0/overlays/dockerhub/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+- ../../base
+images:
+- name: amazon/aws-efs-csi-driver
+  newTag: v0.3.0
+- name: quay.io/k8scsi/livenessprobe
+  newTag: v1.1.0
+- name: quay.io/k8scsi/csi-node-driver-registrar
+  newTag: v1.1.0
+

--- a/deploy/k8s/v0.3.0/overlays/ecr/kustomization.yaml
+++ b/deploy/k8s/v0.3.0/overlays/ecr/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+- ../../base
+images:
+- name: amazon/aws-efs-csi-driver
+  newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/aws-efs-csi-driver
+  newTag: v0.3.0
+- name: quay.io/k8scsi/livenessprobe
+  newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-liveness-probe
+  newTag: v1.1.0
+- name: quay.io/k8scsi/csi-node-driver-registrar
+  newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-node-driver-registrar
+  newTag: v1.1.0
+

--- a/deploy/kubernetes/README.md
+++ b/deploy/kubernetes/README.md
@@ -1,0 +1,3 @@
+The `deploy/kubernetes` directory has been deprecated in favor of `deploy/k8s`. 
+New changes won't be made in this folder. 
+`deploy/kubernetes` is subject to removal in a future release.

--- a/docs/README.md
+++ b/docs/README.md
@@ -55,19 +55,26 @@ The following sections are Kubernetes specific. If you are a Kubernetes user, us
 * Since EFS is an elastic filesystem it doesn't really enforce any filesystem capacity. The actual storage capacity value in persistence volume and persistence volume claim is not used when creating the filesystem. However, since the storage capacity is a required field by Kubernetes, you must specify the value and you can use any valid value for the capacity.
 
 ### Installation
-Deploy the driver:
 
-If you want to deploy the stable driver:
+####Deploy the stable driver
+
+#####From AWS ECR
 ```sh
-kubectl apply -k "github.com/kubernetes-sigs/aws-efs-csi-driver/deploy/kubernetes/overlays/stable/?ref=master"
+kubectl apply -k "github.com/kubernetes-sigs/aws-efs-csi-driver/deploy/k8s/v0.3.0/overlays/ecr"
 ```
 
-If you want to deploy the development driver:
+#####Or from Docker Hub
 ```sh
-kubectl apply -k "github.com/kubernetes-sigs/aws-efs-csi-driver/deploy/kubernetes/overlays/dev/?ref=master"
+kubectl apply -k "github.com/kubernetes-sigs/aws-efs-csi-driver/deploy/k8s/v0.3.0/overlays/dockerhub"
 ```
 
-Alternatively, you could also install the driver using helm:
+####Deploy the driver that is currently under development
+**WARNING: DO NOT use this version of driver in a PRODUCTION environment since it may contain major bugs which are undetected**
+```sh
+kubectl apply -k "github.com/kubernetes-sigs/aws-efs-csi-driver/deploy/k8s/dev"
+```
+
+####Alternatively, install the driver using helm
 ```sh
 helm repo add aws-efs-csi-driver https://kubernetes-sigs.github.io/aws-efs-csi-driver/
 helm install aws-efs-csi-driver aws-efs-csi-driver/aws-efs-csi-driver

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -141,7 +141,7 @@ var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
 			framework.ExpectNoError(err, "getting csidriver efs.csi.aws.com")
 		} else {
 			ginkgo.By("Deploying EFS CSI driver")
-			framework.RunKubectlOrDie("apply", "-k", "github.com/kubernetes-sigs/aws-efs-csi-driver/deploy/kubernetes/overlays/stable/?ref=master")
+			framework.RunKubectlOrDie("apply", "-k", "github.com/kubernetes-sigs/aws-efs-csi-driver/deploy/k8s/v0.3.0/overlays/dockerhub/?ref=master")
 			ginkgo.By("Deployed EFS CSI driver")
 			destroyDriver = true
 		}
@@ -169,7 +169,7 @@ var _ = ginkgo.SynchronizedAfterSuite(func() {
 
 	if destroyDriver {
 		ginkgo.By("Cleaning up EFS CSI driver")
-		framework.RunKubectlOrDie("delete", "-k", "github.com/kubernetes-sigs/aws-efs-csi-driver/deploy/kubernetes/overlays/stable/?ref=master")
+		framework.RunKubectlOrDie("delete", "-k", "github.com/kubernetes-sigs/aws-efs-csi-driver/deploy/k8s/v0.3.0/overlays/dockerhub/?ref=master")
 	}
 })
 


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

/kind feature

**What is this PR about? / Why do we need it?**
To implement the proposal of https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/207

**What testing is done?** 
Deployed drivers with 

```
kubectl apply -k deploy/k8s/dev
kubectl apply -k deploy/k8s/v0.3.0/overlays/dockerhub
kubectl apply -k deploy/k8s/v0.3.0/overlays/ecr
```


```
$ diff deploy/k8s/dev/ deploy/kubernetes/base 
diff deploy/k8s/dev/node.yaml deploy/kubernetes/base/node.yaml
2c2,4
< # Node Service
---
> # The `deploy/kubernetes` directory has been deprecated in favor of `deploy/k8s`.
> # New changes won't be made in this folder.
> # `deploy/kubernetes` is subject to removal in a future release.
```

```
$ diff deploy/k8s/dev/ deploy/k8s/v0.3.0/base
$
```

