### PR TITLE
Added a script to collect logs and other info for easier troubleshooting.

### DIFF
--- a/troubleshooting/README.md
+++ b/troubleshooting/README.md
@@ -1,0 +1,4 @@
+Run
+```
+python3 log_collector.py --driver-pod-name <driver_pod_name>
+```

--- a/troubleshooting/log_collector.py
+++ b/troubleshooting/log_collector.py
@@ -1,0 +1,61 @@
+import subprocess
+import shlex
+import os
+import shutil
+import tarfile
+import argparse
+
+parser = argparse.ArgumentParser(description="Troubleshooting EFS CSI Driver")
+
+parser.add_argument("--driver-pod-name", required=True, help="The EFS CSI driver pod name")
+
+args = parser.parse_args(['--driver-pod-name', 'efs-csi-node-5dpc4'])
+
+driver_pod_name = args.driver_pod_name
+
+results_dir_path = 'results'
+
+# Clean up existing results folder
+shutil.rmtree(results_dir_path, ignore_errors=True)
+
+os.makedirs(results_dir_path)
+
+def execute(command, file, shell=False):
+    print(command + "\n", file=file, flush=True)
+    if shell:
+        subprocess.run(command, shell=True, text=True, stderr=subprocess.STDOUT, stdout=f)
+    else:
+        subprocess.run(shlex.split(command), text=True, stderr=subprocess.STDOUT, stdout=f)
+    print("\n", file=file, flush=True)
+
+
+with open(results_dir_path + '/driver_info', 'w') as f:
+    describe_driver_pod = f'kubectl describe po {driver_pod_name} -n kube-system'
+    execute(command=describe_driver_pod, file=f)
+
+    get_driver_pod = f'kubectl get po {driver_pod_name} -n kube-system -o yaml'
+    execute(command=get_driver_pod, file=f)
+
+with open(results_dir_path + '/driver_logs', 'w') as f:
+    mounts = f'kubectl logs {driver_pod_name} -n kube-system efs-plugin'
+    execute(command=mounts, file=f)
+
+
+def collect_driver_files_under_dir(dir_name, file):
+    collect_driver_files_under_dir = f'kubectl exec {driver_pod_name} -n kube-system -c efs-plugin -- find {dir_name} ' + \
+                                     r'-type f -exec echo {} \; -exec cat {} \; -exec echo \;'
+    execute(command=collect_driver_files_under_dir, file=file)
+
+
+with open(results_dir_path + '/efs_utils_logs', 'w') as f:
+    collect_driver_files_under_dir(dir_name='/var/log/amazon/efs', file=f)
+
+with open(results_dir_path + '/efs_utils_state_dir', 'w') as f:
+    collect_driver_files_under_dir(dir_name='/var/run/efs', file=f)
+
+with open(results_dir_path + '/mounts', 'w') as f:
+    mounts = f'kubectl exec {driver_pod_name} -n kube-system -c efs-plugin -- mount |grep nfs '
+    execute(command=mounts, file=f, shell=True)
+
+with tarfile.open("results.tgz", "w:gz") as tar:
+    tar.add(results_dir_path, arcname=os.path.basename(results_dir_path))


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
feature

**What is this PR about? / Why do we need it?**
Added a script to collect logs and other info for easier troubleshooting.

Info collected:
- driver spec and events
- driver logs
- efs-utils logs
- efs-utils state files
- efs-utils config files
- active mounts

**What testing is done?** 
```
python3 log_collector.py --driver-pod-name efs-csi-node-5dpc4
```
```
$cat results/driver_info

kubectl describe po efs-csi-node-5dpc4 -n kube-system

Name:                 efs-csi-node-5dpc4
Namespace:            kube-system
...

kubectl get po efs-csi-node-5dpc4 -n kube-system -o yaml

apiVersion: v1
kind: Pod
...
```
```
$cat results/driver_logs

kubectl logs efs-csi-node-5dpc4 -n kube-system efs-plugin

I0716 20:05:54.229357       1 mount_linux.go:163] Cannot run systemd-run, assuming non-systemd OS
```

```
$cat results/efs_utils_config_dir

kubectl exec efs-csi-node-5dpc4 -n kube-system -c efs-plugin -- find /etc/amazon/efs -type f -exec echo {} \; -exec cat {} \; -exec echo \;

/etc/amazon/efs/efs-utils.conf

[DEFAULT]
logging_level = INFO
...

/etc/amazon/efs/efs-utils.crt
#
# Copyright 2017-2018 Amazon.com, Inc. and its affiliates. All Rights Reserved.
#
...
```

```
$cat results/efs_utils_logs

kubectl exec efs-csi-node-5dpc4 -n kube-system -c efs-plugin -- find /var/log/amazon/efs -type f -exec echo {} \; -exec cat {} \; -exec echo \;

/var/log/amazon/efs/mount-watchdog.log
2020-07-16 20:05:54,307 - INFO - amazon-efs-mount-watchdog, version 1.24, is enabled and started

/var/log/amazon/efs/mount.log
2020-07-18 00:02:08,906 - INFO - version=1.24 options={'tls': None, 'rw': None}
```

```
$cat results/efs_utils_state_dir

kubectl exec efs-csi-node-5dpc4 -n kube-system -c efs-plugin -- find /var/run/efs -type f -exec echo {} \; -exec cat {} \; -exec echo \;

/var/run/efs/fs-b6654c1c.var.lib.kubelet.pods.3bbc07d6-58ec-4081-b895-36734b1e6fc6.volumes.kubernetes.io~csi.efs-pv.mount.20195
{"files": ["/var/run/efs/stunnel-config.fs-b6654c1c.var.lib.kubelet.pods.
...
```

```
$cat results/mounts

kubectl exec efs-csi-node-5dpc4 -n kube-system -c efs-plugin -- mount |grep nfs 

127.0.0.1:/ on /var/lib/kubelet/pods/3bbc07d6-58ec-4081-b895-36734b1e6fc6/volumes/kubernetes.io~csi/efs-pv/mount type nfs4 (rw,relatime,vers=4.1,rsize=1048576,wsize=1048576,namlen=255,hard,noresvport,proto=tcp,port=20195,timeo=600,retrans=2,sec=sys,clientaddr=127.0.0.1,local_lock=none,addr=127.0.0.1)
```