### PR TITLE
Update compatibility matrix to show master and 1.2.x will require 1.17+

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -50,8 +50,9 @@ The following sections are Kubernetes specific. If you are a Kubernetes user, us
 ### Kubernetes Version Compability Matrix
 | AWS EFS CSI Driver \ Kubernetes Version| maturity | v1.11 | v1.12 | v1.13 | v1.14 | v1.15 | v1.16 | v1.17+ |
 |----------------------------------------|----------|-------|-------|-------|-------|-------|-------|-------|
-| master branch                          | GA       | no    | no    | no    | yes   | yes   | yes   | yes   |
-| v1.x.x                                 | GA       | no    | no    | no    | yes   | yes   | yes   | yes   |
+| master branch                          | GA       | no    | no    | no    | no    | no    | no    | yes   |
+| v1.1.x                                 | GA       | no    | no    | no    | yes   | yes   | yes   | yes   |
+| v1.0.x                                 | GA       | no    | no    | no    | yes   | yes   | yes   | yes   |
 | v0.3.0                                 | beta     | no    | no    | no    | yes   | yes   | yes   | yes   |
 | v0.2.0                                 | beta     | no    | no    | no    | yes   | yes   | yes   | yes   |
 | v0.1.0                                 | alpha    | yes   | yes   | yes   | no    | no    | no    | no    |


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

**What is this PR about? / Why do we need it?** master, and 1.2.x which will be branched off of master shortly,  require 1.17+. Let's fix README in preparation for that.

**What testing is done?** 
