### PR TITLE
release-1.2: Bump sidecar images to latest available in ecr

### DIFF
--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -12,13 +12,13 @@ image:
 sidecars:
   livenessProbeImage:
     repository: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe
-    tag: v2.1.0-eks-1-18-1
+    tag: v2.2.0-eks-1-18-2
   nodeDriverRegistrarImage:
     repository: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar
-    tag: v2.0.1-eks-1-18-1
+    tag: v2.1.0-eks-1-18-2
   csiProvisionerImage:
     repository: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner
-    tag: v2.0.3-eks-1-18-1
+    tag: v2.1.1-eks-1-18-2
 
 imagePullSecrets: []
 nameOverride: ""

--- a/deploy/kubernetes/base/controller-deployment.yaml
+++ b/deploy/kubernetes/base/controller-deployment.yaml
@@ -58,7 +58,7 @@ spec:
             periodSeconds: 10
             failureThreshold: 5
         - name: csi-provisioner
-          image: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner:v2.0.3-eks-1-18-1
+          image: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner:v2.1.1-eks-1-18-2
           args:
             - --csi-address=$(ADDRESS)
             - --v=5
@@ -71,7 +71,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: liveness-probe
-          image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.1.0-eks-1-18-1
+          image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.2.0-eks-1-18-2
           args:
             - --csi-address=/csi/csi.sock
             - --health-port=9808

--- a/deploy/kubernetes/base/node-daemonset.yaml
+++ b/deploy/kubernetes/base/node-daemonset.yaml
@@ -72,7 +72,7 @@ spec:
             periodSeconds: 2
             failureThreshold: 5
         - name: csi-driver-registrar
-          image: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar:v2.0.1-eks-1-18-1
+          image: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar:v2.1.0-eks-1-18-2
           args:
             - --csi-address=$(ADDRESS)
             - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
@@ -92,7 +92,7 @@ spec:
             - name: registration-dir
               mountPath: /registration
         - name: liveness-probe
-          image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.1.0-eks-1-18-1
+          image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.2.0-eks-1-18-2
           args:
             - --csi-address=/csi/csi.sock
             - --health-port=9809

--- a/deploy/kubernetes/overlays/stable/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/kustomization.yaml
@@ -5,9 +5,9 @@ bases:
 images:
   - name: amazon/aws-efs-csi-driver
     newTag: v1.2.0
-  - name: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner
-    newTag: v2.0.3-eks-1-18-1
   - name: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe
-    newTag: v2.1.0-eks-1-18-1
+    newTag: v2.2.0-eks-1-18-2
   - name: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar
-    newTag: v2.0.1-eks-1-18-1
+    newTag: v2.1.0-eks-1-18-2
+  - name: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner
+    newTag: v2.1.1-eks-1-18-2


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
master branch edition: https://github.com/kubernetes-sigs/aws-efs-csi-driver/pull/382
**What is this PR about? / Why do we need it?**

**What testing is done?** 
