### PR TITLE
Run chart releaser action from release branches only

### DIFF
--- a/.github/workflows/helm-chart-release.yaml
+++ b/.github/workflows/helm-chart-release.yaml
@@ -1,0 +1,27 @@
+name: Release Helm Charts
+
+on:
+  push:
+    branches:
+      - "release-*"
+    paths:
+      - "charts/**"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.1.0
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        with:
+          config: .github/workflows/cr.yaml


### PR DESCRIPTION
**Is this a bug fix or adding new feature?** master branch version: https://github.com/kubernetes-sigs/aws-efs-csi-driver/pull/333

**What is this PR about? / Why do we need it?**

**What testing is done?** 
