### PR TITLE
Use ECR sidecars by default in helm and kustomize instead of gcr

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ bin /tmp/helm:
 	@mkdir -p $@
 
 bin/helm: | /tmp/helm bin
-	@curl -o /tmp/helm/helm.tar.gz -sSL https://get.helm.sh/helm-v3.1.2-${GOOS}-amd64.tar.gz
+	@curl -o /tmp/helm/helm.tar.gz -sSL https://get.helm.sh/helm-v3.5.3-${GOOS}-amd64.tar.gz
 	@tar -zxf /tmp/helm/helm.tar.gz -C bin --strip-components=1
 	@rm -rf /tmp/helm/*
 

--- a/charts/aws-efs-csi-driver/Chart.yaml
+++ b/charts/aws-efs-csi-driver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v1
 appVersion: "1.2.0"
 name: aws-efs-csi-driver
 description: A Helm chart for AWS EFS CSI Driver
-version: 1.2.0
-kubeVersion: ">=1.14.0-0"
+version: 1.2.1
+kubeVersion: ">=1.17.0-0"
 home: https://github.com/kubernetes-sigs/aws-efs-csi-driver
 sources:
   - https://github.com/kubernetes-sigs/aws-efs-csi-driver

--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -11,14 +11,14 @@ image:
 
 sidecars:
   livenessProbeImage:
-    repository: k8s.gcr.io/sig-storage/livenessprobe
-    tag: "v2.2.0"
+    repository: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe
+    tag: v2.1.0-eks-1-18-1
   nodeDriverRegistrarImage:
-    repository: k8s.gcr.io/sig-storage/csi-node-driver-registrar
-    tag: "v2.1.0"
+    repository: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar
+    tag: v2.0.1-eks-1-18-1
   csiProvisionerImage:
-    repository: k8s.gcr.io/sig-storage/csi-provisioner
-    tag: "v2.0.3"
+    repository: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner
+    tag: v2.0.3-eks-1-18-1
 
 imagePullSecrets: []
 nameOverride: ""

--- a/deploy/kubernetes/base/controller-deployment.yaml
+++ b/deploy/kubernetes/base/controller-deployment.yaml
@@ -58,7 +58,7 @@ spec:
             periodSeconds: 10
             failureThreshold: 5
         - name: csi-provisioner
-          image: k8s.gcr.io/sig-storage/csi-provisioner:v2.0.3
+          image: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner:v2.0.3-eks-1-18-1
           args:
             - --csi-address=$(ADDRESS)
             - --v=5
@@ -71,7 +71,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: liveness-probe
-          image: k8s.gcr.io/sig-storage/livenessprobe:v2.2.0
+          image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.1.0-eks-1-18-1
           args:
             - --csi-address=/csi/csi.sock
             - --health-port=9808

--- a/deploy/kubernetes/base/node-daemonset.yaml
+++ b/deploy/kubernetes/base/node-daemonset.yaml
@@ -72,7 +72,7 @@ spec:
             periodSeconds: 2
             failureThreshold: 5
         - name: csi-driver-registrar
-          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.1.0
+          image: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar:v2.0.1-eks-1-18-1
           args:
             - --csi-address=$(ADDRESS)
             - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
@@ -92,7 +92,7 @@ spec:
             - name: registration-dir
               mountPath: /registration
         - name: liveness-probe
-          image: k8s.gcr.io/sig-storage/livenessprobe:v2.2.0
+          image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.1.0-eks-1-18-1
           args:
             - --csi-address=/csi/csi.sock
             - --health-port=9809

--- a/deploy/kubernetes/overlays/stable/ecr/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/ecr/kustomization.yaml
@@ -6,12 +6,3 @@ images:
   - name: amazon/aws-efs-csi-driver
     newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/aws-efs-csi-driver
     newTag: v1.2.0
-  - name: quay.io/k8scsi/csi-provisioner
-    newName: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner
-    newTag: v2.0.3-eks-1-18-1
-  - name: quay.io/k8scsi/livenessprobe
-    newName: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe
-    newTag: v2.1.0-eks-1-18-1
-  - name: quay.io/k8scsi/csi-node-driver-registrar
-    newName: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar
-    newTag: v2.0.1-eks-1-18-1

--- a/deploy/kubernetes/overlays/stable/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/kustomization.yaml
@@ -5,9 +5,9 @@ bases:
 images:
   - name: amazon/aws-efs-csi-driver
     newTag: v1.2.0
-  - name: k8s.gcr.io/sig-storage/csi-provisioner
-    newTag: v2.0.3
-  - name: k8s.gcr.io/sig-storage/livenessprobe
-    newTag: v2.2.0
-  - name: k8s.gcr.io/sig-storage/csi-node-driver-registrar
-    newTag: v2.1.0
+  - name: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner
+    newTag: v2.0.3-eks-1-18-1
+  - name: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe
+    newTag: v2.1.0-eks-1-18-1
+  - name: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar
+    newTag: v2.0.1-eks-1-18-1


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

**What is this PR about? / Why do we need it?** 
# helm
- chart v1.2.1: default to getting driver from docker hub and sidecars from ecr public.ecr.aws/eks-distro/kubernetes-csi
# kustomize
- stable overlay: default to getting driver from docker hub and sidecars from ecr public.ecr.aws/eks-distro/kubernetes-csi
- stable/ecr overlay: get driver from ecr 602401143452 and sidecars from ecr public.ecr.aws/eks-distro/kubernetes-csi

**What testing is done?** 
# helm
$ helm upgrade -i aws-efs-csi-driver  ./charts/aws-efs-csi-driver \
                                                          --namespace kube-system

NAME                                 READY   STATUS    RESTARTS   AGE
efs-csi-controller-67b5cd44b-5rlvs   3/3     Running   0          18m
efs-csi-controller-67b5cd44b-8rztb   3/3     Running   0          18m
efs-csi-node-68qfm                   3/3     Running   0          17m
efs-csi-node-dmxg7                   3/3     Running   0          16m
efs-csi-node-n8d8f                   3/3     Running   0          16m
efs-csi-node-rkcps                   3/3     Running   0          17m

$ helm del aws-efs-csi-driver -n kube-system

# kustomize 

$ k apply -k ./deploy/kubernetes/overlays/stable

efs-csi-controller-746bf5488d-kbnqm   3/3     Running   0          31s
efs-csi-controller-746bf5488d-sfxt7   3/3     Running   0          31s
efs-csi-node-9gmft                    3/3     Running   0          31s
efs-csi-node-ghsb8                    3/3     Running   0          31s
efs-csi-node-p5f9x                    3/3     Running   0          31s
efs-csi-node-sp2z2                    3/3     Running   0          31s


$ k apply -k ./deploy/kubernetes/overlays/stable/ecr
efs-csi-controller-67bbc46cd6-nr8sg   3/3     Running   0          34s
efs-csi-controller-67bbc46cd6-qhvvp   3/3     Running   0          40s
efs-csi-node-5qnrd                    3/3     Running   0          32s
efs-csi-node-wrkhx                    3/3     Running   0          18s
efs-csi-node-zn7qw                    3/3     Running   0          7s
efs-csi-node-znsbh                    3/3     Running   0          3s