### PR TITLE
(fix): Update apiVersion from v1beta1 to v1

### DIFF
--- a/charts/aws-efs-csi-driver/templates/csidriver.yaml
+++ b/charts/aws-efs-csi-driver/templates/csidriver.yaml
@@ -1,4 +1,4 @@
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:
   name: efs.csi.aws.com

--- a/charts/aws-efs-csi-driver/templates/csidriver.yaml
+++ b/charts/aws-efs-csi-driver/templates/csidriver.yaml
@@ -1,4 +1,4 @@
-apiVersion: storage.k8s.io/v1
+apiVersion: {{ ternary "storage.k8s.io/v1" "storage.k8s.io/v1beta1" (semverCompare ">=1.19.0-0" .Capabilities.KubeVersion.Version) }}
 kind: CSIDriver
 metadata:
   name: efs.csi.aws.com


### PR DESCRIPTION
Deprecated: storage.k8s.io/v1beta1 CSIDriver is deprecated in v1.19+, unavailable in v1.22+; use storage.k8s.io/v1 CSIDriver
CSIDriver is available in storage.k8s.io/v1 since v1.19

The storage.k8s.io/v1beta1 API version of CSIDriver, CSINode, StorageClass, and VolumeAttachment will no longer be served in v1.22.

Ref: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#storage-resources-v122

**What is this PR about? / Why do we need it?**
Update the apiVersion to v1

**What testing is done?** 
Tested with v1.19 EKS Cluster

