### PR TITLE
helm chart: ensure that upgrades do not delete csidriver resource 

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.1.1"
 name: aws-efs-csi-driver
 description: A Helm chart for AWS EFS CSI Driver
-version: 1.1.1
+version: 1.1.2
 kubeVersion: ">=1.14.0-0"
 home: https://github.com/kubernetes-sigs/aws-efs-csi-driver
 sources:

--- a/helm/templates/csidriver.yaml
+++ b/helm/templates/csidriver.yaml
@@ -3,7 +3,7 @@ kind: CSIDriver
 metadata:
   name: efs.csi.aws.com
   annotations:
-    "helm.sh/hook": pre-install
+    "helm.sh/hook": pre-install, pre-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
     "helm.sh/resource-policy": keep
 spec:


### PR DESCRIPTION
**Is this a bug fix or adding new feature?** cherrypick of https://github.com/kubernetes-sigs/aws-efs-csi-driver/pull/324 into release-1.1 branch so I can make a 1.1.2 helm chart release with the fix.

fixes https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/338

**What is this PR about? / Why do we need it?**

**What testing is done?** 
