### PR TITLE
Release v1.1.0

### DIFF
--- a/CHANGELOG-1.x.md
+++ b/CHANGELOG-1.x.md
@@ -1,3 +1,14 @@
+# v1.1.0
+
+## Notable changes
+- The hostPath directory where the driver DaemonSet Pods write state files to their respective Node hosts has changed to fix the driver not working on Bottlerocket OS Nodes. No matter what OS your Nodes are running, you must use a supported method like helm or kustomize to update the driver. If not, i.e. if you only change the image tag of your DaemonSet, the migration from old to new directory won't succeed. See "change config dir location" below for details.
+
+### New Features
+* Implement NodeGetVolumeStats ([#238](https://github.com/kubernetes-sigs/aws-efs-csi-driver/pull/238), [@kbasv](https://github.com/kbasv))
+
+### Bug fixes
+* change config dir location ([#286](https://github.com/kubernetes-sigs/aws-efs-csi-driver/pull/286), [@webern](https://github.com/webern))
+
 # v1.0.0
 [Documentation](https://github.com/kubernetes-sigs/aws-efs-csi-driver/blob/v1.0.0/docs/README.md)
 

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 
 PKG=github.com/kubernetes-sigs/aws-efs-csi-driver
 IMAGE?=amazon/aws-efs-csi-driver
-VERSION=v1.0.0-dirty
+VERSION=v1.1.0-dirty
 GIT_COMMIT?=$(shell git rev-parse HEAD)
 BUILD_DATE?=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 EFS_CLIENT_SOURCE?=k8s

--- a/charts/aws-efs-csi-driver/Chart.yaml
+++ b/charts/aws-efs-csi-driver/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "1.0.0"
+appVersion: "1.1.0"
 name: aws-efs-csi-driver
 description: A Helm chart for AWS EFS CSI Driver
-version: 1.0.0
+version: 1.1.0
 kubeVersion: ">=1.14.0-0"
 home: https://github.com/kubernetes-sigs/aws-efs-csi-driver
 sources:

--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 2
 
 image:
   repository: amazon/aws-efs-csi-driver
-  tag: "v1.0.0"
+  tag: "v1.1.0"
   pullPolicy: IfNotPresent
 
 sidecars:

--- a/deploy/kubernetes/overlays/stable/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/kustomization.yaml
@@ -1,12 +1,11 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 bases:
-- ../../base
+  - ../../base
 images:
-- name: amazon/aws-efs-csi-driver
-  newTag: v1.0.0
-- name: quay.io/k8scsi/livenessprobe
-  newTag: v2.0.0
-- name: quay.io/k8scsi/csi-node-driver-registrar
-  newTag: v1.3.0
-
+  - name: amazon/aws-efs-csi-driver
+    newTag: v1.1.0
+  - name: quay.io/k8scsi/livenessprobe
+    newTag: v2.0.0
+  - name: quay.io/k8scsi/csi-node-driver-registrar
+    newTag: v1.3.0

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,7 @@ The [Amazon Elastic File System](https://aws.amazon.com/efs/) Container Storage 
 | AWS EFS CSI Driver \ CSI Spec Version  | v0.3.0| v1.1.0 | v1.2.0 |
 |----------------------------------------|-------|--------|--------|
 | master branch                          | no    | no     | yes    |
-| v1.0.0                                 | no    | no     | yes    |
+| v1.x.x                                 | no    | no     | yes    |
 | v0.3.0                                 | no    | yes    | no     |
 | v0.2.0                                 | no    | yes    | no     |
 | v0.1.0                                 | yes   | no     | no     |
@@ -33,10 +33,10 @@ Encryption in transit is enabled by default in the master branch version of the 
 The following sections are Kubernetes specific. If you are a Kubernetes user, use this for driver features, installation steps and examples.
 
 ### Kubernetes Version Compability Matrix
-| AWS EFS CSI Driver \ Kubernetes Version| maturity | v1.11 | v1.12 | v1.13 | v1.14 | v1.15 | v1.16 | v1.17 |
+| AWS EFS CSI Driver \ Kubernetes Version| maturity | v1.11 | v1.12 | v1.13 | v1.14 | v1.15 | v1.16 | v1.17+ |
 |----------------------------------------|----------|-------|-------|-------|-------|-------|-------|-------|
 | master branch                          | GA       | no    | no    | no    | yes   | yes   | yes   | yes   |
-| v1.0.0                                 | GA       | no    | no    | no    | yes   | yes   | yes   | yes   |
+| v1.x.x                                 | GA       | no    | no    | no    | yes   | yes   | yes   | yes   |
 | v0.3.0                                 | beta     | no    | no    | no    | yes   | yes   | yes   | yes   |
 | v0.2.0                                 | beta     | no    | no    | no    | yes   | yes   | yes   | yes   |
 | v0.1.0                                 | alpha    | yes   | yes   | yes   | no    | no    | no    | no    |
@@ -45,6 +45,7 @@ The following sections are Kubernetes specific. If you are a Kubernetes user, us
 |EFS CSI Driver Version     | Image                               |
 |---------------------------|-------------------------------------|
 |master branch              |amazon/aws-efs-csi-driver:master     |
+|v1.1.0                     |amazon/aws-efs-csi-driver:v1.1.0     |
 |v1.0.0                     |amazon/aws-efs-csi-driver:v1.0.0     |
 |v0.3.0                     |amazon/aws-efs-csi-driver:v0.3.0     |
 |v0.2.0                     |amazon/aws-efs-csi-driver:v0.2.0     |
@@ -63,7 +64,7 @@ Deploy the driver:
 
 If you want to deploy the stable driver:
 ```sh
-kubectl apply -k "github.com/kubernetes-sigs/aws-efs-csi-driver/deploy/kubernetes/overlays/stable/?ref=release-1.0"
+kubectl apply -k "github.com/kubernetes-sigs/aws-efs-csi-driver/deploy/kubernetes/overlays/stable/?ref=release-1.1"
 ```
 
 If you want to deploy the development driver:


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

Cherry pick of https://github.com/kubernetes-sigs/aws-efs-csi-driver/pull/312/ commit 2 on master


Regarding the helm chart:
The helm chart in master branch is currently unstable and broken. This is a known issue that this PR does NOT fix.

~~I am working on releasing a stable helm chart version v1.1.0 to the helm repo index based on the stable release-1.1 branch, NOT master.~~

helm chart v1.1.0 has been released

https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/307
https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/308
https://github.com/kubernetes-sigs/aws-efs-csi-driver/pull/291


**What is this PR about? / Why do we need it?**

**What testing is done?** 
