### PR TITLE
Daemonset Antiaffinity for Fargate Nodes

### DIFF
--- a/deploy/kubernetes/base/node.yaml
+++ b/deploy/kubernetes/base/node.yaml
@@ -20,6 +20,15 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: eks.amazonaws.com/compute-type
+                operator: NotIn
+                values:
+                - fargate
       hostNetwork: true
       priorityClassName: system-node-critical
       tolerations:


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

Bug fix. Relating to [Issue 328](https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/328)

**What is this PR about? / Why do we need it?**

By default when following the docs at [1] with a mixed ec2/fargate EKS cluster the efs-csi-node DaemonSet will try to schedule to fargate nodes which results in pods becoming stuck in the "Pending" status.

This is easily resolvable with a node anti affinity rule.

[1] https://docs.aws.amazon.com/eks/latest/userguide/efs-csi.html

**What testing is done?** 

I have tested the changes on my branch within a test cluster using the command below which is the exact command from the documentation but with a modified endpoint pointing to my test branch.

```
kubectl apply -k https://github.com/benmccown-amz/aws-efs-csi-driver/deploy/kubernetes/overlays/stable/ecr?ref=daemonset-antiaffinity-fargate
```
