### PR TITLE
Add resource requests and limits to both DaemonSet and Deployment deployed by the Helm Chart

### DIFF
--- a/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
+++ b/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
@@ -73,6 +73,8 @@ spec:
             timeoutSeconds: 3
             periodSeconds: 10
             failureThreshold: 5
+          resources:
+            {{- toYaml .Values.EFSPlugin.resources | nindent 12 }}
         - name: csi-provisioner
           image: {{ printf "%s:%s" .Values.sidecars.csiProvisionerImage.repository .Values.sidecars.csiProvisionerImage.tag }}
           args:
@@ -86,6 +88,8 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
+          resources:
+            {{- toYaml .Values.CSIProvisioner.resources | nindent 12 }}
         - name: liveness-probe
           image: {{ printf "%s:%s" .Values.sidecars.livenessProbeImage.repository .Values.sidecars.livenessProbeImage.tag }}
           args:
@@ -94,6 +98,8 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+          resources:
+            {{- toYaml .Values.livenessProbe.resources | nindent 12 }}
       volumes:
         - name: socket-dir
           emptyDir: {}

--- a/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
+++ b/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
@@ -99,6 +99,8 @@ spec:
             timeoutSeconds: 3
             periodSeconds: 2
             failureThreshold: 5
+          resources:
+            {{- toYaml .Values.EFSPlugin.resources | nindent 12 }}
         - name: csi-driver-registrar
           image: {{ printf "%s:%s" .Values.sidecars.nodeDriverRegistrarImage.repository .Values.sidecars.nodeDriverRegistrarImage.tag }}
           args:
@@ -119,6 +121,8 @@ spec:
               mountPath: /csi
             - name: registration-dir
               mountPath: /registration
+          resources:
+            {{- toYaml .Values.nodeRegistrar.resources | nindent 12 }}
         - name: liveness-probe
           image: {{ printf "%s:%s" .Values.sidecars.livenessProbeImage.repository .Values.sidecars.livenessProbeImage.tag }}
           args:
@@ -128,6 +132,8 @@ spec:
           volumeMounts:
             - name: plugin-dir
               mountPath: /csi
+          resources:
+            {{- toYaml .Values.livenessProbe.resources | nindent 12 }}
       volumes:
         - name: kubelet-dir
           hostPath:

--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -26,18 +26,21 @@ fullnameOverride: ""
 
 podAnnotations: {}
 
-resources:
-  {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+EFSPlugin:
+  # -- Resource requests and limits for the efs-plugin container in both the Deployment and DaemonSet
+  resources: {}
+
+CSIProvisioner:
+  # -- Resource requests and limits for the csi-provisioner container the Deployment
+  resources: {}
+
+livenessProbe:
+  # -- Resource requests and limits for the liveness-probe container in both the Deployment and DaemonSet
+  resources: {}
+
+nodeRegistrar:
+  # -- Resource requests and limits for the csi-driver-registrar container the DaemonSet
+  resources: {}
 
 nodeSelector: {}
 


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
bugfix
**What is this PR about? / Why do we need it?**
Fix for #283 
**What testing is done?** 
I've rendered the the Helm with all combinations and ran those against a K8s cluster.