### PR TITLE
Update chart index to have 1.0.0 as the appVersion

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -2,10 +2,10 @@ apiVersion: v1
 entries:
   aws-efs-csi-driver:
   - apiVersion: v1
-    appVersion: 0.3.0
-    created: "2020-06-23T13:01:01.395061-06:00"
+    appVersion: 1.0.0
+    created: "2020-12-31T14:52:38.5884209-05:00"
     description: A Helm chart for AWS EFS CSI Driver
-    digest: ed4053dbbaf12daa002845031ba774a6a302e2b94e4bece4a46fb8cb4abe4f23
+    digest: f7f8efd1f201dcee3062b9c37153d737fd9c0d1f2a0983890bd8a456727694f4
     home: https://github.com/kubernetes-sigs/aws-efs-csi-driver
     keywords:
     - aws
@@ -18,6 +18,6 @@ entries:
     sources:
     - https://github.com/kubernetes-sigs/aws-efs-csi-driver
     urls:
-    - https://github.com/kubernetes-sigs/aws-efs-csi-driver/releases/download/v0.3.0/helm-chart.tgz
+    - https://github.com/kubernetes-sigs/aws-efs-csi-driver/releases/download/v1.0.0/helm-chart.tgz
     version: 0.1.0
-generated: "2020-06-23T13:01:01.394341-06:00"
+generated: "2020-12-31T14:52:38.5867514-05:00"


### PR DESCRIPTION
The only chart version with available charts releases is 0.1.0 so setting it to the latest appVersion is probably best

**Is this a bug fix or adding new feature?**
The chart index is out of date

**What is this PR about? / Why do we need it?**
This will update the chart index to the current state of the chart.  The chart version hasn't been being incremented but PR #291 should help with this going forward.
