### PR TITLE
feat: add controller access point tags to helm chart

### DIFF
--- a/charts/aws-efs-csi-driver/Chart.yaml
+++ b/charts/aws-efs-csi-driver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.2.0"
 name: aws-efs-csi-driver
 description: A Helm chart for AWS EFS CSI Driver
-version: 1.2.1
+version: 1.2.2
 kubeVersion: ">=1.17.0-0"
 home: https://github.com/kubernetes-sigs/aws-efs-csi-driver
 sources:

--- a/charts/aws-efs-csi-driver/templates/_helpers.tpl
+++ b/charts/aws-efs-csi-driver/templates/_helpers.tpl
@@ -54,3 +54,14 @@ Create the name of the service account to use
     {{ default "default" .Values.serviceAccount.controller.name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Create a string out of the map for controller tags flag
+*/}}
+{{- define "aws-efs-csi-driver.tags" -}}
+{{- $tags := list -}}
+{{ range $key, $val := . }}
+{{- $tags = print $key ":" $val | append $tags -}}
+{{- end -}}
+{{- join " " $tags -}}
+{{- end -}}

--- a/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
+++ b/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
@@ -53,6 +53,9 @@ spec:
             - --endpoint=$(CSI_ENDPOINT)
             - --logtostderr
             - --v=5
+            {{- if .Values.controller.tags }}
+            - --tags={{ include "aws-efs-csi-driver.tags" .Values.controller.tags }}
+            {{- end }}
             # Uncomment below line to allow access point root directory to be deleted by controller.
             #- --delete-access-point-root-dir
           env:

--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -82,6 +82,10 @@ serviceAccount:
 
 controller:
   create: true
+  # Add additional tags to access points
+  tags: {}
+    # environment: prod
+    # region: us-east-1
 
 storageClasses: []
 # Add StorageClass resources like:


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Feature
**What is this PR about? / Why do we need it?**
This adds the ability to add a parameter to the tags flag.
**What testing is done?** 
Specifying tags can be done using a map inside values.yaml.
If the tags map is empty, the flag will not be appended.
If tags are assigned in .Values.controller.tags those tags will be merged to a string joined by spaces like so:
values.yaml:
```
controller:
  create: true
  # Add additional tags to access points
  tags:
    environment: prod
    region: us-east-1
```
output:
```
kind: Deployment
apiVersion: apps/v1
metadata:
  name: efs-csi-controller
...
spec:
...
    spec:
...
      containers:
        - name: efs-plugin
...
          args:
...
            - --tags=environment:prod region:us-east-1
```

*Note* that the tag string isn't quoted on purpose, since the params are properly passed over by kubernetes and the efs-plugin will handle them wrongly if there are extra quotes:

for example when extra quotes are used:
```
efs-csi-controller-789b5d5884-fhlsq efs-plugin     {
efs-csi-controller-789b5d5884-fhlsq efs-plugin       Key: "\"cluster-name",
efs-csi-controller-789b5d5884-fhlsq efs-plugin       Value: "demo\""
efs-csi-controller-789b5d5884-fhlsq efs-plugin     }
```
To fully test this I have forked this repo, merged the pr, created a new chart version and installed it with terraform into a cluster and added various tags. This created tagged access points inside aws like expected:
![image](https://user-images.githubusercontent.com/40307978/114737753-9bf9a480-9d47-11eb-916e-72de8cc702bb.png)
