### PR TITLE
deploy/kubernetes/base/node.yaml: Fixing deployment on Bottlerocket.

### DIFF
--- a/deploy/kubernetes/base/node.yaml
+++ b/deploy/kubernetes/base/node.yaml
@@ -101,6 +101,6 @@ spec:
             type: DirectoryOrCreate
         - name: efs-utils-config
           hostPath:
-            path: /etc/amazon/efs
+            path: /var/amazon/efs
             type: DirectoryOrCreate
 


### PR DESCRIPTION
Updated the path where are written efs-utils.conf, efs-utils.crt and
privateKey.pem files to /var/amazon/efs which is one of the few
writeable file systems in Bottlerocket.

**Is this a bug fix or adding new feature?**
This resolves issue #246.

**What is this PR about? / Why do we need it?**
This allows aws-efs-csi-driver to be deployed also on Bottlerocket OS where /etc is read-only.

**What testing is done?** 
aws-efs-csi-driver was successfully deployed on Amazon Linux 2 and Bottlerocket OS.

on Bottlerocket OS
```kubectl get nodes -o wide
NAME                              STATUS   ROLES    AGE   VERSION   INTERNAL-IP       EXTERNAL-IP   OS-IMAGE                KERNEL-VERSION   CONTAINER-RUNTIME
ip-192-168-102-136.ec2.internal   Ready    <none>   14m   v1.17.9   192.168.102.136   <none>        Bottlerocket OS 1.0.1   5.4.50           containerd://1.3.7+unknown
ip-192-168-102-151.ec2.internal   Ready    <none>   14m   v1.17.9   192.168.102.151   <none>        Bottlerocket OS 1.0.1   5.4.50           containerd://1.3.7+unknown
ip-192-168-102-72.ec2.internal    Ready    <none>   14m   v1.17.9   192.168.102.72    <none>        Bottlerocket OS 1.0.1   5.4.50           containerd://1.3.7+unknown

kubectl -n kube-system get pods -l app=efs-csi-node -o wide
NAME                 READY   STATUS    RESTARTS   AGE   IP                NODE                              NOMINATED NODE   READINESS GATES
efs-csi-node-bpxd9   3/3     Running   0          20m   192.168.102.136   ip-192-168-102-136.ec2.internal   <none>           <none>
efs-csi-node-mgzpk   3/3     Running   0          19m   192.168.102.151   ip-192-168-102-151.ec2.internal   <none>           <none>
efs-csi-node-mwfm7   3/3     Running   0          20m   192.168.102.72    ip-192-168-102-72.ec2.internal    <none>           <none>
```


Logs from efs-plugin:
```
kubectl -n kube-system logs efs-csi-node-bpxd9 efs-plugin
0909 20:33:43.690761       1 mount_linux.go:163] Cannot run systemd-run, assuming non-systemd OS
I0909 20:33:43.690825       1 mount_linux.go:164] systemd-run failed with: exit status 1
I0909 20:33:43.690834       1 mount_linux.go:165] systemd-run output:
I0909 20:33:43.691006       1 driver.go:87] Starting watchdog
I0909 20:33:43.691089       1 efs_watch_dog.go:174] Copying /etc/amazon/efs/efs-utils.conf since it doesn't exist
I0909 20:33:43.691155       1 efs_watch_dog.go:174] Copying /etc/amazon/efs/efs-utils.crt since it doesn't exist
I0909 20:33:43.691443       1 driver.go:93] Staring subreaper
I0909 20:33:43.691458       1 driver.go:96] Listening for connections on address: &net.UnixAddr{Name:"/csi/csi.sock", Net:"unix"}
I0909 20:33:45.219276       1 node.go:242] NodeGetInfo: called with args
I0909 20:35:07.764987       1 node.go:226] NodeGetCapabilities: called with args
I0909 20:35:10.413111       1 node.go:226] NodeGetCapabilities: called with args
I0909 20:35:10.414248       1 node.go:51] NodePublishVolume: called with args volume_id:"fs-2f7ccfac:/default/test-efs-pod" target_path:"/var/lib/kubelet/pods/36fdc3f8-e12a-44e8-8c3b-ef75f266ccc2/volumes/kubernetes.io~csi/test-efs-pod-data/mount" volume_capability:<mount:<> access_mode:<mode:SINGLE_NODE_WRITER > > volume_context:<key:"encryptInTransit" value:"true" >
I0909 20:35:10.414314       1 node.go:167] NodePublishVolume: creating dir /var/lib/kubelet/pods/36fdc3f8-e12a-44e8-8c3b-ef75f266ccc2/volumes/kubernetes.io~csi/test-efs-pod-data/mount
I0909 20:35:10.414341       1 node.go:172] NodePublishVolume: mounting fs-2f7ccfac:/default/test-efs-pod at /var/lib/kubelet/pods/36fdc3f8-e12a-44e8-8c3b-ef75f266ccc2/volumes/kubernetes.io~csi/test-efs-pod-data/mount with options [tls]
I0909 20:35:10.414355       1 mount_linux.go:135] Mounting cmd (mount) with arguments ([-t efs -o tls fs-2f7ccfac:/default/test-efs-pod /var/lib/kubelet/pods/36fdc3f8-e12a-44e8-8c3b-ef75f266ccc2/volumes/kubernetes.io~csi/test-efs-pod-data/mount])
```

---
**NOTE**

This PR resolves the deployment of aws-efs-csi-driver to Bottlerocket OS, but there is still an issue to attach EFS to a Pod when running on Bottlerocket OS.

Log from efs-plugin
```
Sep 10 14:56:08 ip-192-168-102-149.ec2.internal kubelet[3687]: E0910 14:56:08.234142    3687 nestedpendingoperations.go:301] Operation for "{volumeName:kubernetes.io/csi/efs.csi.aws.com^fs-2f7ccfac:/default/test-efs-pod podName: nodeName:}" failed. No retries permitted until 2020-09-10 14:58:10.234068793 +0000 UTC m=+2597.763747074 (durationBeforeRetry 2m2s). Error: "MountVolume.SetUp failed for volume \"test-efs-pod-data\" (UniqueName: \"kubernetes.io/csi/efs.csi.aws.com^fs-2f7ccfac:/default/test-efs-pod\") pod \"test-efs-pod-0\" (UID: \"1fdd7f4e-46ef-48c5-a1be-f71864d51449\") : kubernetes.io/csi: mounter.SetupAt failed: rpc error: code = DeadlineExceeded desc = context deadline exceeded"
Sep 10 14:56:26 ip-192-168-102-149.ec2.internal kubelet[3687]: E0910 14:56:26.914296    3687 kubelet.go:1681] Unable to attach or mount volumes for pod "test-efs-pod-0_default(1fdd7f4e-46ef-48c5-a1be-f71864d51449)": unmounted volumes=[test-efs-pod-data], unattached volumes=[test-efs-pod-data test-efs-pod-token-2zppv]: timed out waiting for the condition; skipping pod
Sep 10 14:56:26 ip-192-168-102-149.ec2.internal kubelet[3687]: E0910 14:56:26.915660    3687 pod_workers.go:191] Error syncing pod 1fdd7f4e-46ef-48c5-a1be-f71864d51449 ("test-efs-pod-0_default(1fdd7f4e-46ef-48c5-a1be-f71864d51449)"), skipping: unmounted volumes=[test-efs-pod-data], unattached volumes=[test-efs-pod-data test-efs-pod-token-2zppv]: timed out waiting for the condition
```
Log from kubelet
```
Sep 10 06:59:16 ip-192-168-102-157.ec2.internal kubelet[3589]: I0910 06:59:16.953435    3589 reconciler.go:209] operationExecutor.VerifyControllerAttachedVolume started for volume "test-efs-pod-data" (UniqueName: "kubernetes.io/csi/efs.csi.aws.com^fs-2f7ccfac:/default/test-efs-pod") pod "test-efs-pod-0" (UID: "31bec37a-0b16-441a-b323-70be44dcd57c")
Sep 10 06:59:16 ip-192-168-102-157.ec2.internal kubelet[3589]: I0910 06:59:16.954345    3589 reconciler.go:209] operationExecutor.VerifyControllerAttachedVolume started for volume "test-efs-pod-token-fjjz9" (UniqueName: "kubernetes.io/secret/31bec37a-0b16-441a-b323-70be44dcd57c-test-efs-pod-token-fjjz9") pod "test-efs-pod-0" (UID: "31bec37a-0b16-441a-b323-70be44dcd57c")
Sep 10 06:59:17 ip-192-168-102-157.ec2.internal kubelet[3589]: I0910 06:59:17.056503    3589 clientconn.go:104] parsed scheme: ""
Sep 10 06:59:17 ip-192-168-102-157.ec2.internal kubelet[3589]: I0910 06:59:17.056760    3589 clientconn.go:104] scheme "" not registered, fallback to default scheme
Sep 10 06:59:17 ip-192-168-102-157.ec2.internal kubelet[3589]: I0910 06:59:17.056874    3589 passthrough.go:48] ccResolverWrapper: sending update to cc: {[{/var/lib/kubelet/plugins/efs.csi.aws.com/csi.sock 0  <nil>}] <nil>}
Sep 10 06:59:17 ip-192-168-102-157.ec2.internal kubelet[3589]: I0910 06:59:17.056967    3589 clientconn.go:577] ClientConn switching balancer to "pick_first"
Sep 10 06:59:17 ip-192-168-102-157.ec2.internal kubelet[3589]: I0910 06:59:17.063981    3589 csi_attacher.go:310] kubernetes.io/csi: attacher.MountDevice STAGE_UNSTAGE_VOLUME capability not set. Skipping MountDevice...
Sep 10 06:59:17 ip-192-168-102-157.ec2.internal kubelet[3589]: I0910 06:59:17.064015    3589 operation_generator.go:587] MountVolume.MountDevice succeeded for volume "test-efs-pod-data" (UniqueName: "kubernetes.io/csi/efs.csi.aws.com^fs-2f7ccfac:/default/test-efs-pod") pod "test-efs-pod-0" (UID: "31bec37a-0b16-441a-b323-70be44dcd57c") device mount path "/var/lib/kubelet/plugins/kubernetes.io/csi/pv/test-efs-pod-data/globalmount"
```

---


on Amazon Linux 2 (EKS optimized)


```kubectl get nodes -o wide
NAME                              STATUS   ROLES    AGE   VERSION              INTERNAL-IP       EXTERNAL-IP   OS-IMAGE         KERNEL-VERSION                  CONTAINER-RUNTIME
ip-192-168-102-132.ec2.internal   Ready    <none>   53s   v1.17.9-eks-4c6976   192.168.102.132   <none>        Amazon Linux 2   4.14.193-149.317.amzn2.x86_64   docker://19.3.6
ip-192-168-102-142.ec2.internal   Ready    <none>   82s   v1.17.9-eks-4c6976   192.168.102.142   <none>        Amazon Linux 2   4.14.193-149.317.amzn2.x86_64   docker://19.3.6
ip-192-168-102-91.ec2.internal    Ready    <none>   91s   v1.17.9-eks-4c6976   192.168.102.91    <none>        Amazon Linux 2   4.14.193-149.317.amzn2.x86_64   docker://19.3.6

kubectl -n kube-system get pods -l app=efs-csi-node -o wide
NAME                 READY   STATUS    RESTARTS   AGE   IP                NODE                              NOMINATED NODE   READINESS GATES
efs-csi-node-dwfxh   3/3     Running   0          76s   192.168.102.142   ip-192-168-102-142.ec2.internal   <none>           <none>
efs-csi-node-sg2sn   3/3     Running   0          47s   192.168.102.132   ip-192-168-102-132.ec2.internal   <none>           <none>
efs-csi-node-xfbqx   3/3     Running   0          85s   192.168.102.91    ip-192-168-102-91.ec2.internal    <none>           <none>
```


Logs from efs-plugin:
```
kubectl -n kube-system logs efs-csi-node-sg2sn efs-plugin
I0909 19:44:01.135535       1 mount_linux.go:163] Cannot run systemd-run, assuming non-systemd OS
I0909 19:44:01.135652       1 mount_linux.go:164] systemd-run failed with: exit status 1
I0909 19:44:01.135664       1 mount_linux.go:165] systemd-run output: Failed to create bus connection: No such file or directory
I0909 19:44:01.135819       1 driver.go:87] Starting watchdog
I0909 19:44:01.135905       1 efs_watch_dog.go:174] Copying /etc/amazon/efs/efs-utils.conf since it doesn't exist
I0909 19:44:01.136091       1 efs_watch_dog.go:174] Copying /etc/amazon/efs/efs-utils.crt since it doesn't exist
I0909 19:44:01.137521       1 driver.go:93] Staring subreaper
I0909 19:44:01.137538       1 driver.go:96] Listening for connections on address: &net.UnixAddr{Name:"/csi/csi.sock", Net:"unix"}
I0909 19:44:03.078723       1 node.go:242] NodeGetInfo: called with args
I0909 19:44:17.031525       1 node.go:226] NodeGetCapabilities: called with args
I0909 19:44:17.632663       1 node.go:226] NodeGetCapabilities: called with args
I0909 19:44:17.638825       1 node.go:51] NodePublishVolume: called with args volume_id:"fs-2f7ccfac:/default/test-efs-pod" target_path:"/var/lib/kubelet/pods/befebc5f-ff88-40b1-bab5-8ac778cbf258/volumes/kubernetes.io~csi/test-efs-pod-data/mount" volume_capability:<mount:<> access_mode:<mode:SINGLE_NODE_WRITER > > volume_context:<key:"encryptInTransit" value:"true" >
I0909 19:44:17.638922       1 node.go:167] NodePublishVolume: creating dir /var/lib/kubelet/pods/befebc5f-ff88-40b1-bab5-8ac778cbf258/volumes/kubernetes.io~csi/test-efs-pod-data/mount
I0909 19:44:17.638953       1 node.go:172] NodePublishVolume: mounting fs-2f7ccfac:/default/test-efs-pod at /var/lib/kubelet/pods/befebc5f-ff88-40b1-bab5-8ac778cbf258/volumes/kubernetes.io~csi/test-efs-pod-data/mount with options [tls]
I0909 19:44:17.638970       1 mount_linux.go:135] Mounting cmd (mount) with arguments ([-t efs -o tls fs-2f7ccfac:/default/test-efs-pod /var/lib/kubelet/pods/befebc5f-ff88-40b1-bab5-8ac778cbf258/volumes/kubernetes.io~csi/test-efs-pod-data/mount])
```