### PR TITLE
Add PVC and PV metadata as tags to EFS access points

### DIFF
--- a/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
+++ b/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
@@ -80,6 +80,7 @@ spec:
             - --v=5
             - --feature-gates=Topology=true
             - --leader-election
+            - --extra-create-metadata
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock

--- a/deploy/kubernetes/base/controller-deployment.yaml
+++ b/deploy/kubernetes/base/controller-deployment.yaml
@@ -64,6 +64,7 @@ spec:
             - --v=5
             - --feature-gates=Topology=true
             - --leader-election
+            - --extra-create-metadata
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -31,19 +31,22 @@ import (
 )
 
 const (
-	AccessPointMode     = "efs-ap"
-	FsId                = "fileSystemId"
-	GidMin              = "gidRangeStart"
-	GidMax              = "gidRangeEnd"
-	DirectoryPerms      = "directoryPerms"
-	BasePath            = "basePath"
-	ProvisioningMode    = "provisioningMode"
-	DefaultGidMin       = 50000
-	DefaultGidMax       = 7000000
-	RootDirPrefix       = "efs-csi-ap"
-	TempMountPathPrefix = "/var/lib/csi/pv"
-	DefaultTagKey       = "efs.csi.aws.com/cluster"
-	DefaultTagValue     = "true"
+	AccessPointMode       = "efs-ap"
+	FsId                  = "fileSystemId"
+	GidMin                = "gidRangeStart"
+	GidMax                = "gidRangeEnd"
+	DirectoryPerms        = "directoryPerms"
+	BasePath              = "basePath"
+	ProvisioningMode      = "provisioningMode"
+	DefaultGidMin         = 50000
+	DefaultGidMax         = 7000000
+	RootDirPrefix         = "efs-csi-ap"
+	TempMountPathPrefix   = "/var/lib/csi/pv"
+	DefaultTagKey         = "efs.csi.aws.com/cluster"
+	DefaultTagValue       = "true"
+	PVCNameParameter      = "csi.storage.k8s.io/pvc/name"
+	PVCNameSpaceParameter = "csi.storage.k8s.io/pvc/namespace"
+	PVNameParameter       = "csi.storage.k8s.io/pv/name"
 )
 
 var (
@@ -104,6 +107,16 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 		for k, v := range d.tags {
 			tags[k] = v
 		}
+	}
+
+	if value, ok := volumeParams[PVCNameParameter]; ok {
+		tags[PVCNameParameter] = value
+	}
+	if value, ok := volumeParams[PVCNameSpaceParameter]; ok {
+		tags[PVCNameSpaceParameter] = value
+	}
+	if value, ok := volumeParams[PVNameParameter]; ok {
+		tags[PVNameParameter] = value
 	}
 
 	accessPointsOptions := &cloud.AccessPointOptions{


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
new feature

**What is this PR about? / Why do we need it?**
Gets the extra metadata and adds it as tags to the access point. 

**What testing is done?** 
Tested against my eks cluster.  

Most of this work was based from https://github.com/kubernetes-sigs/aws-efs-csi-driver/pull/309. 