### PR TITLE
Started treating the efs-utils config dir stateful and also handles the static files installed at image build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,15 +27,6 @@ RUN make aws-efs-csi-driver
 FROM amazonlinux:2.0.20200406.0
 RUN yum install util-linux-2.30.2-2.amzn2.0.4.x86_64 amazon-efs-utils-1.24-4.amzn2.noarch -y
 
-# Default client source is k8s which can be overriden with –build-arg when building the Docker image
-ARG client_source=k8s
-RUN echo "client_source:${client_source}"
-RUN printf "\n\
-\n\
-[client-info] \n\
-source=${client_source} \n\
-" >> /etc/amazon/efs/efs-utils.conf
-
 COPY --from=builder /go/src/github.com/kubernetes-sigs/aws-efs-csi-driver/bin/aws-efs-csi-driver /bin/aws-efs-csi-driver
 COPY THIRD-PARTY /
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,13 @@ RUN make aws-efs-csi-driver
 FROM amazonlinux:2.0.20200406.0
 RUN yum install util-linux-2.30.2-2.amzn2.0.4.x86_64 amazon-efs-utils-1.24-4.amzn2.noarch -y
 
+# At image build time, static files installed by efs-utils in the config directory, i.e. CAs file, need
+# to be saved in another place so that the other stateful files created at runtime, i.e. private key for
+# client certificate, in the same config directory can be persisted to host with a host path volume.
+# Otherwise creating a host path volume for that directory will clean up everything inside at the first time.
+# Those static files need to be copied back to the config directory when the driver starts up.
+RUN cp -r /etc/amazon/efs /etc/amazon/efs-static-files
+
 COPY --from=builder /go/src/github.com/kubernetes-sigs/aws-efs-csi-driver/bin/aws-efs-csi-driver /bin/aws-efs-csi-driver
 COPY THIRD-PARTY /
 

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,11 @@ IMAGE?=amazon/aws-efs-csi-driver
 VERSION=v0.4.0-dirty
 GIT_COMMIT?=$(shell git rev-parse HEAD)
 BUILD_DATE?=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
-LDFLAGS?="-X ${PKG}/pkg/driver.driverVersion=${VERSION} -X ${PKG}/pkg/driver.gitCommit=${GIT_COMMIT} -X ${PKG}/pkg/driver.buildDate=${BUILD_DATE}"
+EFS_CLIENT_SOURCE?=k8s
+LDFLAGS?="-X ${PKG}/pkg/driver.driverVersion=${VERSION} \
+		  -X ${PKG}/pkg/driver.gitCommit=${GIT_COMMIT} \
+		  -X ${PKG}/pkg/driver.buildDate=${BUILD_DATE} \
+		  -X ${PKG}/pkg/driver.efsClientSource=${EFS_CLIENT_SOURCE}"
 GO111MODULE=on
 GOPROXY=direct
 GOPATH=$(shell go env GOPATH)
@@ -29,6 +33,13 @@ GOPATH=$(shell go env GOPATH)
 aws-efs-csi-driver:
 	mkdir -p bin
 	CGO_ENABLED=0 GOOS=linux go build -ldflags ${LDFLAGS} -o bin/aws-efs-csi-driver ./cmd/
+
+build-darwin:
+	mkdir -p bin/darwin/
+	CGO_ENABLED=0 GOOS=darwin go build -ldflags ${LDFLAGS} -o bin/darwin/aws-efs-csi-driver ./cmd/
+
+run-darwin: build-darwin
+	bin/darwin/aws-efs-csi-driver --version
 
 .PHONY: verify
 verify:

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -27,8 +27,9 @@ import (
 
 func main() {
 	var (
-		endpoint = flag.String("endpoint", "unix://tmp/csi.sock", "CSI Endpoint")
-		version  = flag.Bool("version", false, "Print the version and exit")
+		endpoint        = flag.String("endpoint", "unix://tmp/csi.sock", "CSI Endpoint")
+		version         = flag.Bool("version", false, "Print the version and exit")
+		efsUtilsCfgPath = flag.String("efs-utils-config-path", "/etc/amazon/efs/efs-utils.conf", "The path to efs-utils config")
 	)
 	klog.InitFlags(nil)
 	flag.Parse()
@@ -42,7 +43,7 @@ func main() {
 		os.Exit(0)
 	}
 
-	drv := driver.NewDriver(*endpoint)
+	drv := driver.NewDriver(*endpoint, *efsUtilsCfgPath)
 	if err := drv.Run(); err != nil {
 		klog.Fatalln(err)
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -21,15 +21,17 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/kubernetes-sigs/aws-efs-csi-driver/pkg/driver"
 	"k8s.io/klog"
+
+	"github.com/kubernetes-sigs/aws-efs-csi-driver/pkg/driver"
 )
 
 func main() {
 	var (
-		endpoint        = flag.String("endpoint", "unix://tmp/csi.sock", "CSI Endpoint")
-		version         = flag.Bool("version", false, "Print the version and exit")
-		efsUtilsCfgPath = flag.String("efs-utils-config-path", "/etc/amazon/efs/efs-utils.conf", "The path to efs-utils config")
+		endpoint                = flag.String("endpoint", "unix://tmp/csi.sock", "CSI Endpoint")
+		version                 = flag.Bool("version", false, "Print the version and exit")
+		efsUtilsCfgDirPath      = flag.String("efs-utils-config-dir-path", "/etc/amazon/efs/", "The path to efs-utils config directory")
+		efsUtilsStaticFilesPath = flag.String("efs-utils-static-files-path", "/etc/amazon/efs-static-files/", "The path to efs-utils static files directory")
 	)
 	klog.InitFlags(nil)
 	flag.Parse()
@@ -43,7 +45,7 @@ func main() {
 		os.Exit(0)
 	}
 
-	drv := driver.NewDriver(*endpoint, *efsUtilsCfgPath)
+	drv := driver.NewDriver(*endpoint, *efsUtilsCfgDirPath, *efsUtilsStaticFilesPath)
 	if err := drv.Run(); err != nil {
 		klog.Fatalln(err)
 	}

--- a/deploy/kubernetes/base/node.yaml
+++ b/deploy/kubernetes/base/node.yaml
@@ -41,6 +41,8 @@ spec:
               mountPath: /csi
             - name: efs-state-dir
               mountPath: /var/run/efs
+            - name: efs-utils-config
+              mountPath: /etc/amazon/efs
           ports:
             - containerPort: 9809
               name: healthz
@@ -98,5 +100,8 @@ spec:
           hostPath:
             path: /var/run/efs
             type: DirectoryOrCreate
-
+        - name: efs-utils-config
+          hostPath:
+            path: /etc/amazon/efs
+            type: DirectoryOrCreate
 

--- a/deploy/kubernetes/base/node.yaml
+++ b/deploy/kubernetes/base/node.yaml
@@ -41,8 +41,6 @@ spec:
               mountPath: /csi
             - name: efs-state-dir
               mountPath: /var/run/efs
-            - name: efs-utils-config
-              mountPath: /etc/amazon/efs
           ports:
             - containerPort: 9809
               name: healthz
@@ -99,9 +97,5 @@ spec:
         - name: efs-state-dir
           hostPath:
             path: /var/run/efs
-            type: DirectoryOrCreate
-        - name: efs-utils-config
-          hostPath:
-            path: /etc/amazon/efs
             type: DirectoryOrCreate
 

--- a/deploy/kubernetes/overlays/dev/efs_utils_config_volume.yaml
+++ b/deploy/kubernetes/overlays/dev/efs_utils_config_volume.yaml
@@ -1,0 +1,20 @@
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: efs-csi-node
+  namespace: kube-system
+spec:
+  template:
+    spec:
+      containers:
+        - name: efs-plugin
+          volumeMounts:
+            - name: efs-utils-config
+              mountPath: /etc/amazon/efs
+      volumes:
+        - name: efs-utils-config
+          hostPath:
+            path: /etc/amazon/efs
+            type: DirectoryOrCreate
+
+

--- a/deploy/kubernetes/overlays/dev/kustomization.yaml
+++ b/deploy/kubernetes/overlays/dev/kustomization.yaml
@@ -4,3 +4,4 @@ bases:
 - ../../base
 patchesStrategicMerge:
 - latest_image.yaml
+- efs_utils_config_volume.yaml

--- a/deploy/kubernetes/overlays/dev/latest_image.yaml
+++ b/deploy/kubernetes/overlays/dev/latest_image.yaml
@@ -9,4 +9,3 @@ spec:
       containers:
         - name: efs-plugin
           image: amazon/aws-efs-csi-driver:latest
-          imagePullPolicy: Always

--- a/deploy/kubernetes/overlays/stable/ecr/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/ecr/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+  - ../../../base
+images:
+  - name: amazon/aws-efs-csi-driver
+    newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/aws-efs-csi-driver
+    newTag: v0.3.0
+  - name: quay.io/k8scsi/livenessprobe
+    newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-liveness-probe
+    newTag: v1.1.0
+  - name: quay.io/k8scsi/csi-node-driver-registrar
+    newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-node-driver-registrar
+    newTag: v1.1.0

--- a/helm/templates/daemonset.yaml
+++ b/helm/templates/daemonset.yaml
@@ -49,6 +49,8 @@ spec:
               mountPath: /csi
             - name: efs-state-dir
               mountPath: /var/run/efs
+            - name: efs-utils-config
+              mountPath: /etc/amazon/efs
           ports:
             - name: healthz
               containerPort: 9809
@@ -59,7 +61,7 @@ spec:
               port: healthz
             initialDelaySeconds: 10
             timeoutSeconds: 3
-            periodSeconds: 2 
+            periodSeconds: 2
             failureThreshold: 5
         - name: cs-driver-registrar
           image: {{ printf "%s:%s" .Values.sidecars.nodeDriverRegistrarImage.repository .Values.sidecars.nodeDriverRegistrarImage.tag }}
@@ -105,4 +107,8 @@ spec:
         - name: efs-state-dir
           hostPath:
             path: /var/run/efs
+            type: DirectoryOrCreate
+        - name: efs-utils-config
+          hostPath:
+            path: /etc/amazon/efs
             type: DirectoryOrCreate

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -43,13 +43,13 @@ type Driver struct {
 	efsWatchdog Watchdog
 }
 
-func NewDriver(endpoint, efsUtilsCfgPath string) *Driver {
+func NewDriver(endpoint, efsUtilsCfgPath, efsUtilsStaticFilesPath string) *Driver {
 	cloud, err := cloud.NewCloud()
 	if err != nil {
 		klog.Fatalln(err)
 	}
 
-	watchdog := newExecWatchdog(efsUtilsCfgPath, "amazon-efs-mount-watchdog")
+	watchdog := newExecWatchdog(efsUtilsCfgPath, efsUtilsStaticFilesPath, "amazon-efs-mount-watchdog")
 	return &Driver{
 		endpoint:    endpoint,
 		nodeID:      cloud.GetMetadata().GetInstanceID(),

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -21,10 +21,11 @@ import (
 	"net"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
-	"github.com/kubernetes-sigs/aws-efs-csi-driver/pkg/cloud"
-	"github.com/kubernetes-sigs/aws-efs-csi-driver/pkg/util"
 	"google.golang.org/grpc"
 	"k8s.io/klog"
+
+	"github.com/kubernetes-sigs/aws-efs-csi-driver/pkg/cloud"
+	"github.com/kubernetes-sigs/aws-efs-csi-driver/pkg/util"
 )
 
 const (
@@ -42,13 +43,13 @@ type Driver struct {
 	efsWatchdog Watchdog
 }
 
-func NewDriver(endpoint string) *Driver {
+func NewDriver(endpoint, efsUtilsCfgPath string) *Driver {
 	cloud, err := cloud.NewCloud()
 	if err != nil {
 		klog.Fatalln(err)
 	}
 
-	watchdog := newExecWatchdog("amazon-efs-mount-watchdog")
+	watchdog := newExecWatchdog(efsUtilsCfgPath, "amazon-efs-mount-watchdog")
 	return &Driver{
 		endpoint:    endpoint,
 		nodeID:      cloud.GetMetadata().GetInstanceID(),
@@ -84,7 +85,9 @@ func (d *Driver) Run() error {
 	csi.RegisterNodeServer(d.srv, d)
 
 	klog.Info("Starting watchdog")
-	d.efsWatchdog.start()
+	if err := d.efsWatchdog.start(); err != nil {
+		return err
+	}
 
 	reaper := newReaper()
 	klog.Info("Staring subreaper")

--- a/pkg/driver/efs_watch_dog.go
+++ b/pkg/driver/efs_watch_dog.go
@@ -15,16 +15,72 @@ package driver
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"sync"
+	"text/template"
 
 	"k8s.io/klog"
 )
 
+// https://github.com/aws/efs-utils/blob/master/dist/efs-utils.conf
+const efsUtilsConfigTemplate = `
+[DEFAULT]
+logging_level = INFO
+logging_max_bytes = 1048576
+logging_file_count = 10
+# mode for /var/run/efs and subdirectories in octal
+state_file_dir_mode = 750
+
+[mount]
+dns_name_format = {fs_id}.efs.{region}.{dns_name_suffix}
+dns_name_suffix = amazonaws.com
+#The region of the file system when mounting from on-premises or cross region.
+#region = us-east-1
+stunnel_debug_enabled = true
+#Uncomment the below option to save all stunnel logs for a file system to the same file
+stunnel_logs_file = /var/log/amazon/efs/{fs_id}.stunnel.log
+# RootCA on AmazonLinux2/CentOS. https://golang.org/src/crypto/x509/root_linux.go
+stunnel_cafile = /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+
+# Validate the certificate hostname on mount. This option is not supported by certain stunnel versions.
+stunnel_check_cert_hostname = true
+
+# Use OCSP to check certificate validity. This option is not supported by certain stunnel versions.
+stunnel_check_cert_validity = false
+
+# Define the port range that the TLS tunnel will choose from
+port_range_lower_bound = 20049
+port_range_upper_bound = 20449
+
+[mount.cn-north-1]
+dns_name_suffix = amazonaws.com.cn
+
+[mount.cn-northwest-1]
+dns_name_suffix = amazonaws.com.cn
+
+[mount.us-iso-east-1]
+dns_name_suffix = c2s.ic.gov
+
+[mount.us-isob-east-1]
+dns_name_suffix = sc2s.sgov.gov
+
+[mount-watchdog]
+enabled = true
+poll_interval_sec = 1
+unmount_grace_period_sec = 30
+
+# Set client auth/access point certificate renewal rate. Minimum value is 1 minute.
+tls_cert_renewal_interval_min = 60
+
+[client-info] 
+source={{.EfsClientSource}}
+`
+
 // Watchdog defines the interface for process monitoring and supervising
 type Watchdog interface {
 	// start starts the watch dog along with the process
-	start()
+	start() error
 
 	// stop stops the watch dog along with the process
 	stop()
@@ -39,22 +95,49 @@ type execWatchdog struct {
 	execArg []string
 	// the cmd that is running
 	cmd *exec.Cmd
+	// efs-utils config file path
+	efsUtilsCfgPath string
 	// stopCh indicates if it should be stopped
 	stopCh chan struct{}
 
 	mu sync.Mutex
 }
 
-func newExecWatchdog(cmd string, arg ...string) Watchdog {
+type efsUtilsConfig struct {
+	EfsClientSource string
+}
+
+func newExecWatchdog(efsUtilsCfgPath, cmd string, arg ...string) Watchdog {
 	return &execWatchdog{
-		execCmd: cmd,
-		execArg: arg,
-		stopCh:  make(chan struct{}),
+		efsUtilsCfgPath: efsUtilsCfgPath,
+		execCmd:         cmd,
+		execArg:         arg,
+		stopCh:          make(chan struct{}),
 	}
 }
 
-func (w *execWatchdog) start() {
+func (w *execWatchdog) start() error {
+	if err := w.updateConfig(GetVersion().EfsClientSource); err != nil {
+		return err
+	}
+
 	go w.runLoop(w.stopCh)
+
+	return nil
+}
+
+func (w *execWatchdog) updateConfig(efsClientSource string) error {
+	efsCfgTemplate := template.Must(template.New("efs-utils-config").Parse(efsUtilsConfigTemplate))
+	f, err := os.Create(w.efsUtilsCfgPath)
+	if err != nil {
+		return fmt.Errorf("cannot create config file %s for efs-utils. Error: %v", w.efsUtilsCfgPath, err)
+	}
+	defer f.Close()
+	efsCfg := efsUtilsConfig{EfsClientSource: efsClientSource}
+	if err = efsCfgTemplate.Execute(f, efsCfg); err != nil {
+		return fmt.Errorf("cannot update config %s for efs-utils. Error: %v", w.efsUtilsCfgPath, err)
+	}
+	return nil
 }
 
 // stop kills the underlying process and stops the watchdog

--- a/pkg/driver/efs_watch_dog_test.go
+++ b/pkg/driver/efs_watch_dog_test.go
@@ -14,13 +14,107 @@ limitations under the License.
 package driver
 
 import (
+	"io/ioutil"
+	"os"
 	"testing"
 	"time"
 )
 
+const expectedEfsUtilsConfig = `
+[DEFAULT]
+logging_level = INFO
+logging_max_bytes = 1048576
+logging_file_count = 10
+# mode for /var/run/efs and subdirectories in octal
+state_file_dir_mode = 750
+
+[mount]
+dns_name_format = {fs_id}.efs.{region}.{dns_name_suffix}
+dns_name_suffix = amazonaws.com
+#The region of the file system when mounting from on-premises or cross region.
+#region = us-east-1
+stunnel_debug_enabled = true
+#Uncomment the below option to save all stunnel logs for a file system to the same file
+stunnel_logs_file = /var/log/amazon/efs/{fs_id}.stunnel.log
+# RootCA on AmazonLinux2/CentOS. https://golang.org/src/crypto/x509/root_linux.go
+stunnel_cafile = /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+
+# Validate the certificate hostname on mount. This option is not supported by certain stunnel versions.
+stunnel_check_cert_hostname = true
+
+# Use OCSP to check certificate validity. This option is not supported by certain stunnel versions.
+stunnel_check_cert_validity = false
+
+# Define the port range that the TLS tunnel will choose from
+port_range_lower_bound = 20049
+port_range_upper_bound = 20449
+
+[mount.cn-north-1]
+dns_name_suffix = amazonaws.com.cn
+
+[mount.cn-northwest-1]
+dns_name_suffix = amazonaws.com.cn
+
+[mount.us-iso-east-1]
+dns_name_suffix = c2s.ic.gov
+
+[mount.us-isob-east-1]
+dns_name_suffix = sc2s.sgov.gov
+
+[mount-watchdog]
+enabled = true
+poll_interval_sec = 1
+unmount_grace_period_sec = 30
+
+# Set client auth/access point certificate renewal rate. Minimum value is 1 minute.
+tls_cert_renewal_interval_min = 60
+
+[client-info] 
+source=k8s
+`
+
 func TestExecWatchdog(t *testing.T) {
-	w := newExecWatchdog("sleep", "300")
-	w.start()
+	f := createEmptyConfigFile(t)
+	defer os.Remove(f.Name())
+
+	w := newExecWatchdog(f.Name(), "sleep", "300")
+	if err := w.start(); err != nil {
+		t.Fatalf("Failed to start %v", err)
+	}
 	time.Sleep(time.Second)
 	w.stop()
+}
+
+func createEmptyConfigFile(t *testing.T) *os.File {
+	f, err := ioutil.TempFile("", "")
+	if err != nil {
+		t.Fatalf("couldn't create temp file %v, %v", f, err)
+	}
+	return f
+}
+
+func TestUpdateConfig(t *testing.T) {
+	f := createEmptyConfigFile(t)
+	defer os.Remove(f.Name())
+
+	w := newExecWatchdog(f.Name(), "sleep", "300").(*execWatchdog)
+	efsClient := "k8s"
+	if err := w.updateConfig(efsClient); err != nil {
+		t.Fatalf("Failed to update config file %v, %v", f, err)
+	}
+	bytes, err := ioutil.ReadAll(f)
+	if err != nil {
+		t.Fatalf("Failed to read config file %v, %v", f, err)
+	}
+	actualConfig := string(bytes)
+	if actualConfig != expectedEfsUtilsConfig {
+		t.Errorf("Unexpected efs-utils config content: want %s\nactual:%s", expectedEfsUtilsConfig, actualConfig)
+	}
+}
+
+func TestWrite(t *testing.T) {
+	redirect := newInfoRedirect("info")
+	if _, err := redirect.Write([]byte("abc")); err != nil {
+		t.Errorf("Failed to Write in redirect: %v", err)
+	}
 }

--- a/pkg/driver/efs_watch_dog_test.go
+++ b/pkg/driver/efs_watch_dog_test.go
@@ -16,11 +16,13 @@ package driver
 import (
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 )
 
-const expectedEfsUtilsConfig = `
+const (
+	expectedEfsUtilsConfig = `
 [DEFAULT]
 logging_level = INFO
 logging_max_bytes = 1048576
@@ -33,11 +35,10 @@ dns_name_format = {fs_id}.efs.{region}.{dns_name_suffix}
 dns_name_suffix = amazonaws.com
 #The region of the file system when mounting from on-premises or cross region.
 #region = us-east-1
-stunnel_debug_enabled = true
+stunnel_debug_enabled = false
 #Uncomment the below option to save all stunnel logs for a file system to the same file
-stunnel_logs_file = /var/log/amazon/efs/{fs_id}.stunnel.log
-# RootCA on AmazonLinux2/CentOS. https://golang.org/src/crypto/x509/root_linux.go
-stunnel_cafile = /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+#stunnel_logs_file = /var/log/amazon/efs/{fs_id}.stunnel.log
+stunnel_cafile = /etc/amazon/efs/efs-utils.crt
 
 # Validate the certificate hostname on mount. This option is not supported by certain stunnel versions.
 stunnel_check_cert_hostname = true
@@ -72,12 +73,16 @@ tls_cert_renewal_interval_min = 60
 [client-info] 
 source=k8s
 `
+	configFileName = "efs-utils.conf"
+)
 
 func TestExecWatchdog(t *testing.T) {
-	f := createEmptyConfigFile(t)
-	defer os.Remove(f.Name())
+	configDirName := createTempDir(t)
+	staticFileDirName := createTempDir(t)
+	defer os.RemoveAll(configDirName)
+	defer os.RemoveAll(staticFileDirName)
 
-	w := newExecWatchdog(f.Name(), "sleep", "300")
+	w := newExecWatchdog(configDirName, staticFileDirName, "sleep", "300")
 	if err := w.start(); err != nil {
 		t.Fatalf("Failed to start %v", err)
 	}
@@ -85,31 +90,149 @@ func TestExecWatchdog(t *testing.T) {
 	w.stop()
 }
 
-func createEmptyConfigFile(t *testing.T) *os.File {
-	f, err := ioutil.TempFile("", "")
+func createTempDir(t *testing.T) string {
+	name, err := ioutil.TempDir("", "")
+	checkError(t, err)
+	return name
+}
+
+func checkError(t *testing.T, err error) {
 	if err != nil {
-		t.Fatalf("couldn't create temp file %v, %v", f, err)
+		t.Fatalf("Unexpected error %v", err)
 	}
+}
+
+func createFileInDir(t *testing.T, dirName, fileName string) *os.File {
+	f, err := os.Create(filepath.Join(dirName, fileName))
+	checkError(t, err)
 	return f
 }
 
-func TestUpdateConfig(t *testing.T) {
-	f := createEmptyConfigFile(t)
-	defer os.Remove(f.Name())
+func TestSetupWithEmptyConfigDirectory(t *testing.T) {
+	//create file A, B in static file directory and keep config directory empty
+	configDirName := createTempDir(t)
+	staticFileDirName := createTempDir(t)
+	defer os.RemoveAll(configDirName)
+	defer os.RemoveAll(staticFileDirName)
 
-	w := newExecWatchdog(f.Name(), "sleep", "300").(*execWatchdog)
+	fileAName := "A"
+	fileAContent := "dummyA"
+	createFile(t, staticFileDirName, fileAName, fileAContent)
+
+	fileBName := "B"
+	fileBContent := "dummyB"
+	createFile(t, staticFileDirName, fileBName, fileBContent)
+
+	w := newExecWatchdog(configDirName, staticFileDirName, "sleep", "300").(*execWatchdog)
 	efsClient := "k8s"
-	if err := w.updateConfig(efsClient); err != nil {
-		t.Fatalf("Failed to update config file %v, %v", f, err)
+	configFilePath := filepath.Join(configDirName, configFileName)
+	if err := w.setup(efsClient); err != nil {
+		t.Fatalf("Failed to update config file %v, %v", configFilePath, err)
 	}
-	bytes, err := ioutil.ReadAll(f)
+
+	verifyConfigFile(t, configFilePath)
+
+	//verify file A and B are copied over to static file directory
+	verifyFileContent(t, filepath.Join(configDirName, "A"), fileAContent)
+	verifyFileContent(t, filepath.Join(configDirName, "B"), fileBContent)
+}
+
+func TestSetupWithNonEmptyConfigDirectory(t *testing.T) {
+	//create file A, B in static file directory
+	staticFileDirName := createTempDir(t)
+	defer os.RemoveAll(staticFileDirName)
+
+	fileAName := "A"
+	fileAContent := "dummyA"
+	createFile(t, staticFileDirName, fileAName, fileAContent)
+
+	fileBName := "B"
+	fileBContent := "dummyB"
+	createFile(t, staticFileDirName, fileBName, fileBContent)
+
+	// Create a different B file in the config directory with the expectation that B won't be overwritten.
+	configDirName := createTempDir(t)
+	defer os.RemoveAll(configDirName)
+	differentContent := "differentDummy"
+	createFile(t, configDirName, fileBName, differentContent)
+
+	w := newExecWatchdog(configDirName, staticFileDirName, "sleep", "300").(*execWatchdog)
+	efsClient := "k8s"
+	configFilePath := filepath.Join(configDirName, configFileName)
+	if err := w.setup(efsClient); err != nil {
+		t.Fatalf("Failed to update config file %v, %v", configFilePath, err)
+	}
+
+	verifyConfigFile(t, configFilePath)
+
+	//verify file A is copied over from static files directory but file B in the config direcotry remains as is
+	verifyFileContent(t, filepath.Join(configDirName, "A"), fileAContent)
+	verifyFileContent(t, filepath.Join(configDirName, "B"), differentContent)
+}
+
+func TestSetupWithNonexistentConfigDirectory(t *testing.T) {
+	configDirName := ""
+	staticFileDirName := createTempDir(t)
+	defer os.RemoveAll(staticFileDirName)
+	w := newExecWatchdog(configDirName, staticFileDirName, "sleep", "300").(*execWatchdog)
+	efsClient := "k8s"
+	if err := w.setup(efsClient); err == nil {
+		t.Fatalf("Expected failure since static files directory doesn't exist.")
+	}
+}
+
+func TestSetupWithNonexistentStaticFilesDirectory(t *testing.T) {
+	configDirName := createTempDir(t)
+	defer os.RemoveAll(configDirName)
+	staticFileDirName := ""
+	w := newExecWatchdog(configDirName, staticFileDirName, "sleep", "300").(*execWatchdog)
+	efsClient := "k8s"
+	if err := w.setup(efsClient); err == nil {
+		t.Fatalf("Expected failure since config directory doesn't exist.")
+	}
+}
+
+func TestSetupWithAdditionalDirectoryInStaticFilesDirectory(t *testing.T) {
+	configDirName := createTempDir(t)
+	defer os.RemoveAll(configDirName)
+
+	staticFileDirName := createTempDir(t)
+	defer os.RemoveAll(staticFileDirName)
+
+	_, err := ioutil.TempDir(staticFileDirName, "")
+	checkError(t, err)
+
+	w := newExecWatchdog(configDirName, staticFileDirName, "sleep", "300").(*execWatchdog)
+	efsClient := "k8s"
+	if err := w.setup(efsClient); err == nil {
+		t.Fatalf("Expected failure since config directory contains another directory.")
+	}
+}
+
+func verifyFileContent(t *testing.T, fileName string, expectedFileContent string) {
+	fileContent, err := ioutil.ReadFile(fileName)
 	if err != nil {
-		t.Fatalf("Failed to read config file %v, %v", f, err)
+		t.Fatalf("Failed to read file %v, %v", fileName, err)
 	}
-	actualConfig := string(bytes)
+	actualFileContent := string(fileContent)
+	if actualFileContent != expectedFileContent {
+		t.Fatalf("Unexpected A file config content: want %s\nactual:%s", expectedFileContent, actualFileContent)
+	}
+}
+
+func verifyConfigFile(t *testing.T, configFilePath string) {
+	configFileContent, err := ioutil.ReadFile(configFilePath)
+	checkError(t, err)
+	actualConfig := string(configFileContent)
 	if actualConfig != expectedEfsUtilsConfig {
-		t.Errorf("Unexpected efs-utils config content: want %s\nactual:%s", expectedEfsUtilsConfig, actualConfig)
+		t.Fatalf("Unexpected efs-utils config content: want %s\nactual:%s", expectedEfsUtilsConfig, actualConfig)
 	}
+}
+
+func createFile(t *testing.T, dirName, fileName, fileContent string) {
+	f := createFileInDir(t, dirName, fileName)
+	_, err := f.WriteString(fileContent)
+	checkError(t, err)
 }
 
 func TestWrite(t *testing.T) {

--- a/pkg/driver/sanity_test.go
+++ b/pkg/driver/sanity_test.go
@@ -31,7 +31,8 @@ import (
 type mockWatchdog struct {
 }
 
-func (w *mockWatchdog) start() {
+func (w *mockWatchdog) start() error {
+	return nil
 }
 
 func (w *mockWatchdog) stop() {

--- a/pkg/driver/version.go
+++ b/pkg/driver/version.go
@@ -19,28 +19,31 @@ import (
 )
 
 var (
-	driverVersion string
-	gitCommit     string
-	buildDate     string
+	driverVersion   string
+	gitCommit       string
+	buildDate       string
+	efsClientSource string
 )
 
 type VersionInfo struct {
-	DriverVersion string `json:"driverVersion"`
-	GitCommit     string `json:"gitCommit"`
-	BuildDate     string `json:"buildDate"`
-	GoVersion     string `json:"goVersion"`
-	Compiler      string `json:"compiler"`
-	Platform      string `json:"platform"`
+	DriverVersion   string `json:"driverVersion"`
+	GitCommit       string `json:"gitCommit"`
+	BuildDate       string `json:"buildDate"`
+	EfsClientSource string `json:"efsClientSource"`
+	GoVersion       string `json:"goVersion"`
+	Compiler        string `json:"compiler"`
+	Platform        string `json:"platform"`
 }
 
 func GetVersion() VersionInfo {
 	return VersionInfo{
-		DriverVersion: driverVersion,
-		GitCommit:     gitCommit,
-		BuildDate:     buildDate,
-		GoVersion:     runtime.Version(),
-		Compiler:      runtime.Compiler,
-		Platform:      fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+		DriverVersion:   driverVersion,
+		GitCommit:       gitCommit,
+		BuildDate:       buildDate,
+		EfsClientSource: efsClientSource,
+		GoVersion:       runtime.Version(),
+		Compiler:        runtime.Compiler,
+		Platform:        fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
 	}
 }
 func GetVersionJSON() (string, error) {

--- a/pkg/driver/version_test.go
+++ b/pkg/driver/version_test.go
@@ -23,12 +23,13 @@ func TestGetVersion(t *testing.T) {
 	version := GetVersion()
 
 	expected := VersionInfo{
-		DriverVersion: "",
-		GitCommit:     "",
-		BuildDate:     "",
-		GoVersion:     runtime.Version(),
-		Compiler:      runtime.Compiler,
-		Platform:      fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+		DriverVersion:   "",
+		GitCommit:       "",
+		BuildDate:       "",
+		EfsClientSource: "",
+		GoVersion:       runtime.Version(),
+		Compiler:        runtime.Compiler,
+		Platform:        fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
 	}
 
 	if !reflect.DeepEqual(version, expected) {
@@ -44,6 +45,7 @@ func TestGetVersionJSON(t *testing.T) {
   "driverVersion": "",
   "gitCommit": "",
   "buildDate": "",
+  "efsClientSource": "",
   "goVersion": "%s",
   "compiler": "%s",
   "platform": "%s"


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
/feature

**What is this PR about? / Why do we need it?**
This PR added https://github.com/kubernetes-sigs/aws-efs-csi-driver/pull/196 back by only patching node.yaml in the `dev` overlay. 

This PR also start treating the efs-utils config directory stateful and handles static files installed at image build time. 

At image build time, static files installed by efs-utils in the config directory, i.e. CAs file, need to be saved in another place so that the other stateful files created at runtime, i.e. private key for client certificate, in the same config directory can be persisted to host with a host path volume. Otherwise creating a host path volume for that directory will clean up everything inside at the first time. Those static files need to be copied back to the config directory when the driver starts up.

**What testing is done?** 
Tested by verifying both tls and non-tls mount installed by 0.3.0 driver can be safely upgraded to the latest driver code without much interruption (other than during the downtime of the old driver). 

