### PR TITLE
Fix mounting /etc/amazon/efs in the node-driver-registrar container instead of the efs-plugin one

### DIFF
--- a/deploy/kubernetes/base/node.yaml
+++ b/deploy/kubernetes/base/node.yaml
@@ -41,6 +41,8 @@ spec:
               mountPath: /csi
             - name: efs-state-dir
               mountPath: /var/run/efs
+            - name: efs-utils-config
+              mountPath: /etc/amazon/efs
           ports:
             - containerPort: 9809
               name: healthz
@@ -73,8 +75,6 @@ spec:
               mountPath: /csi
             - name: registration-dir
               mountPath: /registration
-            - name: efs-utils-config
-              mountPath: /etc/amazon/efs
         - name: liveness-probe
           image: quay.io/k8scsi/livenessprobe:v2.0.0
           args:


### PR DESCRIPTION
**Is this a bug fix or adding new feature?** bug fix.

**What is this PR about? / Why do we need it?** Since I put the volume in the wrong container, the contents of /etc/amazon/efs are not persisted across driver restarts. Notably, the privateKey.pem. Which can cause tls mounts to hang.

**What testing is done?** /etc/amazon/efs contains persisted files with this change to the YAML
