### PR TITLE
helm chart: ensure that upgrades do not delete csidriver resource

### DIFF
--- a/charts/aws-efs-csi-driver/templates/csidriver.yaml
+++ b/charts/aws-efs-csi-driver/templates/csidriver.yaml
@@ -3,7 +3,7 @@ kind: CSIDriver
 metadata:
   name: efs.csi.aws.com
   annotations:
-    "helm.sh/hook": pre-install
+    "helm.sh/hook": pre-install, pre-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
     "helm.sh/resource-policy": keep
 spec:


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

Bug fix.

**What is this PR about? / Why do we need it?**

Upgrades of the Helm chart from a version pre-hook addition (52315a522d1a6bc93f04afcfef22b8d256db5f79) to one with the hook will delete the csidriver object without creating another in its place.


**What testing is done?** 

```
$ git checkout v0.3.0
$ cd helm/
$ helm install . --generate-name
...
$ kubectl get csidriver
NAME              CREATED AT
efs.csi.aws.com   2021-02-03T23:56:36Z

$ git checkout v1.1.0
$ helm upgrade chart-1612396594 .
$ kubectl get csidriver
No resources found

$ git checkout <this branch>
$ helm upgrade chart-1612396594 .
$ kubectl get csidriver
NAME              CREATED AT
efs.csi.aws.com   2021-02-04T00:24:51Z
```