### PR TITLE
Update access point root directory name to use PV name

### DIFF
--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -23,7 +23,6 @@ import (
 	"strings"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
-	"github.com/google/uuid"
 	"github.com/kubernetes-sigs/aws-efs-csi-driver/pkg/cloud"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -40,7 +39,6 @@ const (
 	ProvisioningMode    = "provisioningMode"
 	DefaultGidMin       = 50000
 	DefaultGidMax       = 7000000
-	RootDirPrefix       = "efs-csi-ap"
 	TempMountPathPrefix = "/var/lib/csi/pv"
 	DefaultTagKey       = "efs.csi.aws.com/cluster"
 	DefaultTagValue     = "true"
@@ -179,8 +177,7 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 		return nil, err
 	}
 
-	gidStr := strconv.Itoa(gid)
-	rootDirName := RootDirPrefix + "-" + gidStr + "-" + uuid.New().String()
+	rootDirName := volName
 	rootDir := basePath + "/" + rootDirName
 
 	accessPointsOptions.Gid = int64(gid)


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

**What is this PR about? / Why do we need it?**
 Access point root directory name will be created with PV name. This makes it easy to track access point associated with a PV .

**What testing is done?** 

Tested on EKS cluster.

Before this change, AP root directory looks like:

```bash
efs-csi-ap-1000-72f94a19-4f91-46c0-bd7b-d7acde1d969c
```

After applying this change, AP root directory looks like:

```bash
pvc-0af3bcf3-6f60-4164-8055-88466a239624
```
