### PR TITLE
Added http_proxy to the helm chart

### DIFF
--- a/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
+++ b/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
@@ -57,6 +57,14 @@ spec:
           env:
             - name: CSI_ENDPOINT
               value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+            {{- if .Values.controller.proxy.http_proxy }}
+            - name: HTTP_PROXY
+              value: {{ .Values.controller.proxy.http_proxy | quote }}
+            - name: HTTPS_PROXY
+              value: {{ .Values.controller.proxy.http_proxy | quote }}
+            - name: NO_PROXY
+              value: {{ .Values.controller.proxy.no_proxy | quote }}
+            {{- end }}
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/

--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -52,6 +52,7 @@ controller:
   # path on efs when deleteing an access point
   deleteAccessPointRootDir: false
   podAnnotations: {}
+  proxy: {}
   resources:
     {}
     # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
This PR adds the ability of setting proxy variables. Mimics the EBS CSI Driver's [implementation](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/charts/aws-ebs-csi-driver/templates/controller.yaml#L97). 

**What is this PR about? / Why do we need it?**
Closes #409 

**What testing is done?** 
This was tested by upgrading a release and by creating a new release.