### PR TITLE
Fix verify command

### DIFF
--- a/examples/kubernetes/dynamic_provisioning/README.md
+++ b/examples/kubernetes/dynamic_provisioning/README.md
@@ -45,5 +45,5 @@ After the objects are created, verify that pod is running:
 Also you can verify that data is written onto EFS filesystem:
 
 ```sh
->> kubectl exec -ti efs-app -- tail -f /data/out.txt
+>> kubectl exec -ti efs-app -- tail -f /data/out
 ```


### PR DESCRIPTION
The file in the mountpath in the pod is `out` instead of `out.txt`
```bash
[root@efs-app /]# ls
bin  data  dev	etc  home  lib	lib64  lost+found  media  mnt  opt  proc  root	run  sbin  srv	sys  tmp  usr  var
[root@efs-app /]# cd data
[root@efs-app data]# ls
out
[root@efs-app data]# pwd
/data
[root@efs-app data]#

$ kubectl exec -ti efs-app -- tail -f /data/out.txt
tail: cannot open '/data/out.txt' for reading: No such file or directory
tail: no files remaining
command terminated with exit code 1
$ kubectl exec -ti efs-app -- tail -f /data/out
Sun Apr 25 11:59:59 UTC 2021
Sun Apr 25 12:00:04 UTC 2021
Sun Apr 25 12:00:09 UTC 2021
Sun Apr 25 12:00:14 UTC 2021
```

**Is this a bug fix or adding new feature?**

**What is this PR about? / Why do we need it?**

**What testing is done?** 
