### PR TITLE
Add empty StorageClasses from static example

### DIFF
--- a/examples/kubernetes/static_provisioning/specs/claim.yaml
+++ b/examples/kubernetes/static_provisioning/specs/claim.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
+  storageClassName: ""
   resources:
     requests:
       storage: 5Gi

--- a/examples/kubernetes/static_provisioning/specs/pv.yaml
+++ b/examples/kubernetes/static_provisioning/specs/pv.yaml
@@ -8,6 +8,7 @@ spec:
   volumeMode: Filesystem
   accessModes:
     - ReadWriteOnce
+  storageClassName: ""
   persistentVolumeReclaimPolicy: Retain
   csi:
     driver: efs.csi.aws.com


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Fix static sample missing empty storageclasses

**What is this PR about? / Why do we need it?**
In the current static example, PV and PVC lack empty StorageClasses, so PVC cannot bind PV

**What testing is done?** 
Add empty StorageClasses and apply