### PR TITLE
Actually use the existing nodeSelector value for the deamonset

### DIFF
--- a/helm/templates/daemonset.yaml
+++ b/helm/templates/daemonset.yaml
@@ -22,12 +22,15 @@ spec:
     spec:
       nodeSelector:
         beta.kubernetes.io/os: linux
+        {{- with .Values.nodeSelector }}
+        {{- . | toYaml | nindent 8 }}
+        {{- end }}
       hostNetwork: true
       priorityClassName: system-node-critical
       tolerations:
         - operator: Exists
         {{- with .Values.node.tolerations }}
-{{ toYaml . | indent 8 }}
+        {{- . | toYaml | nindent 8 }}
         {{- end }}
       containers:
         - name: efs-plugin


### PR DESCRIPTION
This allows to select only workers having the EFS mounted via labels.

**Is this a bug fix or adding new feature?**
Bug fix I think.

**What is this PR about? / Why do we need it?**
Improves helm deployment

**What testing is done?** 
Tested on personal test cluster 