### PR TITLE
Update efs-utils to 1.26-3.amzn2 and amazonlinux to 2.0.20200602.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ ADD . .
 RUN make aws-efs-csi-driver
 
 FROM amazonlinux:2.0.20200406.0
-RUN yum install util-linux-2.30.2-2.amzn2.0.4.x86_64 amazon-efs-utils-1.24-4.amzn2.noarch -y
+RUN yum install util-linux-2.30.2-2.amzn2.0.4.x86_64 amazon-efs-utils-1.26-3.amzn2.noarch -y
 
 # At image build time, static files installed by efs-utils in the config directory, i.e. CAs file, need
 # to be saved in another place so that the other stateful files created at runtime, i.e. private key for

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN go mod download
 ADD . .
 RUN make aws-efs-csi-driver
 
-FROM amazonlinux:2.0.20200406.0
+FROM amazonlinux:2.0.20200602.0
 RUN yum install util-linux-2.30.2-2.amzn2.0.4.x86_64 amazon-efs-utils-1.26-3.amzn2.noarch -y
 
 # At image build time, static files installed by efs-utils in the config directory, i.e. CAs file, need


### PR DESCRIPTION
**Is this a bug fix or adding new feature?** fix https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/208

**What is this PR about? / Why do we need it?** Routine update of efs-utils to pick up some bugfixes to do with tls mounts. Need this before the next release.

Also amazonlinux to fix https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/210

**What testing is done?** I tested that the efs-utils issues linked in https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/208 are fixed. By restarting the driver pod when it has multiple tls mounts active, all tls mounts should continue to read/write after the driver pod is back.
