### PR TITLE
release-1.2: Change controller port 9808->9909 to avoid node/ebs conflict

### DIFF
--- a/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
+++ b/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
@@ -64,7 +64,7 @@ spec:
               mountPath: /var/lib/csi/sockets/pluginproxy/
           ports:
             - name: healthz
-              containerPort: 9808
+              containerPort: 9909
               protocol: TCP
           livenessProbe:
             httpGet:
@@ -91,7 +91,7 @@ spec:
           image: {{ printf "%s:%s" .Values.sidecars.livenessProbeImage.repository .Values.sidecars.livenessProbeImage.tag }}
           args:
             - --csi-address=/csi/csi.sock
-            - --health-port=9808
+            - --health-port=9909
           volumeMounts:
             - name: socket-dir
               mountPath: /csi

--- a/deploy/kubernetes/base/controller-deployment.yaml
+++ b/deploy/kubernetes/base/controller-deployment.yaml
@@ -47,7 +47,7 @@ spec:
               mountPath: /var/lib/csi/sockets/pluginproxy/
           ports:
             - name: healthz
-              containerPort: 9808
+              containerPort: 9909
               protocol: TCP
           livenessProbe:
             httpGet:
@@ -74,7 +74,7 @@ spec:
           image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.2.0-eks-1-18-2
           args:
             - --csi-address=/csi/csi.sock
-            - --health-port=9808
+            - --health-port=9909
           volumeMounts:
             - name: socket-dir
               mountPath: /csi


### PR DESCRIPTION

**Is this a bug fix or adding new feature?** /bug

**What is this PR about? / Why do we need it?** 9808 is a poor choice because ebs asks for the same port. Related regarding hostnetwork true: https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/436

**What testing is done?** 
