### PR TITLE
Add Makefile target for test e2e binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,11 @@ test-e2e:
 	go get github.com/aws/aws-k8s-tester/e2e/tester/cmd/k8s-e2e-tester@master
 	TESTCONFIG=./tester/e2e-test-config.yaml ${GOPATH}/bin/k8s-e2e-tester
 
+.PHONY: test-e2e-bin
+test-e2e-bin:
+	mkdir -p bin
+	CGO_ENABLED=0 GOOS=linux go test -mod=vendor -ldflags ${LDFLAGS} -c -o bin/test-e2e ./test/e2e/
+
 .PHONY: image
 image:
 	docker build -t $(IMAGE):master .

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -8,6 +8,11 @@ go test -v -timeout 0 ./... -kubeconfig=$HOME/.kube/config -report-dir=$ARTIFACT
   -file-system-id=fs-c2a43e69
 ```
 
+# Make binary
+```sh
+make test-e2e-bin
+```
+
 # Update dependencies
 ```sh
 go mod edit -require=k8s.io/kubernetes@v1.15.3


### PR DESCRIPTION
/sig storage

**Is this a bug fix or adding new feature?**
Adding a new feature.

**What is this PR about? / Why do we need it?**
This PR adds a `Makefile` target to create a binary for the e2e test for this driver. This enables users to execute the EFS e2e tests similarly to how users execute the e2e tests in the k8s repo via the `e2e.test` binary.

**What testing is done?** 
```
# Built test binary locally.
make test-e2e-bin

# Executed e2e tests via binary with existing filesystem, saw tests execute.
bin/test-e2e \
	-kubeconfig=$HOME/.kube/config \
	-ginkgo.focus="should continue reading/writing without hanging after the driver pod is restarted" \
	-ginkgo.skip="\[Disruptive\]" \
	-file-system-id fs-0c7a3009 \
	-region us-west-2
```

@msau42