### PR TITLE
Fixed overriding client source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,10 +22,15 @@ COPY go.sum .
 RUN go mod download
 
 ADD . .
+
+# Default client source is `k8s` which can be overriden with –build-arg when building the Docker image
+ARG client_source=k8s
+ENV EFS_CLIENT_SOURCE=$client_source
+
 RUN make aws-efs-csi-driver
 
 FROM amazonlinux:2.0.20200602.0
-RUN yum install util-linux-2.30.2-2.amzn2.0.4.x86_64 amazon-efs-utils-1.26-3.amzn2.noarch -y
+RUN yum install amazon-efs-utils-1.26-3.amzn2.noarch -y
 
 # At image build time, static files installed by efs-utils in the config directory, i.e. CAs file, need
 # to be saved in another place so that the other stateful files created at runtime, i.e. private key for


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Fixed https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/229

**What is this PR about? / Why do we need it?**

**What testing is done?** 
```
docker build -t 705114051414.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-efs-csi-driver:latest .

# launched a new driver and checkout `/etc/amazon/efs/efs-utils.conf`
[client-info] 
source=k8s
```

```
docker build -t 705114051414.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-efs-csi-driver:latest --build-arg client_source=eks.ec2 .

# launched a new driver and checkout `/etc/amazon/efs/efs-utils.conf`
[client-info] 
source=eks.ec2
```