### PR TITLE
Bump chart version as appVersion was updated to 1.0.0

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0.0"
 name: aws-efs-csi-driver
 description: A Helm chart for AWS EFS CSI Driver
-version: 0.1.0
+version: 0.2.0
 kubeVersion: ">=1.14.0-0"
 home: https://github.com/kubernetes-sigs/aws-efs-csi-driver
 sources:


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
This fixes https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/235

**What is this PR about? / Why do we need it?**
The helm chart was updated without bumping the chart version. A chart should never be updated like this as it will cause problems with the digest in the index and breaks versioning i.e. someone that expects version 0.1.0 to be consistent and static would have the chart changing underneath them if they ever redeploy the same chart version. To avoid this, changes to the chart require the chart version to be bumped, hence this PR. 