### PR TITLE
Fix helm chart external-provisioner RBAC not being created if serviceaccount.controller.create false

### DIFF
--- a/charts/aws-efs-csi-driver/Chart.yaml
+++ b/charts/aws-efs-csi-driver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.2.0"
 name: aws-efs-csi-driver
 description: A Helm chart for AWS EFS CSI Driver
-version: 1.2.1
+version: 1.2.2
 kubeVersion: ">=1.17.0-0"
 home: https://github.com/kubernetes-sigs/aws-efs-csi-driver
 sources:

--- a/charts/aws-efs-csi-driver/templates/_helpers.tpl
+++ b/charts/aws-efs-csi-driver/templates/_helpers.tpl
@@ -48,7 +48,7 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 Create the name of the service account to use
 */}}
 {{- define "aws-efs-csi-driver.serviceAccountName" -}}
-{{- if .Values.serviceAccount.controller.create -}}
+{{- if .Values.controller.create -}}
     {{ default (include "aws-efs-csi-driver.fullname" .) .Values.serviceAccount.controller.name }}
 {{- else -}}
     {{ default "default" .Values.serviceAccount.controller.name }}

--- a/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
+++ b/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
@@ -34,9 +34,7 @@ spec:
         {{- with .Values.nodeSelector }}
         {{- . | toYaml | nindent 8 }}
         {{- end }}
-      {{- if .Values.serviceAccount.controller.create }}
       serviceAccountName: {{ include "aws-efs-csi-driver.serviceAccountName" . }}
-      {{- end }}
       priorityClassName: system-cluster-critical
       tolerations:
         - operator: Exists

--- a/charts/aws-efs-csi-driver/templates/controller-serviceaccount.yaml
+++ b/charts/aws-efs-csi-driver/templates/controller-serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceAccount.controller.create -}}
+{{- if .Values.serviceAccount.controller.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -9,6 +9,7 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+{{- end }}
 ---
 
 kind: ClusterRole
@@ -56,4 +57,3 @@ roleRef:
   kind: ClusterRole
   name: efs-csi-external-provisioner-role
   apiGroup: rbac.authorization.k8s.io
-{{- end }}

--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -90,7 +90,7 @@ storageClasses: []
 #   - tls
 #   parameters:
 #     provisioningMode: efs-ap
-#     fileSystemId: fs-92107410
+#     fileSystemId: fs-1122aabb
 #     directoryPerms: "700"
 #     gidRangeStart: "1000"
 #     gidRangeEnd: "2000"


### PR DESCRIPTION
**Is this a bug fix or adding new feature?** cherry-pick of https://github.com/kubernetes-sigs/aws-efs-csi-driver/pull/377 back onto master so we don't lose the fix in a future release.

**What is this PR about? / Why do we need it?**

**What testing is done?** 
