### PR TITLE
Use latest AL2 tag as build base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ ENV EFS_CLIENT_SOURCE=$client_source
 
 RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} make aws-efs-csi-driver
 
-FROM amazonlinux:2.0.20210126.0
+FROM amazonlinux:2
 RUN yum install amazon-efs-utils-1.26-3.amzn2.noarch -y
 
 # At image build time, static files installed by efs-utils in the config directory, i.e. CAs file, need


### PR DESCRIPTION
**Is this a bug fix or adding new feature?** fix

**What is this PR about? / Why do we need it?** Given the difficulty in keeping up with amount of CVEs and whatnot, let's just always use latest AL2 which will have the latest packages.

Ideally we would be distroless and not be affected by packages taht are installed by default in AL2 but we need efs-utils.

**What testing is done?** 
