### PR TITLE
Remove the need to install the clusterrole/binding controller if you don't need it.

### DIFF
--- a/charts/aws-efs-csi-driver/templates/controller-serviceaccount.yaml
+++ b/charts/aws-efs-csi-driver/templates/controller-serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
   {{- end }}
 {{- end }}
 ---
-
+{{- if .Values.controller.create }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -57,3 +57,4 @@ roleRef:
   kind: ClusterRole
   name: efs-csi-external-provisioner-role
   apiGroup: rbac.authorization.k8s.io
+{{- end }}


### PR DESCRIPTION
… controller

**Is this a bug fix or adding new feature?**
This is a bug fix in the helm chart.

**What is this PR about? / Why do we need it?**
This is a change in the helm chart. If I don't need to deploy the controller I don't need the clusterrole and clusterrolebinding associated with it.

**What testing is done?** 
`helm template -f values.yaml `
This only change the helm chart. 
