### PR TITLE
feat: add helm config to enable deleteAccessPointRootDir

### DIFF
--- a/charts/aws-efs-csi-driver/Chart.yaml
+++ b/charts/aws-efs-csi-driver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.2.0"
 name: aws-efs-csi-driver
 description: A Helm chart for AWS EFS CSI Driver
-version: 1.2.2
+version: 1.2.3
 kubeVersion: ">=1.17.0-0"
 home: https://github.com/kubernetes-sigs/aws-efs-csi-driver
 sources:

--- a/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
+++ b/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
@@ -50,9 +50,8 @@ spec:
           args:
             - --endpoint=$(CSI_ENDPOINT)
             - --logtostderr
-            - --v=5
-            # Uncomment below line to allow access point root directory to be deleted by controller.
-            #- --delete-access-point-root-dir
+            - --v={{ .Values.logLevel }}
+            - --delete-access-point-root-dir={{ hasKey .Values.controller "deleteAccessPointRootDir" | ternary .Values.controller.deleteAccessPointRootDir false }}
           env:
             - name: CSI_ENDPOINT
               value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
@@ -75,7 +74,7 @@ spec:
           image: {{ printf "%s:%s" .Values.sidecars.csiProvisionerImage.repository .Values.sidecars.csiProvisionerImage.tag }}
           args:
             - --csi-address=$(ADDRESS)
-            - --v=5
+            - --v={{ .Values.logLevel }}
             - --feature-gates=Topology=true
             - --leader-election
           env:

--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -82,6 +82,9 @@ serviceAccount:
 
 controller:
   create: true
+  # Enable if you want the controller to also delete the
+  # path on efs when deleteing an access point
+  deleteAccessPointRootDir: false
 
 storageClasses: []
 # Add StorageClass resources like:


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
This is a new feature. (Also includes very minor fix for the log level in the controller deployment for the log level)
**What is this PR about? / Why do we need it?**
It adds the ability to enable the --delete-access-point-root-dir flag on the controller deployments efs-plugin sidecar.
**What testing is done?** 
Talked about the flag in #411 
I'd suggest to use it like this in helm. If the value is set to false or is omitted, then the flag will be set to false. If the value is set to true, then it will be set to true. This way we don't have to change the chart again, if the default behavior of the flag will be changed, like if it would default to true.
Merged this pr in my fork and rolled it out in a cluster.