### PR TITLE
Add v1.0.0 to helm index file

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -3,9 +3,9 @@ entries:
   aws-efs-csi-driver:
   - apiVersion: v1
     appVersion: 0.3.0
-    created: "2020-06-23T13:01:01.395061-06:00"
+    created: "2020-07-23T12:17:07.06616-07:00"
     description: A Helm chart for AWS EFS CSI Driver
-    digest: ed4053dbbaf12daa002845031ba774a6a302e2b94e4bece4a46fb8cb4abe4f23
+    digest: 09ece2b079efba4bbea7011e0ecba761b5c7e9b49c3d02291ff8718f2729606b
     home: https://github.com/kubernetes-sigs/aws-efs-csi-driver
     keywords:
     - aws
@@ -19,5 +19,24 @@ entries:
     - https://github.com/kubernetes-sigs/aws-efs-csi-driver
     urls:
     - https://github.com/kubernetes-sigs/aws-efs-csi-driver/releases/download/v0.3.0/helm-chart.tgz
+    version: 0.2.0
+  - apiVersion: v1
+    appVersion: 1.0.0
+    created: "2020-07-23T12:17:07.066881-07:00"
+    description: A Helm chart for AWS EFS CSI Driver
+    digest: f7f8efd1f201dcee3062b9c37153d737fd9c0d1f2a0983890bd8a456727694f4
+    home: https://github.com/kubernetes-sigs/aws-efs-csi-driver
+    keywords:
+    - aws
+    - efs
+    - csi
+    kubeVersion: '>=1.14.0-0'
+    maintainers:
+    - name: leakingtapan
+    name: aws-efs-csi-driver
+    sources:
+    - https://github.com/kubernetes-sigs/aws-efs-csi-driver
+    urls:
+    - https://github.com/kubernetes-sigs/aws-efs-csi-driver/releases/download/v1.0.0/helm-chart.tgz
     version: 0.1.0
-generated: "2020-06-23T13:01:01.394341-06:00"
+generated: "2020-07-23T12:17:07.064801-07:00"


### PR DESCRIPTION
**Is this a bug fix or adding new feature?** NEW

**What is this PR about? / Why do we need it?** 

The helm index file needs to be updated to include the latest release.

I'm not sure if I did this correctly. I downloaded the v0.3.0 and v1.0.0 helm-chart.tgz into my current directory and ran `helm repo index`.

Then I edited the `urls:` field to point to where I downloaded them from.

**What testing is done?** N/A
