### PR TITLE
Added e2e test for driver version upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.swp
 bin/
 vendor/
+/test/e2e/results/
+/test/.DS_Store

--- a/pkg/driver/efs_watch_dog.go
+++ b/pkg/driver/efs_watch_dog.go
@@ -71,7 +71,7 @@ dns_name_suffix = sc2s.sgov.gov
 [mount-watchdog]
 enabled = true
 poll_interval_sec = 1
-unmount_grace_period_sec = 30
+unmount_grace_period_sec = 5
 
 # Set client auth/access point certificate renewal rate. Minimum value is 1 minute.
 tls_cert_renewal_interval_min = 60

--- a/pkg/driver/efs_watch_dog_test.go
+++ b/pkg/driver/efs_watch_dog_test.go
@@ -65,7 +65,7 @@ dns_name_suffix = sc2s.sgov.gov
 [mount-watchdog]
 enabled = true
 poll_interval_sec = 1
-unmount_grace_period_sec = 30
+unmount_grace_period_sec = 5
 
 # Set client auth/access point certificate renewal rate. Minimum value is 1 minute.
 tls_cert_renewal_interval_min = 60

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -3,9 +3,15 @@
 - kubernetes 1.14+ cluster whose workers (preferably 2 or more) can mount the Amazon EFS file system
 
 # Run
+
+## Run all CSI tests
 ```sh
-go test -v -timeout 0 ./... -kubeconfig=$HOME/.kube/config -report-dir=$ARTIFACTS -ginkgo.focus="\[efs-csi\]" -ginkgo.skip="\[Disruptive\]" \
-  -file-system-id=fs-c2a43e69
+go test ./test/e2e/ -v -kubeconfig=$HOME/.kube/config --region=us-west-2 --report-dir="./results" -ginkgo.focus="\[efs-csi\]" --cluster-name="cluster-name"
+```
+
+## Run single CSI test
+```sh
+go test ./test/e2e/ -v -kubeconfig=$HOME/.kube/config --region=us-west-2 --report-dir="./results" -ginkgo.focus="should continue reading/writing after the driver pod is upgraded from stable version" --cluster-name="cluster-name"
 ```
 
 # Update dependencies

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -55,6 +55,7 @@ func init() {
 
 	flag.StringVar(&ClusterName, "cluster-name", "", "the cluster name")
 	flag.StringVar(&Region, "region", "us-west-2", "the region")
+	flag.StringVar(&FileSystemId, "file-system-id", "", "the file system id")
 
 	flag.Parse()
 }


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
feature 

**What is this PR about? / Why do we need it?**
Added e2e test for driver version upgrade

**What testing is done?** 
```
go test ./test/e2e/ -v -kubeconfig=$HOME/.kube/config --region=us-west-2 --report-dir="./results" -ginkgo.focus="\[restart\]|\[upgrade\]" --cluster-name="eks-11602" --file-system-id fs-b6654c1c 
```