### PR TITLE
Create a new AWS session with the region

### DIFF
--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -95,7 +95,7 @@ func NewCloud() (Cloud, error) {
 		return nil, fmt.Errorf("could not get metadata from AWS: %v", err)
 	}
 
-	efsClient := efs.New(sess, aws.NewConfig().WithRegion(metadata.GetRegion()))
+	efsClient := efs.New(session.Must(session.NewSession(aws.NewConfig().WithRegion(metadata.GetRegion()))))
 	return &cloud{
 		metadata: metadata,
 		efs:      efsClient,


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

Fixes #433

**What is this PR about? / Why do we need it?**

Rather than use a region-less session and configure the EFS client with the region from the metadata service, create a new session with the region. This way when `AWS_STS_REGIONAL_ENDPOINTS=regional` is set the session will return the correct STS endpoint.

**What testing is done?** 

With this change, when I deploy the EFS driver to my EKS cluster with the aws-efs-csi-driver container patched to include the `AWS_STS_REGIONAL_ENDPOINTS=regional` environment variable it now works correctly and uses the `sts.<region>.amazonaws.com` endpoint. If I remove the environment variable or set it to `legacy` then it reverts back to using the `sts.amazonaws.com` endpoint which is the original behaviour.