### PR TITLE
Build and push every master commit to master tag

### DIFF
--- a/.github/workflows/container-image.yaml
+++ b/.github/workflows/container-image.yaml
@@ -25,6 +25,10 @@ jobs:
         docker login docker.pkg.github.com -u $USER -p ${{ secrets.REGISTRY_TOKEN }}
         docker tag aws-efs-csi-driver docker.pkg.github.com/$GITHUB_REPOSITORY/$IMAGE:$TAG
         docker push docker.pkg.github.com/$GITHUB_REPOSITORY/$IMAGE:$TAG
+        if [ "$BRANCH" = "master" ]; then
+          docker tag aws-efs-csi-driver docker.pkg.github.com/$GITHUB_REPOSITORY/$IMAGE:master
+          docker push docker.pkg.github.com/$GITHUB_REPOSITORY/$IMAGE:master
+        fi
     - name: Push to Dockerhub registry
       run: |
         BRANCH=$(echo $GITHUB_REF | cut -d'/' -f3)
@@ -38,3 +42,7 @@ jobs:
         docker login -u ${{ secrets.DOCKERHUB_USER }} -p ${{ secrets.DOCKERHUB_TOKEN }}
         docker tag aws-efs-csi-driver $REPO:$TAG
         docker push $REPO:$TAG
+        if [ "$BRANCH" = "master" ]; then
+          docker tag aws-efs-csi-driver $REPO:master
+          docker push $REPO:master
+        fi

--- a/Makefile
+++ b/Makefile
@@ -58,11 +58,11 @@ test-e2e:
 
 .PHONY: image
 image:
-	docker build -t $(IMAGE):latest .
+	docker build -t $(IMAGE):master .
 
 .PHONY: push
 push: image
-	docker push $(IMAGE):latest
+	docker push $(IMAGE):master
 
 .PHONY: image-release
 image-release:

--- a/deploy/kubernetes/overlays/dev/kustomization.yaml
+++ b/deploy/kubernetes/overlays/dev/kustomization.yaml
@@ -3,5 +3,5 @@ kind: Kustomization
 bases:
 - ../../base
 patchesStrategicMerge:
-- latest_image.yaml
+- master_image.yaml
 - efs_utils_config_volume.yaml

--- a/deploy/kubernetes/overlays/dev/master_image.yaml
+++ b/deploy/kubernetes/overlays/dev/master_image.yaml
@@ -8,4 +8,5 @@ spec:
     spec:
       containers:
         - name: efs-plugin
-          image: amazon/aws-efs-csi-driver:latest
+          image: amazon/aws-efs-csi-driver:master
+          imagePullPolicy: Always

--- a/docs/README.md
+++ b/docs/README.md
@@ -42,7 +42,7 @@ The following sections are Kubernetes specific. If you are a Kubernetes user, us
 ### Container Images
 |EFS CSI Driver Version     | Image                               |
 |---------------------------|-------------------------------------|
-|master branch              |amazon/aws-efs-csi-driver:latest     |
+|master branch              |amazon/aws-efs-csi-driver:master     |
 |v0.3.0                     |amazon/aws-efs-csi-driver:v0.3.0     |
 |v0.2.0                     |amazon/aws-efs-csi-driver:v0.2.0     |
 |v0.1.0                     |amazon/aws-efs-csi-driver:v0.1.0     |

--- a/hack/run-e2e-test
+++ b/hack/run-e2e-test
@@ -78,7 +78,7 @@ done;
 
 echo "Deploying driver"
 sed -i'' "s,amazon/aws-efs-csi-driver,$IMAGE_NAME," deploy/kubernetes/overlays/dev/kustomization.yaml
-sed -i'' "s,newTag: latest,newTag: \"$IMAGE_TAG\"," deploy/kubernetes/overlays/dev/kustomization.yaml
+sed -i'' "s,master,\"$IMAGE_TAG\"," deploy/kubernetes/overlays/dev/kustomization.yaml
 kubectl apply -k deploy/kubernetes/overlays/dev/
 
 echo "Creating EFS file system"


### PR DESCRIPTION
**Is this a bug fix or adding new feature?** fix

**What is this PR about? / Why do we need it?** dev overlay still points to tag latest but we stopped pushing to tag latest. So the dev overlay is out of sync with the image. To put it back in sync, use tag `master`.

**What testing is done?** N/A
