### PR TITLE
feat: helm add storageclass annotations

### DIFF
--- a/charts/aws-efs-csi-driver/Chart.yaml
+++ b/charts/aws-efs-csi-driver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.2.0"
 name: aws-efs-csi-driver
 description: A Helm chart for AWS EFS CSI Driver
-version: 1.2.2
+version: 1.2.3
 kubeVersion: ">=1.17.0-0"
 home: https://github.com/kubernetes-sigs/aws-efs-csi-driver
 sources:

--- a/charts/aws-efs-csi-driver/templates/storageclass.yaml
+++ b/charts/aws-efs-csi-driver/templates/storageclass.yaml
@@ -3,9 +3,13 @@ kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
   name: {{ .name }}
+  {{- with .annotations }}
+  annotations:
+  {{ toYaml . | indent 4 }}
+  {{- end }}
 provisioner: efs.csi.aws.com
 {{- with .mountOptions }}
-mountOptions: 
+mountOptions:
 {{ toYaml . }}
 {{- end }}
 {{- with .parameters }}

--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -86,6 +86,9 @@ controller:
 storageClasses: []
 # Add StorageClass resources like:
 # - name: efs-sc
+##  Use that annotation if you want this to your default storageclass
+#   annotations:
+#     storageclass.kubernetes.io/is-default-class: "true"
 #   mountOptions:
 #   - tls
 #   parameters:


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Feature
**What is this PR about? / Why do we need it?**
Small feature to enable helm users to add annotations to the storageclass to make it the default storageclass for example
**What testing is done?** 
Deployed it to a cluster