### PR TITLE
Add support for node affinity of the daemonset in Helm chart

### DIFF
--- a/helm/templates/daemonset.yaml
+++ b/helm/templates/daemonset.yaml
@@ -29,6 +29,9 @@ spec:
         {{- with .Values.node.tolerations }}
 {{ toYaml . | indent 8 }}
         {{- end }}
+      {{- if .Values.node.affinity }}
+      affinity: {{ toYaml .Values.node.affinity | nident 8 }}
+      {{- end}}
       containers:
         - name: efs-plugin
           securityContext:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -44,3 +44,4 @@ affinity: {}
 node:
   podAnnotations: {}
   tolerations: []
+  affinity: {}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
New feature

**What is this PR about? / Why do we need it?**
Adding support for node affinity of the daemonset in the Helm chart, so that more advanced control over pod scheduling is possible. 
In my case I have a hybrid EKS cluster with both Fargate and EC2 nodes, but as persistent volumes are not supported on Fargate I wish to prevent the daemonset from trying to deploy there.

**What testing is done?** 
Manually tested on the private EKS cluster. Using anti-affinity the daemonset was no longer scheduling pods for the Fargate nodes.