### PR TITLE
change config dir location

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN yum install amazon-efs-utils-1.26-3.amzn2.noarch -y
 # client certificate, in the same config directory can be persisted to host with a host path volume.
 # Otherwise creating a host path volume for that directory will clean up everything inside at the first time.
 # Those static files need to be copied back to the config directory when the driver starts up.
-RUN cp -r /etc/amazon/efs /etc/amazon/efs-static-files
+RUN mv /etc/amazon/efs /etc/amazon/efs-static-files
 
 COPY --from=builder /go/src/github.com/kubernetes-sigs/aws-efs-csi-driver/bin/aws-efs-csi-driver /bin/aws-efs-csi-driver
 COPY THIRD-PARTY /

--- a/deploy/kubernetes/base/node.yaml
+++ b/deploy/kubernetes/base/node.yaml
@@ -45,7 +45,9 @@ spec:
             - name: efs-state-dir
               mountPath: /var/run/efs
             - name: efs-utils-config
-              mountPath: /etc/amazon/efs
+              mountPath: /var/amazon/efs
+            - name: efs-utils-config-legacy
+              mountPath: /etc/amazon/efs-legacy
           ports:
             - containerPort: 9809
               name: healthz
@@ -104,6 +106,10 @@ spec:
             path: /var/run/efs
             type: DirectoryOrCreate
         - name: efs-utils-config
+          hostPath:
+            path: /var/amazon/efs
+            type: DirectoryOrCreate
+        - name: efs-utils-config-legacy
           hostPath:
             path: /etc/amazon/efs
             type: DirectoryOrCreate

--- a/helm/templates/daemonset.yaml
+++ b/helm/templates/daemonset.yaml
@@ -76,7 +76,9 @@ spec:
             - name: efs-state-dir
               mountPath: /var/run/efs
             - name: efs-utils-config
-              mountPath: /etc/amazon/efs
+              mountPath: /var/amazon/efs
+            - name: efs-utils-config-legacy
+              mountPath: /etc/amazon/efs-legacy
           ports:
             - name: healthz
               containerPort: 9809
@@ -136,6 +138,10 @@ spec:
             path: /var/run/efs
             type: DirectoryOrCreate
         - name: efs-utils-config
+          hostPath:
+            path: /var/amazon/efs
+            type: DirectoryOrCreate
+        - name: efs-utils-config-legacy
           hostPath:
             path: /etc/amazon/efs
             type: DirectoryOrCreate

--- a/pkg/driver/config_dir.go
+++ b/pkg/driver/config_dir.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package driver
+
+import (
+	"fmt"
+	"k8s.io/klog"
+	"os"
+	"path"
+)
+
+// InitConfigDir decides which of two mounted directories will be used to store driver config files. It creates a
+// symlink at etcAmazonEfs to the chosen location (legacyDir or preferredDir). If neither of these locations is present
+// (i.e. when the user does not need to durably store configs and thus does not mount host directories), an empty
+// directory will be created at etcAmazonEfs.
+//
+// - legacyDir    is the path to a config directory where previous versions of this driver may have written config
+//                files. In previous versions of this driver, a host path that was not writeable on Bottlerocket hosts
+//                was being used, so we introduce preferredDir.
+//
+// - preferredDir is the path to config directory that we will use so long as we do not find files in legacyDir.
+//
+// - etcAmazonEfs is the path where the symlink will be written. In practice, this will always be /etc/amazon/efs, but
+//                we take it as an input so the function can be tested.
+// Examples:
+// On a host that has EFS mounts created by an earlier version of this driver, InitConfigDir will detect a conf file in
+// legacyDir and write a symlink at etcAmazonEfs pointing to legacyDir.
+//
+// On a host that does not have pre-existing legacy EFS mount configs, InitConfigDir will detect no files in  legacyDir
+// and will create a symlink at etcAmazonEfs pointing to preferredDir.
+//
+// For a use case in which durable storage of the configs is not required, and no host volumes are mounted, the function
+// creates an empty directory at etcAmazonEfs.
+//
+// If a symlink already existing at etcAmazonEfs, InitConfigDir does nothing. If something other than a symlink exists
+// at etcAmazonEfs, InitConfigDir returns an error.
+func InitConfigDir(legacyDir, preferredDir, etcAmazonEfs string) error {
+
+	// if there is already a symlink or directory in place, we have nothing to do
+	if _, err := os.Stat(etcAmazonEfs); err == nil {
+		klog.Infof("Symlink or directory exists at '%s', no need to create one", etcAmazonEfs)
+		return nil
+	}
+
+	// if neither legacyDir nor preferredDir exist, create an empty directory.
+	if _, err := os.Stat(preferredDir); err != nil {
+		if _, err := os.Stat(legacyDir); err != nil {
+			klog.Infof("Mounted directories do not exist, creating directory at '%s'", etcAmazonEfs)
+			if err := os.MkdirAll(etcAmazonEfs, 0755); err != nil {
+				return fmt.Errorf(
+					"unable to create directory at '%s': %s",
+					etcAmazonEfs,
+					err.Error())
+			}
+			return nil
+		}
+	}
+
+	// check if a conf file exists in the legacy directory and symlink to the directory if so
+	existingConfFile := path.Join(legacyDir, "efs-utils.conf")
+	if _, err := os.Stat(existingConfFile); err == nil {
+		if err = os.Symlink(legacyDir, etcAmazonEfs); err != nil {
+			return fmt.Errorf(
+				"unable to create symlink from '%s' to '%s': %s",
+				etcAmazonEfs,
+				legacyDir,
+				err.Error())
+		}
+		klog.Infof("Pre-existing config files are being used from '%s'", legacyDir)
+		return nil
+	}
+
+	klog.Infof("Creating symlink from '%s' to '%s'", etcAmazonEfs, preferredDir)
+
+	// create a symlink to the config directory
+	if err := os.Symlink(preferredDir, etcAmazonEfs); err != nil {
+		return fmt.Errorf(
+			"unable to create symlink from '%s' to '%s': %s",
+			etcAmazonEfs,
+			preferredDir,
+			err.Error())
+	}
+
+	return nil
+}

--- a/pkg/driver/config_dir_test.go
+++ b/pkg/driver/config_dir_test.go
@@ -1,0 +1,242 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package driver
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+	"path/filepath"
+	"testing"
+)
+
+func tempDir(t *testing.T) string {
+	dir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatalf("error creating directory %v", err)
+	}
+	return dir
+}
+
+const (
+	// the directory names we will use in these tests (any valid names will work)
+
+	// the path to the legacy mounted directory
+	legacy = "etc-amazon-efs-legacy"
+
+	// the path to the preferred mounted directory
+	preferred = "var-amazon-efs"
+
+	// the path to the canonical path used by mount.efs
+	canonical = "etc"
+
+	// this is a fixed name of a config file used by mount.efs
+	configFilename = "efs-utils.conf"
+
+	// these improve readability
+	createConfig      = true
+	doNotCreateConfig = false
+)
+
+// create creates a directory under tempDir named dirName and optionally adds a file to it, returning the paths
+func create(t *testing.T, tempDir, dirName string, createConfigFile bool) (dirPath, configFilepath string) {
+	dirPath = filepath.Join(tempDir, dirName)
+	if err := os.MkdirAll(dirPath, os.ModePerm); err != nil {
+		t.Fatalf("Unable to create a directory: %v", err)
+	}
+	if createConfigFile {
+		configFilepath = filepath.Join(dirPath, configFilename)
+		if f, err := os.Create(configFilepath); err != nil {
+			t.Fatalf("Unable to create a file: %v", err)
+		} else {
+			if err := f.Close(); err != nil {
+				t.Fatalf("Unable to close a file: %v", err)
+			}
+		}
+	}
+	return dirPath, configFilepath
+}
+
+// assertSymlink asserts that a symlink exists
+func assertSymlink(t *testing.T, from, to string) {
+	// assert symlink is there
+	if _, err := os.Lstat(from); err != nil {
+		t.Fatalf("symlink was not created at %s", from)
+	}
+
+	// create some file using the symlink to be absolutely certain the symlink is correct
+	symlinkFile := path.Join(from, "foo.txt")
+	expectedLocation := path.Join(to, "foo.txt")
+
+	if f, err := os.Create(symlinkFile); err != nil {
+		t.Fatalf("Unable to create file using symlink: %v", err)
+	} else {
+		if err := f.Close(); err != nil {
+			t.Fatalf("Unable to close a file: %v", err)
+		}
+	}
+
+	// assert that the file was created in the legacy dir
+	if _, err := os.Stat(expectedLocation); err != nil {
+		t.Errorf("Something is wrong with the symlink at '%s' which should point to '%s'", from, to)
+	}
+}
+
+func cleanup(t *testing.T, tempDir string) {
+	if err := os.RemoveAll(tempDir); err != nil {
+		t.Fatalf("Unable to delete temp dir: %v", err)
+	}
+}
+
+// TestInitConfigDirPreExistingConfig asserts that a symlink is created to the legacy directory if efs-utils.conf is
+// found there.
+func TestInitConfigDirPreExistingConfig(t *testing.T) {
+	dir := tempDir(t)
+	defer cleanup(t, dir)
+
+	// create legacy dir and a fake pre-existing conf file
+	legacyDir, _ := create(t, dir, legacy, createConfig)
+
+	// create the preferred dir which will go unused
+	preferredDir, _ := create(t, dir, preferred, doNotCreateConfig)
+
+	// the path where a symlink is expected
+	etcAmazonEfs := filepath.Join(dir, canonical)
+
+	// function under test
+	if err := InitConfigDir(legacyDir, preferredDir, etcAmazonEfs); err != nil {
+		t.Fatalf("InitConfigDir returned an error: %v", err)
+	}
+
+	// assert that a symlink exists: etcAmazonEfs -> legacyDir
+	assertSymlink(t, etcAmazonEfs, legacyDir)
+}
+
+// TestInitConfigDirPreferred asserts that a symlink is created to the preferred directory if efs-utils.conf is
+// not found in the legacy location.
+func TestInitConfigDirPreferred(t *testing.T) {
+	dir := tempDir(t)
+	defer cleanup(t, dir)
+
+	// create an empty legacy dir
+	legacyDir, _ := create(t, dir, legacy, doNotCreateConfig)
+
+	// create the preferred dir (symlink should be created with or without pre-existing config here)
+	preferredDir, _ := create(t, dir, preferred, doNotCreateConfig)
+
+	// the path where a symlink is expected
+	etcAmazonEfs := filepath.Join(dir, canonical)
+
+	// function under test
+	if err := InitConfigDir(legacyDir, preferredDir, etcAmazonEfs); err != nil {
+		t.Fatalf("InitConfigDir returned an error: %v", err)
+	}
+
+	// assert that a symlink exists: etcAmazonEfs -> preferredDir
+	assertSymlink(t, etcAmazonEfs, preferredDir)
+}
+
+// TestInitConfigDirDoNothing asserts that a pre-existing symlink is not altered.
+func TestInitConfigDirDoNothing(t *testing.T) {
+	dir := tempDir(t)
+	defer cleanup(t, dir)
+
+	// create an empty legacy dir
+	legacyDir, _ := create(t, dir, legacy, doNotCreateConfig)
+
+	// create the preferred dir
+	preferredDir, _ := create(t, dir, preferred, doNotCreateConfig)
+
+	// the path where a symlink is expected
+	etcAmazonEfs := filepath.Join(dir, canonical)
+
+	// create a symlink
+	if err := InitConfigDir(legacyDir, preferredDir, etcAmazonEfs); err != nil {
+		t.Fatalf("InitConfigDir returned an error: %v", err)
+	}
+
+	// run the function again, as if the container has been started a second time
+	if err := InitConfigDir(legacyDir, preferredDir, etcAmazonEfs); err != nil {
+		t.Fatalf("InitConfigDir returned an error: %v", err)
+	}
+
+	// assert that a symlink exists: etcAmazonEfs -> preferredDir
+	assertSymlink(t, etcAmazonEfs, preferredDir)
+}
+
+// TestInitConfigDirNoMounts asserts that a directory is created at etcAmazonEfs if legacyDir and preferredDir are not
+// mounted.
+func TestInitConfigDirNoMounts(t *testing.T) {
+	dir := tempDir(t)
+	defer cleanup(t, dir)
+
+	missingLegacyDir := filepath.Join(dir, legacy)
+	missingPreferredDir := filepath.Join(dir, legacy)
+	etcAmazonEfs := filepath.Join(dir, canonical)
+
+	// function under test
+	if err := InitConfigDir(missingLegacyDir, missingPreferredDir, etcAmazonEfs); err != nil {
+		t.Fatalf("InitConfigDir returned an error: %v", err)
+	}
+
+	// check that a directory was created
+	if stat, err := os.Stat(etcAmazonEfs); err != nil {
+		t.Errorf("etcAmazonEfs dir was not created: %v", err)
+	} else if !stat.IsDir() {
+		t.Errorf("Something other than directory was created")
+	}
+}
+
+// TestInitConfigDirPreferredError asserts that an error is returned when a symlink cannot be created to the
+// preferredDir
+func TestInitConfigDirPreferredError(t *testing.T) {
+	dir := tempDir(t)
+	defer cleanup(t, dir)
+
+	// create an empty legacy dir
+	legacyDir, _ := create(t, dir, legacy, doNotCreateConfig)
+
+	// create the preferred dir
+	preferredDir, _ := create(t, dir, preferred, doNotCreateConfig)
+
+	etcAmazonEfs := filepath.Join(dir, "bad", "path")
+
+	// function under test
+	if err := InitConfigDir(legacyDir, preferredDir, etcAmazonEfs); err == nil {
+		t.Errorf("Expected an error when calling InitConfigDir")
+	}
+}
+
+// TestInitConfigDirPreExistingConfigError asserts that an error is returned if a symlink cannot be created to the
+// legacyDir.
+func TestInitConfigDirPreExistingConfigError(t *testing.T) {
+	dir := tempDir(t)
+	defer cleanup(t, dir)
+
+	// create legacy dir and a fake pre-existing conf file
+	legacyDir, _ := create(t, dir, legacy, createConfig)
+
+	// create the preferred dir which will go unused
+	preferredDir, _ := create(t, dir, preferred, doNotCreateConfig)
+
+	etcAmazonEfs := filepath.Join(dir, "bad", "path")
+
+	// function under test
+	if err := InitConfigDir(legacyDir, preferredDir, etcAmazonEfs); err == nil {
+		t.Errorf("Expected an error when calling InitConfigDir")
+	}
+}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

Fixes #246
Replaces #247

Fixes https://github.com/bottlerocket-os/bottlerocket/issues/1111

**What is this PR about? / Why do we need it?**

``` text
change config dir location

Before this change, the driver fails to work on Bottlerocket because it
tries to write files into the host directory /etc/amazon/efs. On
Bottlerocket that directory is not writable by the container.

We want to move the host mount point to /var/amazon/efs, but we need to
support backward compatibility with hosts that may already have configs
written to /etc/amazon/efs.

To solve this, we mount both host paths and check for the presence of
config files at container runtime. If we find files in the old location,
we symlink to that location, otherwise we symlink to the new location.
```

**What testing is done?**

I built my changes to a container image, pushed to a private ECR repo, and changed yaml files accordingly to use my changes. Throughout, I used a canary application from these instructions https://docs.aws.amazon.com/eks/latest/userguide/efs-csi.html which mounts an EFS volume and logs to it every five seconds.

- First, I deployed the current production version to a cluster that had one AL2 node and one Bottlerocket node.
  - I observed that the deployment failed on Bottlerocket and succeeded on AL2.
  - I ssh'ed to the AL2 box and confirmed that files had been written to `/etc/amazon/efs`.
  - I confirmed that the canary application was writing logs to the EFS mount, but only on AL2, Bottlerocket was broken.
- Next I deployed my updated version of the efs driver.
  - I observed that pods on both hosts were now healthy and writing to their EFS mounts.
  - I ssh'ed to AL2 and found that `/etc/amazon/efs` was still being used and `/var/amazon/efs` was empty.
  - I ssh'ed to Bottlerocket and found that `/etc/amazon/efs` was empty and `/var/amazon/efs/ was being used.
- I rebooted both nodes and found that when the pods resumed, they were still able to write to their EFS mounts.
- I also deployed my changed driver into a clean cluster and observed that both AL2 and Bottlerocket used `/var/amazon/efs` and that mounts were working.