### PR TITLE
Install efs-utils from github

### DIFF
--- a/pkg/driver/efs_watch_dog.go
+++ b/pkg/driver/efs_watch_dog.go
@@ -264,7 +264,7 @@ func (w *execWatchdog) runLoop(stopCh <-chan struct{}) {
 	for {
 		select {
 		case <-stopCh:
-			//klog.Info("stopping...")
+			klog.Info("stopping...")
 			break
 		default:
 			err := w.exec()


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
New feature

**What is this PR about? / Why do we need it?**
Bump efs-utils to `1.30.2-1`. Install latest efs-utils from github since it is not available on yum . Additionally, provide an option to install efs-utils from yum repo.

**What testing is done?** 
Manual tests on my cluster.