### PR TITLE
Don't fail making mount dirs if they already exist

### DIFF
--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -204,7 +204,7 @@ var _ = ginkgo.Describe("[efs-csi] EFS CSI", func() {
 			}()
 
 			ginkgo.By(fmt.Sprintf("Creating pod to make subpaths /a and /b"))
-			pod := e2epod.MakePod(f.Namespace.Name, nil, []*v1.PersistentVolumeClaim{pvcRoot}, false, "mkdir /mnt/volume1/a && mkdir /mnt/volume1/b")
+			pod := e2epod.MakePod(f.Namespace.Name, nil, []*v1.PersistentVolumeClaim{pvcRoot}, false, "mkdir -p /mnt/volume1/a && mkdir -p /mnt/volume1/b")
 			pod, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(context.TODO(), pod, metav1.CreateOptions{})
 			framework.ExpectNoError(err, "creating pod")
 			framework.ExpectNoError(e2epod.WaitForPodSuccessInNamespace(f.ClientSet, pod.Name, f.Namespace.Name), "waiting for pod success")


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Bug fix.

**What is this PR about? / Why do we need it?**
When the `should mount different paths on same volume on same node` e2e test is re-ran more than once against the same pre-provisioned EFS file system, the test fails because the first pod in the test repeatedly crashloops. The pod crashloops because `mkdir` fails if the directory already exists. This fixes the issue by ignoring if the directory already exists.

A followup to this might include adding a cleanup step that deletes the files / directories placed on the EFS file system in these tests. Thoughts on this?

**What testing is done?**
```sh
# Pre-provision an EFS file system

# Make the binary.
make test-e2e-bin

# Run test against pre-provisioned EFS file system.
bin/test-e2e \
	-kubeconfig=$HOME/.kube/config \
	-ginkgo.focus="should mount different paths on same volume on same node" \
	-ginkgo.skip="\[Disruptive\]" \
	-ginkgo.dryRun \
	-file-system-id fs-0c7a3009 \
	-region us-west-2

# Run it a second time and observe the test not fail.
bin/test-e2e \
	-kubeconfig=$HOME/.kube/config \
	-ginkgo.focus="should mount different paths on same volume on same node" \
	-ginkgo.skip="\[Disruptive\]" \
	-ginkgo.dryRun \
	-file-system-id fs-0c7a3009 \
	-region us-west-2
```

@msau42 @wongma7 