### PR TITLE
Remove helm chart step from release github workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,9 +11,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v1
-      - name: Create Helm chart
-        run: |
-          tar cvzf helm-chart.tgz helm
       - name: Create Release
         id: create-release
         uses: actions/create-release@v1


### PR DESCRIPTION
**Is this a bug fix or adding new feature?** this is obsoleted by the dedicated helm chart workflow and will fail since we moved the charts from helm/ to charts/

**What is this PR about? / Why do we need it?**

**What testing is done?** 
