### PR TITLE
 Add `hostNetwork: true` on efs-csi-controller deployement.

### DIFF
--- a/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
+++ b/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
@@ -23,6 +23,7 @@ spec:
       annotations: {{ toYaml .Values.node.podAnnotations | nindent 8 }}
       {{- end }}
     spec:
+      hostNetwork: true 
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- range .Values.imagePullSecrets }}

--- a/deploy/kubernetes/base/controller-deployment.yaml
+++ b/deploy/kubernetes/base/controller-deployment.yaml
@@ -21,6 +21,7 @@ spec:
         app.kubernetes.io/name: aws-efs-csi-driver
         app.kubernetes.io/instance: kustomize
     spec:
+      hostNetwork: true
       nodeSelector:
         kubernetes.io/os: linux
       serviceAccountName: efs-csi-controller-sa

--- a/deploy/kubernetes/base/controller-serviceaccount.yaml
+++ b/deploy/kubernetes/base/controller-serviceaccount.yaml
@@ -47,7 +47,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: efs-csi-controller-sa
-    namespace: default
+    namespace: sample
 roleRef:
   kind: ClusterRole
   name: efs-csi-external-provisioner-role


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
This will add the fix for #313 on helm chart.

**What is this PR about? / Why do we need it?**
As #313 still open, the helm chart needs to enable hostNetwork on `efs-csi-driver` deployment. 

**What testing is done?** 
``` kgpo
+ kubectl get pods
NAME                                           READY   STATUS    RESTARTS   AGE
efs-csi-controller-54967db5bd-nq4qv            3/3     Running   0          9m2s
efs-csi-node-865bp                             3/3     Running   0          3d1h
efs-csi-node-g728g                             3/3     Running   0          3d1h
efs-csi-node-jbplr                             3/3     Running   0          3d1h
efs-csi-node-jdxb7                             3/3     Running   0          3d1h
efs-csi-node-mhmm5                             3/3     Running   0          3d1h
efs-csi-node-npgsc                             3/3     Running   0          3d1h
efs-csi-node-xp4tm                             3/3     Running   0          3d1h```