### PR TITLE
Don't exit script prematurely if test fails

### DIFF
--- a/hack/e2e/run.sh
+++ b/hack/e2e/run.sh
@@ -120,8 +120,10 @@ fi
 loudecho "Testing focus ${GINKGO_FOCUS}"
 eval "EXPANDED_TEST_EXTRA_FLAGS=$TEST_EXTRA_FLAGS"
 set -x
+set +e
 ${GINKGO_BIN} -p -nodes="${GINKGO_NODES}" -v --focus="${GINKGO_FOCUS}" --skip="${GINKGO_SKIP}" "${TEST_PATH}" -- -kubeconfig="${KUBECONFIG}" -report-dir="${ARTIFACTS}" -gce-zone="${ZONES%,*}" "${EXPANDED_TEST_EXTRA_FLAGS}"
 TEST_PASSED=$?
+set -e
 set +x
 loudecho "TEST_PASSED: ${TEST_PASSED}"
 


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

**What is this PR about? / Why do we need it?** PIcking up https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/802 from "upstream" ebs edition of these scripts. otherwise, the script doesn't reach logging part and we can't debug flakes. 

**What testing is done?** 
