### PR TITLE
Support for custom SG / subnet IDs for provisioned EFS file system in E2E tests

### DIFF
--- a/test/e2e/cloud.go
+++ b/test/e2e/cloud.go
@@ -48,6 +48,7 @@ func NewCloud(region string) *cloud {
 type CreateOptions struct {
 	ClusterName      string
 	SecurityGroupIds []string
+	SubnetIds        []string
 }
 
 func (c *cloud) CreateFileSystem(opts CreateOptions) (string, error) {
@@ -93,15 +94,19 @@ func (c *cloud) CreateFileSystem(opts CreateOptions) (string, error) {
 		}
 	}
 
-	subnetIds, err := c.getSubnetIds(opts.ClusterName)
-	if err != nil {
-		return "", err
+	subnetIds := aws.StringSlice(opts.SubnetIds)
+	if len(subnetIds) == 0 {
+		matchingSubnetIds, err := c.getSubnetIds(opts.ClusterName)
+		if err != nil {
+			return "", err
+		}
+		subnetIds = aws.StringSlice(matchingSubnetIds)
 	}
 
 	for _, subnetId := range subnetIds {
 		request := &efs.CreateMountTargetInput{
 			FileSystemId:   fileSystemId,
-			SubnetId:       aws.String(subnetId),
+			SubnetId:       subnetId,
 			SecurityGroups: securityGroupIds,
 		}
 

--- a/test/e2e/cloud.go
+++ b/test/e2e/cloud.go
@@ -45,17 +45,21 @@ func NewCloud(region string) *cloud {
 	}
 }
 
-func (c *cloud) CreateFileSystem(clusterName string) (string, error) {
+type CreateOptions struct {
+	ClusterName string
+}
+
+func (c *cloud) CreateFileSystem(opts CreateOptions) (string, error) {
 	tags := []*efs.Tag{
 		{
 			Key:   aws.String("KubernetesCluster"),
-			Value: aws.String(clusterName),
+			Value: aws.String(opts.ClusterName),
 		},
 	}
 
 	// Use cluster name as the token
 	request := &efs.CreateFileSystemInput{
-		CreationToken: aws.String(clusterName),
+		CreationToken: aws.String(opts.ClusterName),
 		Tags:          tags,
 	}
 
@@ -77,12 +81,12 @@ func (c *cloud) CreateFileSystem(clusterName string) (string, error) {
 		return "", err
 	}
 
-	securityGroupId, err := c.getSecurityGroup(clusterName)
+	securityGroupId, err := c.getSecurityGroup(opts.ClusterName)
 	if err != nil {
 		return "", err
 	}
 
-	subnetIds, err := c.getSubnetIds(clusterName)
+	subnetIds, err := c.getSubnetIds(opts.ClusterName)
 	if err != nil {
 		return "", err
 	}

--- a/test/e2e/cloud.go
+++ b/test/e2e/cloud.go
@@ -46,6 +46,7 @@ func NewCloud(region string) *cloud {
 }
 
 type CreateOptions struct {
+	Name             string
 	ClusterName      string
 	SecurityGroupIds []string
 	SubnetIds        []string
@@ -53,6 +54,10 @@ type CreateOptions struct {
 
 func (c *cloud) CreateFileSystem(opts CreateOptions) (string, error) {
 	tags := []*efs.Tag{
+		{
+			Key:   aws.String("Name"),
+			Value: aws.String(opts.Name),
+		},
 		{
 			Key:   aws.String("KubernetesCluster"),
 			Value: aws.String(opts.ClusterName),

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -30,6 +30,7 @@ var (
 	Region                      string
 	FileSystemId                string
 	MountTargetSecurityGroupIds []string
+	MountTargetSubnetIds        []string
 	EfsDriverNamespace          string
 	EfsDriverLabelSelectors     map[string]string
 
@@ -124,6 +125,7 @@ var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
 		opts := CreateOptions{
 			ClusterName:      ClusterName,
 			SecurityGroupIds: MountTargetSecurityGroupIds,
+			SubnetIds:        MountTargetSubnetIds,
 		}
 		id, err := c.CreateFileSystem(opts)
 		if err != nil {

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -26,11 +26,12 @@ var (
 	// Parameters that are expected to be set by consumers of this package.
 	// If FileSystemId is not set, ClusterName and Region must be set so that a
 	// file system can be created
-	ClusterName             string
-	Region                  string
-	FileSystemId            string
-	EfsDriverNamespace      string
-	EfsDriverLabelSelectors map[string]string
+	ClusterName                 string
+	Region                      string
+	FileSystemId                string
+	MountTargetSecurityGroupIds []string
+	EfsDriverNamespace          string
+	EfsDriverLabelSelectors     map[string]string
 
 	deleteFileSystem = false
 
@@ -121,7 +122,8 @@ var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
 		c := NewCloud(Region)
 
 		opts := CreateOptions{
-			ClusterName: ClusterName,
+			ClusterName:      ClusterName,
+			SecurityGroupIds: MountTargetSecurityGroupIds,
 		}
 		id, err := c.CreateFileSystem(opts)
 		if err != nil {

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -119,7 +119,11 @@ var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
 		ginkgo.By(fmt.Sprintf("Creating EFS filesystem in region %q for cluster %q", Region, ClusterName))
 
 		c := NewCloud(Region)
-		id, err := c.CreateFileSystem(ClusterName)
+
+		opts := CreateOptions{
+			ClusterName: ClusterName,
+		}
+		id, err := c.CreateFileSystem(opts)
 		if err != nil {
 			framework.ExpectNoError(err, "creating file system")
 		}

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -29,6 +29,7 @@ var (
 	ClusterName                 string
 	Region                      string
 	FileSystemId                string
+	FileSystemName              string
 	MountTargetSecurityGroupIds []string
 	MountTargetSubnetIds        []string
 	EfsDriverNamespace          string
@@ -123,6 +124,7 @@ var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
 		c := NewCloud(Region)
 
 		opts := CreateOptions{
+			Name:             FileSystemName,
 			ClusterName:      ClusterName,
 			SecurityGroupIds: MountTargetSecurityGroupIds,
 			SubnetIds:        MountTargetSubnetIds,

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -36,9 +36,13 @@ import (
 
 const kubeconfigEnvVar = "KUBECONFIG"
 
-// Combined label selectors in the form of key1=value1,key2=value2.
-// Supplied by users.
-var combinedEfsDriverLabelSelectors string
+// Flag values supplied by users.
+var (
+	// Combined security group IDs in the form sg-0,sg-1,sg-2.
+	combinedMountTargetSecurityGroupIds string
+	// Combined label selectors in the form of key1=value1,key2=value2.
+	combinedEfsDriverLabelSelectors string
+)
 
 func init() {
 	testing.Init()
@@ -59,7 +63,8 @@ func init() {
 
 	flag.StringVar(&ClusterName, "cluster-name", "", "the cluster name")
 	flag.StringVar(&Region, "region", "us-west-2", "the region")
-	flag.StringVar(&FileSystemId, "file-system-id", "", "the id of an existing file system")
+	flag.StringVar(&FileSystemId, "file-system-id", "", "the ID of an existing file system")
+	flag.StringVar(&combinedMountTargetSecurityGroupIds, "mount-target-security-group-ids", "", "comma-separated list of security group IDs to use for mount targets of provisioned EFS file system, only used if -file-system-id is not set")
 	flag.StringVar(&EfsDriverNamespace, "efs-driver-namespace", "kube-system", "namespace of EFS driver pods")
 	flag.StringVar(&combinedEfsDriverLabelSelectors, "efs-driver-label-selectors", "app=efs-csi-node", "comma-separated label selectors for EFS driver pods, follows the form key1=value1,key2=value2")
 
@@ -70,6 +75,7 @@ func init() {
 	if err != nil {
 		log.Fatalln(err)
 	}
+	MountTargetSecurityGroupIds = parseCommaSeparatedStrings(combinedMountTargetSecurityGroupIds)
 }
 
 func TestEFSCSI(t *testing.T) {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -66,6 +66,7 @@ func init() {
 	flag.StringVar(&ClusterName, "cluster-name", "", "the cluster name")
 	flag.StringVar(&Region, "region", "us-west-2", "the region")
 	flag.StringVar(&FileSystemId, "file-system-id", "", "the ID of an existing file system")
+	flag.StringVar(&FileSystemName, "file-system-name", "", "name to use for provisioned EFS file system, only used if -file-system-id is not set")
 	flag.StringVar(&combinedMountTargetSecurityGroupIds, "mount-target-security-group-ids", "", "comma-separated list of security group IDs to use for mount targets of provisioned EFS file system, only used if -file-system-id is not set")
 	flag.StringVar(&combinedMountTargetSubnetIds, "mount-target-subnet-ids", "", "comma-separated list of subnet IDs to use for mount targets of provisioned EFS file system, only used if -file-system-id is not set")
 	flag.StringVar(&EfsDriverNamespace, "efs-driver-namespace", "kube-system", "namespace of EFS driver pods")

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -40,6 +40,8 @@ const kubeconfigEnvVar = "KUBECONFIG"
 var (
 	// Combined security group IDs in the form sg-0,sg-1,sg-2.
 	combinedMountTargetSecurityGroupIds string
+	// Combined subnet IDs in the form subnet-0,subnet-1,subnet-2.
+	combinedMountTargetSubnetIds string
 	// Combined label selectors in the form of key1=value1,key2=value2.
 	combinedEfsDriverLabelSelectors string
 )
@@ -65,6 +67,7 @@ func init() {
 	flag.StringVar(&Region, "region", "us-west-2", "the region")
 	flag.StringVar(&FileSystemId, "file-system-id", "", "the ID of an existing file system")
 	flag.StringVar(&combinedMountTargetSecurityGroupIds, "mount-target-security-group-ids", "", "comma-separated list of security group IDs to use for mount targets of provisioned EFS file system, only used if -file-system-id is not set")
+	flag.StringVar(&combinedMountTargetSubnetIds, "mount-target-subnet-ids", "", "comma-separated list of subnet IDs to use for mount targets of provisioned EFS file system, only used if -file-system-id is not set")
 	flag.StringVar(&EfsDriverNamespace, "efs-driver-namespace", "kube-system", "namespace of EFS driver pods")
 	flag.StringVar(&combinedEfsDriverLabelSelectors, "efs-driver-label-selectors", "app=efs-csi-node", "comma-separated label selectors for EFS driver pods, follows the form key1=value1,key2=value2")
 
@@ -76,6 +79,7 @@ func init() {
 		log.Fatalln(err)
 	}
 	MountTargetSecurityGroupIds = parseCommaSeparatedStrings(combinedMountTargetSecurityGroupIds)
+	MountTargetSubnetIds = parseCommaSeparatedStrings(combinedMountTargetSubnetIds)
 }
 
 func TestEFSCSI(t *testing.T) {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -17,14 +17,12 @@ limitations under the License.
 package e2e
 
 import (
-	"errors"
 	"flag"
 	"fmt"
 	"log"
 	"os"
 	"path"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/onsi/ginkgo"
@@ -36,13 +34,7 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework/testfiles"
 )
 
-const (
-	kubeconfigEnvVar = "KUBECONFIG"
-
-	commaDelim             = ","
-	equalDelim             = "="
-	expectedSelectorTokens = 2
-)
+const kubeconfigEnvVar = "KUBECONFIG"
 
 // Combined label selectors in the form of key1=value1,key2=value2.
 // Supplied by users.
@@ -74,22 +66,10 @@ func init() {
 	flag.Parse()
 
 	var err error
-	EfsDriverLabelSelectors, err = parseCombinedEfsDriverLabelSelectors()
+	EfsDriverLabelSelectors, err = parseCommaSeparatedKVPairs(combinedEfsDriverLabelSelectors)
 	if err != nil {
 		log.Fatalln(err)
 	}
-}
-
-func parseCombinedEfsDriverLabelSelectors() (map[string]string, error) {
-	selectors := map[string]string{}
-	for _, combinedTokens := range strings.Split(combinedEfsDriverLabelSelectors, commaDelim) {
-		selectorTokens := strings.Split(combinedTokens, equalDelim)
-		if len(selectorTokens) != expectedSelectorTokens {
-			return nil, errors.New("failed to parse combined EFS driver label selectors")
-		}
-		selectors[selectorTokens[0]] = selectorTokens[1]
-	}
-	return selectors, nil
 }
 
 func TestEFSCSI(t *testing.T) {

--- a/test/e2e/parse.go
+++ b/test/e2e/parse.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	commaDelim     = ","
+	equalDelim     = "="
+	expectedTokens = 2
+)
+
+func parseCommaSeparatedKVPairs(combined string) (map[string]string, error) {
+	pairs := map[string]string{}
+	for _, combinedTokens := range strings.Split(combined, commaDelim) {
+		tokens := strings.Split(combinedTokens, equalDelim)
+		if len(tokens) != expectedTokens {
+			return nil, fmt.Errorf("failed to parse key=value pair %v", combinedTokens)
+		}
+		pairs[tokens[0]] = tokens[1]
+	}
+	return pairs, nil
+}

--- a/test/e2e/parse.go
+++ b/test/e2e/parse.go
@@ -38,3 +38,10 @@ func parseCommaSeparatedKVPairs(combined string) (map[string]string, error) {
 	}
 	return pairs, nil
 }
+
+func parseCommaSeparatedStrings(combined string) []string {
+	if combined == "" {
+		return []string{}
+	}
+	return strings.Split(combined, commaDelim)
+}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

Adding a new feature.

**What is this PR about? / Why do we need it?**

This PR adds two flags to the E2E test binary:
- `-mount-target-security-group-ids`
- `-mount-target-subnet-ids`

These flags are added to make it easier to provision EFS file systems in the E2E test suite for custom K8s clusters.

**What testing is done?** 

```sh
# Make E2E test binary.
make test-e2e-bin

# Execute E2E test and check it passes.
bin/test-e2e \
	-kubeconfig=$HOME/.kube/config \
	-ginkgo.focus="should continue reading/writing without hanging after the driver pod is restarted" \
	-region=us-west-2 \
	-mount-target-security-group-ids=sg-0,sg-1,sg-2 \
	-mount-target-subnet-ids=subnet-0,subnet-1,subnet-2 \
	-cluster-name=foo
```

@msau42
@wongma7 