### PR TITLE
Added multi-arch support including ARM.

### DIFF
--- a/.github/workflows/container-image.yaml
+++ b/.github/workflows/container-image.yaml
@@ -8,9 +8,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - name: Build container image
-      run: |
-        docker build -t aws-efs-csi-driver .
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: crazy-max/ghaction-docker-buildx@v3
+      with:
+        buildx-version: latest
+        qemu-version: latest
     - name: Push to Github registry
       run: |
         USER=$(echo $GITHUB_REPOSITORY | cut -d'/' -f1)
@@ -23,6 +26,7 @@ jobs:
           TAG=$BRANCH
         fi
         docker login docker.pkg.github.com -u $USER -p ${{ secrets.REGISTRY_TOKEN }}
+        docker build -t aws-efs-csi-driver .
         docker tag aws-efs-csi-driver docker.pkg.github.com/$GITHUB_REPOSITORY/$IMAGE:$TAG
         docker push docker.pkg.github.com/$GITHUB_REPOSITORY/$IMAGE:$TAG
         if [ "$BRANCH" = "master" ]; then
@@ -40,9 +44,16 @@ jobs:
           TAG=$BRANCH
         fi
         docker login -u ${{ secrets.DOCKERHUB_USER }} -p ${{ secrets.DOCKERHUB_TOKEN }}
-        docker tag aws-efs-csi-driver $REPO:$TAG
-        docker push $REPO:$TAG
+
+        docker buildx build \
+              -t $REPO:$TAG \
+              --platform=linux/amd64,linux/arm64 \
+              --progress plain \
+              --push .
         if [ "$BRANCH" = "master" ]; then
-          docker tag aws-efs-csi-driver $REPO:master
-          docker push $REPO:master
+          docker buildx build \
+                -t $REPO:master \
+                --platform=linux/amd64,linux/arm64 \
+                --progress plain \
+                --push .
         fi

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ VERSION=v1.0.0-dirty
 GIT_COMMIT?=$(shell git rev-parse HEAD)
 BUILD_DATE?=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 EFS_CLIENT_SOURCE?=k8s
+IMAGE_PLATFORMS?=linux/arm64,linux/amd64
 LDFLAGS?="-X ${PKG}/pkg/driver.driverVersion=${VERSION} \
 		  -X ${PKG}/pkg/driver.gitCommit=${GIT_COMMIT} \
 		  -X ${PKG}/pkg/driver.buildDate=${BUILD_DATE} \
@@ -32,6 +33,7 @@ GOPATH=$(shell go env GOPATH)
 .PHONY: aws-efs-csi-driver
 aws-efs-csi-driver:
 	mkdir -p bin
+	@echo GOARCH:${GOARCH}
 	CGO_ENABLED=0 GOOS=linux go build -ldflags ${LDFLAGS} -o bin/aws-efs-csi-driver ./cmd/
 
 build-darwin:
@@ -59,6 +61,14 @@ test-e2e:
 .PHONY: image
 image:
 	docker build -t $(IMAGE):master .
+
+.PHONY: image-multi-arch--push
+image-multi-arch-push:
+	docker buildx build \
+			  -t $(IMAGE):master \
+			  --platform=$(IMAGE_PLATFORMS) \
+			  --progress plain \
+			  --push .
 
 .PHONY: push
 push: image

--- a/deploy/kubernetes/base/node.yaml
+++ b/deploy/kubernetes/base/node.yaml
@@ -16,7 +16,6 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-        kubernetes.io/arch: amd64
       hostNetwork: true
       priorityClassName: system-node-critical
       tolerations:


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
feature. 

**What is this PR about? / Why do we need it?**
Added multi-arch support including ARM.

**What testing is done?** 

Verify the `/bin/aws-efs-csi-driver` binary was ARM when simulating an ARM environment with docker run. 
```
docker run --name aws-efs-csi-driver --platform linux/arm64 --rm --network host  --entrypoint="" -it jqmichael/aws-efs-csi-driver:2 /bin/bash -c "yum -y install file; file /bin/aws-efs-csi-driver"

---
/bin/aws-efs-csi-driver: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, not stripped
```

Launched an `a1` instance, which is ARM architecture, and verified the driver worked with the TLS example (had to use csi-node-driver-registrar from https://github.com/raspbernetes/multi-arch-images since upstream image isn't available yet).