### PR TITLE
Correcting the helm chart imagePullSecrets variable not being used

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0.0"
 name: aws-efs-csi-driver
 description: A Helm chart for AWS EFS CSI Driver
-version: 0.2.0
+version: 0.2.1
 kubeVersion: ">=1.14.0-0"
 home: https://github.com/kubernetes-sigs/aws-efs-csi-driver
 sources:

--- a/helm/templates/daemonset.yaml
+++ b/helm/templates/daemonset.yaml
@@ -20,6 +20,12 @@ spec:
       annotations: {{ toYaml .Values.node.podAnnotations | nindent 8 }}
       {{- end }}
     spec:
+    {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.imagePullSecrets }}
+        - name: {{ . }}
+      {{- end }}
+    {{- end }}
       nodeSelector:
         beta.kubernetes.io/os: linux
         {{- with .Values.nodeSelector }}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
This is a bug

**What is this PR about? / Why do we need it?**
The imagePullSecrets variable from values.yaml is not being used in the daemonset.yaml

It was not possible to use a private registry because there was no possibility to set the username password used.

With this it is now possible to use a private registry.


**What testing is done?** 

Simply set the imagePullSecrets variable like this : 
imagePullSecrets: 
  - aws-efs-csi-driver-pullsecret

When the helm is built you should have the following : 

  template:
    metadata:
      labels:
        app: efs-csi-node
        app.kubernetes.io/name: aws-efs-csi-driver
        app.kubernetes.io/instance: aws-efs-csi-driver
    spec:
      **_imagePullSecrets:
        - name: aws-efs-csi-driver-pullsecret_**
      nodeSelector:
        beta.kubernetes.io/os: linux
      hostNetwork: true
      priorityClassName: system-node-critical
      tolerations:
        - operator: Exists
      containers: