### PR TITLE
Add x-AZ mount support for efs-csi-driver

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ ENV EFS_CLIENT_SOURCE=$client_source
 RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} make aws-efs-csi-driver
 
 FROM amazonlinux:2.0.20210219.0
-RUN yum install amazon-efs-utils-1.28.2-1.amzn2.noarch -y
+RUN yum install amazon-efs-utils-1.30.1-1.amzn2.noarch -y
 
 # At image build time, static files installed by efs-utils in the config directory, i.e. CAs file, need
 # to be saved in another place so that the other stateful files created at runtime, i.e. private key for

--- a/pkg/driver/efs_watch_dog.go
+++ b/pkg/driver/efs_watch_dog.go
@@ -26,9 +26,17 @@ import (
 	"k8s.io/klog"
 )
 
-// https://github.com/aws/efs-utils/blob/v1.28.2/dist/efs-utils.conf
+// https://github.com/aws/efs-utils/blob/v1.30.2/dist/efs-utils.conf
 const (
 	efsUtilsConfigTemplate = `
+#
+# Copyright 2017-2018 Amazon.com, Inc. and its affiliates. All Rights Reserved.
+#
+# Licensed under the MIT License. See the LICENSE accompanying this file
+# for the specific language governing permissions and limitations under
+# the License.
+#
+
 [DEFAULT]
 logging_level = INFO
 logging_max_bytes = 1048576
@@ -37,7 +45,7 @@ logging_file_count = 10
 state_file_dir_mode = 750
 
 [mount]
-dns_name_format = {fs_id}.efs.{region}.{dns_name_suffix}
+dns_name_format = {az}.{fs_id}.efs.{region}.{dns_name_suffix}
 dns_name_suffix = amazonaws.com
 #The region of the file system when mounting from on-premises or cross region.
 {{if .Region -}}
@@ -60,17 +68,25 @@ stunnel_check_cert_validity = false
 port_range_lower_bound = 20049
 port_range_upper_bound = 20449
 
+# Optimize read_ahead_kb for Linux 5.4+
+optimize_readahead = true
+
+
 [mount.cn-north-1]
 dns_name_suffix = amazonaws.com.cn
+
 
 [mount.cn-northwest-1]
 dns_name_suffix = amazonaws.com.cn
 
+
 [mount.us-iso-east-1]
 dns_name_suffix = c2s.ic.gov
+stunnel_cafile = /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
 
 [mount.us-isob-east-1]
 dns_name_suffix = sc2s.sgov.gov
+stunnel_cafile = /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
 
 [mount-watchdog]
 enabled = true
@@ -248,7 +264,7 @@ func (w *execWatchdog) runLoop(stopCh <-chan struct{}) {
 	for {
 		select {
 		case <-stopCh:
-			klog.Info("stopping...")
+			//klog.Info("stopping...")
 			break
 		default:
 			err := w.exec()

--- a/pkg/driver/efs_watch_dog_test.go
+++ b/pkg/driver/efs_watch_dog_test.go
@@ -23,6 +23,14 @@ import (
 
 const (
 	expectedEfsUtilsConfig = `
+#
+# Copyright 2017-2018 Amazon.com, Inc. and its affiliates. All Rights Reserved.
+#
+# Licensed under the MIT License. See the LICENSE accompanying this file
+# for the specific language governing permissions and limitations under
+# the License.
+#
+
 [DEFAULT]
 logging_level = INFO
 logging_max_bytes = 1048576
@@ -31,7 +39,7 @@ logging_file_count = 10
 state_file_dir_mode = 750
 
 [mount]
-dns_name_format = {fs_id}.efs.{region}.{dns_name_suffix}
+dns_name_format = {az}.{fs_id}.efs.{region}.{dns_name_suffix}
 dns_name_suffix = amazonaws.com
 #The region of the file system when mounting from on-premises or cross region.
 #region = us-east-1
@@ -50,17 +58,25 @@ stunnel_check_cert_validity = false
 port_range_lower_bound = 20049
 port_range_upper_bound = 20449
 
+# Optimize read_ahead_kb for Linux 5.4+
+optimize_readahead = true
+
+
 [mount.cn-north-1]
 dns_name_suffix = amazonaws.com.cn
+
 
 [mount.cn-northwest-1]
 dns_name_suffix = amazonaws.com.cn
 
+
 [mount.us-iso-east-1]
 dns_name_suffix = c2s.ic.gov
+stunnel_cafile = /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
 
 [mount.us-isob-east-1]
 dns_name_suffix = sc2s.sgov.gov
+stunnel_cafile = /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
 
 [mount-watchdog]
 enabled = true


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
New feature.

**What is this PR about? / Why do we need it?**
Bump efs-utils to 1.30.1. This adds support for x-AZ mounts. Users can pass desired AZ under `mountOptions` either in PV or Storage class. For example, to mount file system with a mount target in the AZ us-east-1a, add `az=us-east-1a` under mount options.

**What testing is done?** 
Tested on my EKS cluster