### PR TITLE
Handled pre-installed CSIDriver object

### DIFF
--- a/helm/templates/csidriver.yaml
+++ b/helm/templates/csidriver.yaml
@@ -2,5 +2,9 @@ apiVersion: storage.k8s.io/v1beta1
 kind: CSIDriver
 metadata:
   name: efs.csi.aws.com
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/resource-policy": keep
 spec:
   attachRequired: false


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
bug fix 

**What is this PR about? / Why do we need it?**
Fix https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/267

With the idea from https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/267#issuecomment-715642179
@jwesolowski-rms 

The catch is that the `efs.csi.aws.com` object will no longer be deleted with `helm uninstall`. 

**What testing is done?** 
With a 1.18 EKS cluster,  `helm install aws-efs-csi-driver ./helm` now works after the change. 