### PR TITLE
Add tags to EFS resources. Update EFS Utils

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ ENV EFS_CLIENT_SOURCE=$client_source
 RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} make aws-efs-csi-driver
 
 FROM amazonlinux:2.0.20210126.0
-RUN yum install amazon-efs-utils-1.26-3.amzn2.noarch -y
+RUN yum install amazon-efs-utils-1.28.2-1.amzn2.noarch -y
 
 # At image build time, static files installed by efs-utils in the config directory, i.e. CAs file, need
 # to be saved in another place so that the other stateful files created at runtime, i.e. private key for

--- a/charts/aws-efs-csi-driver/templates/serviceaccount.yaml
+++ b/charts/aws-efs-csi-driver/templates/serviceaccount.yaml
@@ -30,7 +30,7 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["events"]
-    verbs: ["list", "watch", "create", "update", "patch"]
+    verbs: ["list", "watch", "create"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["csinodes"]
     verbs: ["get", "list", "watch"]
@@ -40,6 +40,7 @@ rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["get", "watch", "list", "delete", "update", "create"]
+
 ---
 
 kind: ClusterRoleBinding

--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -18,7 +18,7 @@ sidecars:
     tag: "v1.3.0"
   csiProvisionerImage:
     repository: k8s.gcr.io/sig-storage/csi-provisioner
-    tag: "v2.0.2"
+    tag: "v2.0.4"
 
 imagePullSecrets: []
 nameOverride: ""

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -41,6 +41,7 @@ func main() {
 		volMetricsFsRateLimit    = flag.Int("vol-metrics-fs-rate-limit", 5, "Volume metrics routines rate limiter per file system")
 		deleteAccessPointRootDir = flag.Bool("delete-access-point-root-dir", false,
 			"Opt in to delete access point root directory by DeleteVolume. By default, DeleteVolume will delete the access point behind Persistent Volume and deleting access point will not delete the access point root directory or its contents.")
+		tags = flag.String("tags", "", "Space separated key:value pairs which will be added as tags for EFS resources. For example, 'environment:prod region:us-east-1'")
 	)
 	klog.InitFlags(nil)
 	flag.Parse()
@@ -59,7 +60,7 @@ func main() {
 	if err != nil {
 		klog.Fatalln(err)
 	}
-	drv := driver.NewDriver(*endpoint, etcAmazonEfs, *efsUtilsStaticFilesPath, *volMetricsOptIn, *volMetricsRefreshPeriod, *volMetricsFsRateLimit, *deleteAccessPointRootDir)
+	drv := driver.NewDriver(*endpoint, etcAmazonEfs, *efsUtilsStaticFilesPath, *tags, *volMetricsOptIn, *volMetricsRefreshPeriod, *volMetricsFsRateLimit, *deleteAccessPointRootDir)
 	if err := drv.Run(); err != nil {
 		klog.Fatalln(err)
 	}

--- a/deploy/kubernetes/base/clusterrole-provisioner.yaml
+++ b/deploy/kubernetes/base/clusterrole-provisioner.yaml
@@ -17,7 +17,7 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["events"]
-    verbs: ["list", "watch", "create", "update", "patch"]
+    verbs: ["list", "watch", "create"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["csinodes"]
     verbs: ["get", "list", "watch"]

--- a/deploy/kubernetes/base/controller.yaml
+++ b/deploy/kubernetes/base/controller.yaml
@@ -56,7 +56,7 @@ spec:
             periodSeconds: 10
             failureThreshold: 5
         - name: csi-provisioner
-          image: k8s.gcr.io/sig-storage/csi-provisioner:v2.0.2
+          image: k8s.gcr.io/sig-storage/csi-provisioner:v2.0.4
           args:
             - --csi-address=$(ADDRESS)
             - --v=5

--- a/pkg/cloud/cloud_test.go
+++ b/pkg/cloud/cloud_test.go
@@ -36,12 +36,16 @@ func TestCreateAccessPoint(t *testing.T) {
 					efs: mockEfs,
 				}
 
+				tags := make(map[string]string)
+				tags["cluster"] = "efs"
+
 				req := &AccessPointOptions{
 					FileSystemId:   fsId,
 					Uid:            uid,
 					Gid:            gid,
 					DirectoryPerms: directoryPerms,
 					DirectoryPath:  directoryPath,
+					Tags:           tags,
 				}
 
 				output := &efs.CreateAccessPointOutput{

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -42,6 +42,8 @@ const (
 	DefaultGidMax       = 7000000
 	RootDirPrefix       = "efs-csi-ap"
 	TempMountPathPrefix = "/var/lib/csi/pv"
+	DefaultTagKey       = "efs.csi.aws.com/cluster"
+	DefaultTagValue     = "true"
 )
 
 var (
@@ -92,8 +94,21 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 		return nil, status.Errorf(codes.InvalidArgument, "Missing %v parameter", ProvisioningMode)
 	}
 
+	// Create tags
+	tags := map[string]string{
+		DefaultTagKey: DefaultTagValue,
+	}
+
+	// Append input tags to default tag
+	if len(d.tags) != 0 {
+		for k, v := range d.tags {
+			tags[k] = v
+		}
+	}
+
 	accessPointsOptions := &cloud.AccessPointOptions{
 		CapacityGiB: volSize,
+		Tags:        tags,
 	}
 
 	if value, ok := volumeParams[FsId]; ok {

--- a/pkg/driver/efs_watch_dog.go
+++ b/pkg/driver/efs_watch_dog.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/klog"
 )
 
-// https://github.com/aws/efs-utils/blob/v1.26.3/dist/efs-utils.conf
+// https://github.com/aws/efs-utils/blob/v1.28.2/dist/efs-utils.conf
 const (
 	efsUtilsConfigTemplate = `
 [DEFAULT]
@@ -78,6 +78,14 @@ tls_cert_renewal_interval_min = 60
 
 [client-info] 
 source={{.EfsClientSource}}
+
+[cloudwatch-log]
+# enabled = true
+log_group_name = /aws/efs/utils
+
+# Possible values are : 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, and 3653
+# Comment this config to prevent log deletion
+retention_in_days = 14
 `
 
 	efsUtilsConfigFileName = "efs-utils.conf"

--- a/pkg/driver/efs_watch_dog_test.go
+++ b/pkg/driver/efs_watch_dog_test.go
@@ -72,6 +72,14 @@ tls_cert_renewal_interval_min = 60
 
 [client-info] 
 source=k8s
+
+[cloudwatch-log]
+# enabled = true
+log_group_name = /aws/efs/utils
+
+# Possible values are : 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, and 3653
+# Comment this config to prevent log deletion
+retention_in_days = 14
 `
 	configFileName = "efs-utils.conf"
 )


### PR DESCRIPTION
**What is this PR about? / Why do we need it?**

* Allow adding tags to EFS resources to configure IAM policy condition based on tags.
* Add default tags and provide a command line option to provide more tags.
* Update RBAC permissions and efs-utils version.
*  Fixes #303 

**What testing is done?** 

Tested against my EKS cluster. 

Ran `make test-e2e` on a fresh ec2 instance 
