### PR TITLE
release-1.2: Release 1.2.1 and chart 1.2.3 with cherry-picked helm chart changes #380 #412 #413 #414 #426

### DIFF
--- a/CHANGELOG-1.x.md
+++ b/CHANGELOG-1.x.md
@@ -1,3 +1,8 @@
+# v1.2.1
+
+### Bug fixes
+* Revert efs-utils to 1.28.2 ([#385](https://github.com/kubernetes-sigs/aws-efs-csi-driver/pull/385), [@wongma7](https://github.com/wongma7))
+
 # v1.2
 
 ## Notable changes

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 
 PKG=github.com/kubernetes-sigs/aws-efs-csi-driver
 IMAGE?=amazon/aws-efs-csi-driver
-VERSION=v1.2.0-dirty
+VERSION=v1.2.1-dirty
 GIT_COMMIT?=$(shell git rev-parse HEAD)
 BUILD_DATE?=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 EFS_CLIENT_SOURCE?=k8s

--- a/charts/aws-efs-csi-driver/Chart.yaml
+++ b/charts/aws-efs-csi-driver/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "1.2.0"
+appVersion: "1.2.1"
 name: aws-efs-csi-driver
 description: A Helm chart for AWS EFS CSI Driver
 version: 1.2.3

--- a/charts/aws-efs-csi-driver/Chart.yaml
+++ b/charts/aws-efs-csi-driver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.2.0"
 name: aws-efs-csi-driver
 description: A Helm chart for AWS EFS CSI Driver
-version: 1.2.2
+version: 1.2.3
 kubeVersion: ">=1.17.0-0"
 home: https://github.com/kubernetes-sigs/aws-efs-csi-driver
 sources:

--- a/charts/aws-efs-csi-driver/templates/_helpers.tpl
+++ b/charts/aws-efs-csi-driver/templates/_helpers.tpl
@@ -54,3 +54,14 @@ Create the name of the service account to use
     {{ default "default" .Values.serviceAccount.controller.name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Create a string out of the map for controller tags flag
+*/}}
+{{- define "aws-efs-csi-driver.tags" -}}
+{{- $tags := list -}}
+{{ range $key, $val := . }}
+{{- $tags = print $key ":" $val | append $tags -}}
+{{- end -}}
+{{- join " " $tags -}}
+{{- end -}}

--- a/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
+++ b/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
@@ -23,6 +23,7 @@ spec:
       annotations: {{ toYaml .Values.node.podAnnotations | nindent 8 }}
       {{- end }}
     spec:
+      hostNetwork: true
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- range .Values.imagePullSecrets }}
@@ -50,9 +51,11 @@ spec:
           args:
             - --endpoint=$(CSI_ENDPOINT)
             - --logtostderr
-            - --v=5
-            # Uncomment below line to allow access point root directory to be deleted by controller.
-            #- --delete-access-point-root-dir
+            {{- if .Values.controller.tags }}
+            - --tags={{ include "aws-efs-csi-driver.tags" .Values.controller.tags }}
+            {{- end }}
+            - --v={{ .Values.logLevel }}
+            - --delete-access-point-root-dir={{ hasKey .Values.controller "deleteAccessPointRootDir" | ternary .Values.controller.deleteAccessPointRootDir false }}
           env:
             - name: CSI_ENDPOINT
               value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
@@ -75,7 +78,7 @@ spec:
           image: {{ printf "%s:%s" .Values.sidecars.csiProvisionerImage.repository .Values.sidecars.csiProvisionerImage.tag }}
           args:
             - --csi-address=$(ADDRESS)
-            - --v=5
+            - --v={{ .Values.logLevel }}
             - --feature-gates=Topology=true
             - --leader-election
           env:

--- a/charts/aws-efs-csi-driver/templates/storageclass.yaml
+++ b/charts/aws-efs-csi-driver/templates/storageclass.yaml
@@ -3,9 +3,13 @@ kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
   name: {{ .name }}
+  {{- with .annotations }}
+  annotations:
+  {{ toYaml . | indent 4 }}
+  {{- end }}
 provisioner: efs.csi.aws.com
 {{- with .mountOptions }}
-mountOptions: 
+mountOptions:
 {{ toYaml . }}
 {{- end }}
 {{- with .parameters }}

--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 2
 
 image:
   repository: amazon/aws-efs-csi-driver
-  tag: "v1.2.0"
+  tag: "v1.2.1"
   pullPolicy: IfNotPresent
 
 sidecars:

--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -49,7 +49,7 @@ node:
   podAnnotations: {}
   tolerations: []
 
-logLevel: 5
+logLevel: 2
 
 hostAliases:
   {}
@@ -82,10 +82,21 @@ serviceAccount:
 
 controller:
   create: true
+  # Add additional tags to access points
+  tags:
+    {}
+    # environment: prod
+    # region: us-east-1
+  # Enable if you want the controller to also delete the
+  # path on efs when deleteing an access point
+  deleteAccessPointRootDir: false
 
 storageClasses: []
 # Add StorageClass resources like:
 # - name: efs-sc
+##  Use that annotation if you want this to your default storageclass
+#   annotations:
+#     storageclass.kubernetes.io/is-default-class: "true"
 #   mountOptions:
 #   - tls
 #   parameters:

--- a/deploy/kubernetes/base/controller-deployment.yaml
+++ b/deploy/kubernetes/base/controller-deployment.yaml
@@ -32,7 +32,7 @@ spec:
         - name: efs-plugin
           securityContext:
             privileged: true
-          image: "amazon/aws-efs-csi-driver:v1.2.0"
+          image: "amazon/aws-efs-csi-driver:v1.2.1"
           imagePullPolicy: IfNotPresent
           args:
             - --endpoint=$(CSI_ENDPOINT)

--- a/deploy/kubernetes/base/controller-deployment.yaml
+++ b/deploy/kubernetes/base/controller-deployment.yaml
@@ -21,6 +21,7 @@ spec:
         app.kubernetes.io/name: aws-efs-csi-driver
         app.kubernetes.io/instance: kustomize
     spec:
+      hostNetwork: true
       nodeSelector:
         kubernetes.io/os: linux
       serviceAccountName: efs-csi-controller-sa
@@ -36,9 +37,8 @@ spec:
           args:
             - --endpoint=$(CSI_ENDPOINT)
             - --logtostderr
-            - --v=5
-            # Uncomment below line to allow access point root directory to be deleted by controller.
-            #- --delete-access-point-root-dir
+            - --v=2
+            - --delete-access-point-root-dir=false
           env:
             - name: CSI_ENDPOINT
               value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
@@ -61,7 +61,7 @@ spec:
           image: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner:v2.1.1-eks-1-18-2
           args:
             - --csi-address=$(ADDRESS)
-            - --v=5
+            - --v=2
             - --feature-gates=Topology=true
             - --leader-election
           env:

--- a/deploy/kubernetes/base/node-daemonset.yaml
+++ b/deploy/kubernetes/base/node-daemonset.yaml
@@ -39,7 +39,7 @@ spec:
         - name: efs-plugin
           securityContext:
             privileged: true
-          image: "amazon/aws-efs-csi-driver:v1.2.0"
+          image: "amazon/aws-efs-csi-driver:v1.2.1"
           args:
             - --endpoint=$(CSI_ENDPOINT)
             - --logtostderr

--- a/deploy/kubernetes/base/node-daemonset.yaml
+++ b/deploy/kubernetes/base/node-daemonset.yaml
@@ -43,7 +43,7 @@ spec:
           args:
             - --endpoint=$(CSI_ENDPOINT)
             - --logtostderr
-            - --v=5
+            - --v=2
           env:
             - name: CSI_ENDPOINT
               value: unix:/csi/csi.sock
@@ -76,7 +76,7 @@ spec:
           args:
             - --csi-address=$(ADDRESS)
             - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-            - --v=5
+            - --v=2
           env:
             - name: ADDRESS
               value: /csi/csi.sock
@@ -96,7 +96,7 @@ spec:
           args:
             - --csi-address=/csi/csi.sock
             - --health-port=9809
-            - --v=5
+            - --v=2
           volumeMounts:
             - name: plugin-dir
               mountPath: /csi

--- a/docs/README.md
+++ b/docs/README.md
@@ -64,6 +64,7 @@ The following sections are Kubernetes specific. If you are a Kubernetes user, us
 |EFS CSI Driver Version     | Image                               |
 |---------------------------|-------------------------------------|
 |master branch              |amazon/aws-efs-csi-driver:master     |
+|v1.2.1                     |amazon/aws-efs-csi-driver:v1.2.1     |
 |v1.2.0                     |amazon/aws-efs-csi-driver:v1.2.0     |
 |v1.1.1                     |amazon/aws-efs-csi-driver:v1.1.1     |
 |v1.1.0                     |amazon/aws-efs-csi-driver:v1.1.0     |


### PR DESCRIPTION
**Is this a bug fix or adding new feature?** helm chart release, fix https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/421

**What is this PR about? / Why do we need it?** Over the last few weeks lots of small-ish chart fixes have made it into master branch that don't need to wait for 1.3, cherry-pick them into 1.2 and release a 1.2.3 chart.

I squashed them all together.

**What testing is done?** 
