### PR TITLE
Fix restart test creating pod on random, potentially wrong, node

### DIFF
--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -223,6 +223,7 @@ var _ = ginkgo.Describe("[efs-csi] EFS CSI", func() {
 
 			ginkgo.By(fmt.Sprintf("Creating pod on node %q to mount pvc %q and run %q", node.Name, pvc.Name, command))
 			pod := e2epod.MakePod(f.Namespace.Name, nil, []*v1.PersistentVolumeClaim{pvc}, false, command)
+			pod.Spec.NodeName = node.Name
 			pod, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(pod)
 			framework.ExpectNoError(err, "creating pod")
 			framework.ExpectNoError(e2epod.WaitForPodNameRunningInNamespace(f.ClientSet, pod.Name, f.Namespace.Name), "waiting for pod running")


### PR DESCRIPTION
**Is this a bug fix or adding new feature?** Bug fix.

**What is this PR about? / Why do we need it?** The test is supposed to create a pod on a certain node and then restart the driver pod on that same node to test that read/write still works. But the test did not specify a node to create the pod on, so actually, since our CI creates 3 nodes, there was only a 33% chance the test was working as intended. Otherwise 66% of the time we were getting false positives.

**What testing is done?**  CI
