### PR TITLE
Revert efs-utils to 1.28.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ ENV EFS_CLIENT_SOURCE=$client_source
 RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} make aws-efs-csi-driver
 
 FROM amazonlinux:2.0.20210219.0
-RUN yum install amazon-efs-utils-1.29.1-1.amzn2.noarch -y
+RUN yum install amazon-efs-utils-1.28.2-1.amzn2.noarch -y
 
 # At image build time, static files installed by efs-utils in the config directory, i.e. CAs file, need
 # to be saved in another place so that the other stateful files created at runtime, i.e. private key for


### PR DESCRIPTION
**Is this a bug fix or adding new feature?** /bug

**What is this PR about? / Why do we need it?** I am reasonably sure that this is contributing to the high failure rate https://testgrid.k8s.io/provider-aws-efs-csi-driver#e2e-test&width=20. Locally I ran the test and reproduced the write pod hanginga fter the driver pod restarts (it cannot read or write to the efs mount point). I then replaced the driver pod with a 1.1 version and the mount stopped hanging.

**What testing is done?** 
