### PR TITLE
feat: Add option to provision StorageClasses

### DIFF
--- a/charts/aws-efs-csi-driver/templates/storageclass.yaml
+++ b/charts/aws-efs-csi-driver/templates/storageclass.yaml
@@ -1,0 +1,15 @@
+{{- range .Values.storageClasses }}
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: {{ .name }}
+provisioner: efs.csi.aws.com
+{{- with .mountOptions }}
+mountOptions: 
+{{ toYaml . }}
+{{- end }}
+{{- with .parameters }}
+parameters:
+{{ toYaml . | indent 2 }}
+{{- end }}
+{{- end }}

--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -82,3 +82,16 @@ serviceAccount:
 
 controller:
   create: false
+
+storageClasses: []
+# Add StorageClass resources like:
+# - name: efs-sc
+#   mountOptions:
+#   - tls
+#   parameters:
+#     provisioningMode: efs-ap
+#     fileSystemId: fs-92107410
+#     directoryPerms: "700"
+#     gidRangeStart: "1000"
+#     gidRangeEnd: "2000"
+#     basePath: "/dynamic_provisioning"


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
New feature in the helm chart

**What is this PR about? / Why do we need it?**
Most application charts don't usually create `StorageClass`es. They create PVCs. This is extending the work done in #274. The chart itself is kind of broken unless `image.tag` is set to "master". #291 will probably address that.

**What testing is done?** 
Installed the chart with the following custom values:

```yaml
image:
  tag: "master"

serviceAccount:
  annotations:
    eks.amazonaws.com/role-arn: arn:aws:iam::<accountId>:role/<roleName>

storageClasses:
- name: efs-sc
  mountOptions:
  - tls
  parameters:
    provisioningMode: efs-ap
    fileSystemId: fs-<id>
    directoryPerms: "700"
```

Then tried creating a PVC and a pod that used it:

```yaml
---
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: efs-claim
spec:
  accessModes:
    - ReadWriteMany
  storageClassName: efs-sc
  resources:
    requests:
      storage: 5Gi
---
apiVersion: v1
kind: Pod
metadata:
  name: efs-app
spec:
  containers:
    - name: app
      image: centos
      command: ["/bin/sh"]
      args: ["-c", "while true; do echo $(date -u) >> /data/out; sleep 5; done"]
      volumeMounts:
        - name: persistent-storage
          mountPath: /data
  volumes:
    - name: persistent-storage
      persistentVolumeClaim:
        claimName: efs-claim
```

Verified the following:
- PV was provisioned.
- EFS access point was created.
- test pod was  writing to EFS as expected.