### PR TITLE
release-1.2: Fix creation of multiple storage classes in Helm chart

### DIFF
--- a/charts/aws-efs-csi-driver/templates/storageclass.yaml
+++ b/charts/aws-efs-csi-driver/templates/storageclass.yaml
@@ -12,4 +12,5 @@ mountOptions:
 parameters:
 {{ toYaml . | indent 2 }}
 {{- end }}
+---
 {{- end }}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?** /bug

**What is this PR about? / Why do we need it?** cherry-pick of https://github.com/kubernetes-sigs/aws-efs-csi-driver/pull/388 . Will release a helm chart later today/tomorrow because I was hoping also to include ECRa nd efs-utils changes

**What testing is done?** 
