### PR TITLE
Fix creation of multiple storage classes in Helm chart

### DIFF
--- a/charts/aws-efs-csi-driver/templates/storageclass.yaml
+++ b/charts/aws-efs-csi-driver/templates/storageclass.yaml
@@ -12,4 +12,5 @@ mountOptions:
 parameters:
 {{ toYaml . | indent 2 }}
 {{- end }}
+---
 {{- end }}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
This is a bug fix for https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/387

**What is this PR about? / Why do we need it?**
The PR adds yaml separators to the storageclass template, so that helm can create all storageclasses specified
in `values.yaml`

**What testing is done?**
Applied the changed chart against my local k8s cluster. The outcome was
```
# Source: aws-efs-csi-driver/templates/storageclass.yaml
kind: StorageClass
apiVersion: storage.k8s.io/v1
metadata:
  name: efs-sc1
provisioner: efs.csi.aws.com
parameters:
  directoryPerms: "700"
  fileSystemId: 123
  provisioningMode: efs-ap
---
# Source: aws-efs-csi-driver/templates/storageclass.yaml
kind: StorageClass
apiVersion: storage.k8s.io/v1
metadata:
  name: efs-sc2
provisioner: efs.csi.aws.com
parameters:
  directoryPerms: "700"
  fileSystemId: 345
  provisioningMode: efs-ap
```
