### PR TITLE
Gate controller creation behind helm value

### DIFF
--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -48,9 +48,9 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 Create the name of the service account to use
 */}}
 {{- define "aws-efs-csi-driver.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create -}}
-    {{ default (include "aws-efs-csi-driver.fullname" .) .Values.serviceAccount.name }}
+{{- if .Values.serviceAccount.controller.create -}}
+    {{ default (include "aws-efs-csi-driver.fullname" .) .Values.serviceAccount.controller.name }}
 {{- else -}}
-    {{ default "default" .Values.serviceAccount.name }}
+    {{ default "default" .Values.serviceAccount.controller.name }}
 {{- end -}}
 {{- end -}}

--- a/helm/templates/controller.yaml
+++ b/helm/templates/controller.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.controller.create }}
 # Controller Service
 kind: Deployment
 apiVersion: apps/v1
@@ -34,7 +35,9 @@ spec:
         {{- with .Values.nodeSelector }}
         {{- . | toYaml | nindent 8 }}
         {{- end }}
+      {{- if .Values.serviceAccount.controller.create }}
       serviceAccountName: {{ include "aws-efs-csi-driver.serviceAccountName" . }}
+      {{- end }}
       priorityClassName: system-cluster-critical
       tolerations:
         - operator: Exists
@@ -95,3 +98,4 @@ spec:
       volumes:
         - name: socket-dir
           emptyDir: {}
+{{- end }}

--- a/helm/templates/serviceaccount.yaml
+++ b/helm/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceAccount.create -}}
+{{- if .Values.serviceAccount.controller.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -6,7 +6,7 @@ metadata:
   namespace: kube-system
   labels:
     app.kubernetes.io/name: {{ include "aws-efs-csi-driver.name" . }}
-  {{- with .Values.serviceAccount.annotations }}
+  {{- with .Values.serviceAccount.controller.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
@@ -56,4 +56,4 @@ roleRef:
   kind: ClusterRole
   name: efs-csi-external-provisioner-role
   apiGroup: rbac.authorization.k8s.io
-  {{- end }}
+{{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -26,7 +26,8 @@ fullnameOverride: ""
 
 podAnnotations: {}
 
-resources: {}
+resources:
+  {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -50,7 +51,8 @@ node:
 
 logLevel: 5
 
-hostAliases: {}
+hostAliases:
+  {}
   # for cross VPC EFS, you need to poison or overwrite the DNS for the efs volume as per
   # https://docs.aws.amazon.com/efs/latest/ug/efs-different-vpc.html#wt6-efs-utils-step3
   # implementing the suggested solution found here:
@@ -61,7 +63,8 @@ hostAliases: {}
   #   region: us-east-2
 
 dnsPolicy: ""
-dnsConfig: {}
+dnsConfig:
+  {}
   # Example config which uses the AWS nameservers
   # dnsPolicy: "None"
   # dnsConfig:
@@ -69,9 +72,13 @@ dnsConfig: {}
   #     - 169.254.169.253
 
 serviceAccount:
-  # Specifies whether a service account should be created
-  create: true
-  annotations: {}
-  ## Enable if EKS IAM for SA is used
-  #  eks.amazonaws.com/role-arn: arn:aws:iam::111122223333:role/efs-csi-role
-  name: efs-csi-controller-sa
+  controller:
+    # Specifies whether a service account should be created
+    create: false
+    annotations: {}
+    ## Enable if EKS IAM for SA is used
+    #  eks.amazonaws.com/role-arn: arn:aws:iam::111122223333:role/efs-csi-role
+    name: efs-csi-controller-sa
+
+controller:
+  create: false

--- a/tester/e2e-test-config.yaml
+++ b/tester/e2e-test-config.yaml
@@ -37,7 +37,7 @@ install: |
   wget https://get.helm.sh/$helm_name
   tar xvzf $helm_name
   mv $OS_ARCH/helm /usr/local/bin/helm
-  
+
   AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
   IMAGE_TAG={{TEST_ID}}
   IMAGE_NAME=$AWS_ACCOUNT_ID.dkr.ecr.us-west-2.amazonaws.com/aws-efs-csi-driver
@@ -45,6 +45,8 @@ install: |
   helm install aws-efs-csi-driver \
       --set image.repository=$IMAGE_NAME \
       --set image.tag=$IMAGE_TAG \
+      --set controller.create=true \
+      --set serviceAccount.controller.create=true \
       ./helm
 
 uninstall: |


### PR DESCRIPTION
**Is this a bug fix or adding new feature?** 

**What is this PR about? / Why do we need it?**

I want to release a new version of the driver and a new chart but without the dynamic provisioning changes which deserves its own future release, so I need to gate creation of the controller. After dynamic provisioning is released, this `controller.create` could either be flipped to true or removed altogether in case.

**What testing is done?**  ~~TODO, need to test it on my cluster.~~

I tested on my cluster with 

```
helm upgrade aws-efs-csi-driver \
      --set image.repository=amazon/aws-efs-csi-driver \
      --set image.tag=master \
      --set controller.create=true \
      --set controller.serviceAccount.create=true \
    ./helm
```
and 
```
helm upgrade aws-efs-csi-driver \
      --set image.repository=amazon/aws-efs-csi-driver \
      --set image.tag=master \
    ./helm
```

and work fine. for me.

Now waiting for CI to pass

~~Also want to wait for https://github.com/kubernetes-sigs/aws-efs-csi-driver/pull/291 to merge first but it's not a huge deal if tihs one does~~

Actually this one must merge first so I can make a helm release immediately after, in 291.
