### PR TITLE
Add eks fargate antiaffinity to controller (same as is in node)

### DIFF
--- a/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
+++ b/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
@@ -34,6 +34,15 @@ spec:
         {{- with .Values.nodeSelector }}
         {{- . | toYaml | nindent 8 }}
         {{- end }}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: eks.amazonaws.com/compute-type
+                operator: NotIn
+                values:
+                - fargate
       {{- if .Values.serviceAccount.controller.create }}
       serviceAccountName: {{ include "aws-efs-csi-driver.serviceAccountName" . }}
       {{- end }}

--- a/deploy/kubernetes/base/controller-deployment.yaml
+++ b/deploy/kubernetes/base/controller-deployment.yaml
@@ -23,6 +23,15 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: eks.amazonaws.com/compute-type
+                operator: NotIn
+                values:
+                - fargate
       serviceAccountName: efs-csi-controller-sa
       priorityClassName: system-cluster-critical
       tolerations:


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

**What is this PR about? / Why do we need it?** otherwise, the controller could get scheduled to a fargate node where it won't be able to function full y.

I'm going to hold off b umping the helm chart for now, trying to squeeze sidecar image updates in today as well



**What testing is done?** 
