### PR TITLE
Reduce default log level to 2

### DIFF
--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -49,7 +49,7 @@ node:
   podAnnotations: {}
   tolerations: []
 
-logLevel: 5
+logLevel: 2
 
 hostAliases:
   {}
@@ -83,7 +83,8 @@ serviceAccount:
 controller:
   create: true
   # Add additional tags to access points
-  tags: {}
+  tags:
+    {}
     # environment: prod
     # region: us-east-1
   # Enable if you want the controller to also delete the

--- a/deploy/kubernetes/base/controller-deployment.yaml
+++ b/deploy/kubernetes/base/controller-deployment.yaml
@@ -37,9 +37,8 @@ spec:
           args:
             - --endpoint=$(CSI_ENDPOINT)
             - --logtostderr
-            - --v=5
-            # Uncomment below line to allow access point root directory to be deleted by controller.
-            #- --delete-access-point-root-dir
+            - --v=2
+            - --delete-access-point-root-dir=false
           env:
             - name: CSI_ENDPOINT
               value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
@@ -62,7 +61,7 @@ spec:
           image: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner:v2.1.1-eks-1-18-2
           args:
             - --csi-address=$(ADDRESS)
-            - --v=5
+            - --v=2
             - --feature-gates=Topology=true
             - --leader-election
           env:

--- a/deploy/kubernetes/base/controller-serviceaccount.yaml
+++ b/deploy/kubernetes/base/controller-serviceaccount.yaml
@@ -47,7 +47,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: efs-csi-controller-sa
-    namespace: sample
+    namespace: default
 roleRef:
   kind: ClusterRole
   name: efs-csi-external-provisioner-role

--- a/deploy/kubernetes/base/node-daemonset.yaml
+++ b/deploy/kubernetes/base/node-daemonset.yaml
@@ -43,7 +43,7 @@ spec:
           args:
             - --endpoint=$(CSI_ENDPOINT)
             - --logtostderr
-            - --v=5
+            - --v=2
           env:
             - name: CSI_ENDPOINT
               value: unix:/csi/csi.sock
@@ -76,7 +76,7 @@ spec:
           args:
             - --csi-address=$(ADDRESS)
             - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-            - --v=5
+            - --v=2
           env:
             - name: ADDRESS
               value: /csi/csi.sock
@@ -96,7 +96,7 @@ spec:
           args:
             - --csi-address=/csi/csi.sock
             - --health-port=9809
-            - --v=5
+            - --v=2
           volumeMounts:
             - name: plugin-dir
               mountPath: /csi


### PR DESCRIPTION
**Is this a bug fix or adding new feature?** fix https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/252

**What is this PR about? / Why do we need it?** 5 is meant for debugging, https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md 

I ran make generate-kustomize.

**What testing is done?** 
