### PR TITLE
Release 1.1.1

### DIFF
--- a/CHANGELOG-1.x.md
+++ b/CHANGELOG-1.x.md
@@ -1,3 +1,8 @@
+# v1.1.1
+
+### Bug fixes
+* Bump AL2 to 20210126.0 ([#326](https://github.com/kubernetes-sigs/aws-efs-csi-driver/pull/326), [@wongma7](https://github.com/wongma7))
+
 # v1.1.0
 
 ## Notable changes

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 
 PKG=github.com/kubernetes-sigs/aws-efs-csi-driver
 IMAGE?=amazon/aws-efs-csi-driver
-VERSION=v1.1.0-dirty
+VERSION=v1.1.1-dirty
 GIT_COMMIT?=$(shell git rev-parse HEAD)
 BUILD_DATE?=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 EFS_CLIENT_SOURCE?=k8s

--- a/deploy/kubernetes/overlays/stable/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/kustomization.yaml
@@ -4,7 +4,7 @@ bases:
   - ../../base
 images:
   - name: amazon/aws-efs-csi-driver
-    newTag: v1.1.0
+    newTag: v1.1.1
   - name: quay.io/k8scsi/livenessprobe
     newTag: v2.0.0
   - name: quay.io/k8scsi/csi-node-driver-registrar

--- a/docs/README.md
+++ b/docs/README.md
@@ -45,6 +45,7 @@ The following sections are Kubernetes specific. If you are a Kubernetes user, us
 |EFS CSI Driver Version     | Image                               |
 |---------------------------|-------------------------------------|
 |master branch              |amazon/aws-efs-csi-driver:master     |
+|v1.1.1                     |amazon/aws-efs-csi-driver:v1.1.1     |
 |v1.1.0                     |amazon/aws-efs-csi-driver:v1.1.0     |
 |v1.0.0                     |amazon/aws-efs-csi-driver:v1.0.0     |
 |v0.3.0                     |amazon/aws-efs-csi-driver:v0.3.0     |

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "1.1.0"
+appVersion: "1.1.1"
 name: aws-efs-csi-driver
 description: A Helm chart for AWS EFS CSI Driver
-version: 1.1.0
+version: 1.1.1
 kubeVersion: ">=1.14.0-0"
 home: https://github.com/kubernetes-sigs/aws-efs-csi-driver
 sources:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 2
 
 image:
   repository: amazon/aws-efs-csi-driver
-  tag: "v1.1.0"
+  tag: "v1.1.1"
   pullPolicy: IfNotPresent
 
 sidecars:


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

**What is this PR about? / Why do we need it?**
push the AL2 bump out.

**What testing is done?** 
CI
 
TODO after this merges:
manually release helm chart 1.1.1
cherry-pick this to master