### PR TITLE
Add E2E test flag for EFS file system ID

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -55,6 +55,7 @@ func init() {
 
 	flag.StringVar(&ClusterName, "cluster-name", "", "the cluster name")
 	flag.StringVar(&Region, "region", "us-west-2", "the region")
+	flag.StringVar(&FileSystemId, "file-system-id", "", "the id of an existing file system")
 
 	flag.Parse()
 }


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

Bug fix.

**What is this PR about? / Why do we need it?**

The E2E test suite documentation suggests users supply a `-file-system-id` flag, but no flag exists for this.

**What testing is done?** 

Running E2E test suite against cluster with pre-provisioned EFS file system.