### PR TITLE
Run chart releaser action from release branches only

### DIFF
--- a/.github/workflows/helm-chart-release.yaml
+++ b/.github/workflows/helm-chart-release.yaml
@@ -3,7 +3,7 @@ name: Release Helm Charts
 on:
   push:
     branches:
-      - master
+      - "release-*"
     paths:
       - "charts/**"
 


### PR DESCRIPTION
**Is this a bug fix or adding new feature?** fixes https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/330

**What is this PR about? / Why do we need it?** I'm finding it doesn't make sense to release helm charts from master branch. We tie kustomize and driver versions to release branches, so we should do the same for helm chart. This way, helm charts are insulated from unstable/broken changes in master branch, for example currently there are dynamic provisioning changes in master branch that I do not wish to release, so it would make more sense for the helm chart to be released from release-1.1 branch which doesn't have those changes.

**What testing is done?** I'll try this on my fork.

edit: it works, but the  release-* branch needs this change as well and also of course expects charts to be under charts/. (release-1.1 is too behind for that atm) https://github.com/wongma7/aws-efs-csi-driver/releases/tag/helm-chart-aws-efs-csi-driver-1.1.99