### PR TITLE
Don't push to unused github registry

### DIFF
--- a/.github/workflows/container-image.yaml
+++ b/.github/workflows/container-image.yaml
@@ -14,25 +14,6 @@ jobs:
       with:
         buildx-version: latest
         qemu-version: latest
-    - name: Push to Github registry
-      run: |
-        USER=$(echo $GITHUB_REPOSITORY | cut -d'/' -f1)
-        BRANCH=$(echo $GITHUB_REF | cut -d'/' -f3)
-        SHORT_SHA=$(echo $GITHUB_SHA | cut -c -7)
-        IMAGE=aws-efs-csi-driver
-        if [ "$BRANCH" = "master" ]; then
-          TAG=$SHORT_SHA
-        else
-          TAG=$BRANCH
-        fi
-        docker login docker.pkg.github.com -u $USER -p ${{ secrets.REGISTRY_TOKEN }}
-        docker build -t aws-efs-csi-driver .
-        docker tag aws-efs-csi-driver docker.pkg.github.com/$GITHUB_REPOSITORY/$IMAGE:$TAG
-        docker push docker.pkg.github.com/$GITHUB_REPOSITORY/$IMAGE:$TAG
-        if [ "$BRANCH" = "master" ]; then
-          docker tag aws-efs-csi-driver docker.pkg.github.com/$GITHUB_REPOSITORY/$IMAGE:master
-          docker push docker.pkg.github.com/$GITHUB_REPOSITORY/$IMAGE:master
-        fi
     - name: Push to Dockerhub registry
       run: |
         BRANCH=$(echo $GITHUB_REF | cut -d'/' -f3)


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

**What is this PR about? / Why do we need it?**

It is not used by anybody, will be superseded* soon, and is not referenced anywhere in the repo, so it is safe to remove.

*https://docs.github.com/en/free-pro-team@latest/packages/guides/configuring-docker-for-use-with-github-packages#publishing-an-image
"Note: The GitHub Packages Docker registry will be superseded by GitHub Container Registry. To learn how to migrate your existing Docker images and any workflows using them, see "Migrating to GitHub Container Registry for Docker images" and "Container guides for GitHub Packages.""

**What testing is done?** 
