### PR TITLE
feat: Update efs-utils to 1.28.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ ENV EFS_CLIENT_SOURCE=$client_source
 RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} make aws-efs-csi-driver
 
 FROM amazonlinux:2.0.20200602.0
-RUN yum install amazon-efs-utils-1.26-3.amzn2.noarch -y
+RUN yum install amazon-efs-utils-1.28.1-1.amzn2.noarch -y
 
 # At image build time, static files installed by efs-utils in the config directory, i.e. CAs file, need
 # to be saved in another place so that the other stateful files created at runtime, i.e. private key for


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Updates to the latest available efs-utils to enable the use of IAM AssumeRoleWithWebIdentity: https://github.com/aws/efs-utils/pull/60

**What is this PR about? / Why do we need it?**
This makes it possible to secure EFS using a File System Policy and allow only the `efs-csi-node` pods access to a filesystem.

**What testing is done?**
Tested as per: https://github.com/aws/efs-utils/pull/60#issuecomment-667885227
