### PR TITLE
Post-release v1.0.0: update ECR stable overlay image tags to match vanilla stable overlay

### DIFF
--- a/deploy/kubernetes/overlays/stable/ecr/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/ecr/kustomization.yaml
@@ -5,10 +5,10 @@ bases:
 images:
   - name: amazon/aws-efs-csi-driver
     newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/aws-efs-csi-driver
-    newTag: v0.3.0
+    newTag: v1.0.0
   - name: quay.io/k8scsi/livenessprobe
-    newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-liveness-probe
-    newTag: v1.1.0
+    newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/livenessprobe
+    newTag: v2.0.0
   - name: quay.io/k8scsi/csi-node-driver-registrar
     newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-node-driver-registrar
-    newTag: v1.1.0
+    newTag: v1.3.0


### PR DESCRIPTION
**Is this a bug fix or adding new feature?** fix

**What is this PR about? / Why do we need it?** ECR is always going to lag noticeably behind docker hub because GitHub actions push to docker hub but ECR gets pushed via an EKS-specific process. So this PR is post-v1.0.0 release to update the tags.

**What testing is done?** 
aws ecr get-login-password | docker login --username AWS --password-stdin 602401143452.dkr.ecr.us-west-2.amazonaws.com
docker pull 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/livenessprobe:v2.0.0
docker pull 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-node-driver-registrar:v1.3.0