### PR TITLE
release-1.2: Helm chart 2.0.0 with changelog

### DIFF
--- a/charts/aws-efs-csi-driver/CHANGELOG.md
+++ b/charts/aws-efs-csi-driver/CHANGELOG.md
@@ -1,0 +1,89 @@
+# Helm chart
+
+# v2.0.0
+
+## Breaking changes
+
+Multiple changes in values file at `sidecars`, `controller` and `node`
+
+---
+```yaml
+sidecars:
+  xxxxxxxxx:
+    repository:
+    tag:
+```
+
+Moving to
+
+```yaml
+sidecars:
+  xxxxxxxxx:
+    image:
+      repository:
+      tag:
+```
+
+---
+```yaml
+podAnnotations:
+resources:
+nodeSelector:
+tolerations:
+affinity:
+```
+
+Moving to
+
+```yaml
+controller:
+  podAnnotations:
+  resources:
+  nodeSelector:
+  tolerations:
+  affinity:
+```
+
+---
+```yaml
+hostAliases:
+dnsPolicy:
+dnsConfig:
+```
+
+Moving to
+
+```yaml
+node:
+  hostAliases:
+  dnsPolicy:
+  dnsConfig:
+```
+
+---
+```yaml
+serviceAccount:
+  controller:
+```
+
+Moving to
+
+```yaml
+controller:
+  serviceAccount:
+```
+
+## New features
+
+* Chart API `v2` (requires Helm 3)
+* Set `resources` and `imagePullPolicy` fields independently for containers
+* Set `logLevel`, `affinity`, `nodeSelector`, `podAnnotations` and `tolerations` fields independently
+for Controller deployment and Node daemonset
+* Set `reclaimPolicy` and `volumeBindingMode` fields in storage class
+
+## Fixes
+
+* Fixing Controller deployment using `podAnnotations` and `tolerations` values from Node daemonset
+* Let the user define the whole `tolerations` array, default to `- operator: Exists`
+* Default `logLevel` lowered from `5` to `2`
+* Default `imagePullPolicy` everywhere set to `IfNotPresent`

--- a/charts/aws-efs-csi-driver/Chart.yaml
+++ b/charts/aws-efs-csi-driver/Chart.yaml
@@ -1,9 +1,9 @@
-apiVersion: v1
-appVersion: "1.2.1"
+apiVersion: v2
 name: aws-efs-csi-driver
-description: A Helm chart for AWS EFS CSI Driver
-version: 1.2.4
+version: 2.0.0
+appVersion: 1.2.1
 kubeVersion: ">=1.17.0-0"
+description: "A Helm chart for AWS EFS CSI Driver"
 home: https://github.com/kubernetes-sigs/aws-efs-csi-driver
 sources:
   - https://github.com/kubernetes-sigs/aws-efs-csi-driver

--- a/charts/aws-efs-csi-driver/templates/_helpers.tpl
+++ b/charts/aws-efs-csi-driver/templates/_helpers.tpl
@@ -49,9 +49,9 @@ Create the name of the service account to use
 */}}
 {{- define "aws-efs-csi-driver.serviceAccountName" -}}
 {{- if .Values.controller.create -}}
-    {{ default (include "aws-efs-csi-driver.fullname" .) .Values.serviceAccount.controller.name }}
+    {{ default (include "aws-efs-csi-driver.fullname" .) .Values.controller.serviceAccount.name }}
 {{- else -}}
-    {{ default "default" .Values.serviceAccount.controller.name }}
+    {{ default "default" .Values.controller.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
 

--- a/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
+++ b/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
@@ -19,8 +19,8 @@ spec:
         app: efs-csi-controller
         app.kubernetes.io/name: {{ include "aws-efs-csi-driver.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
-      {{- if .Values.node.podAnnotations }}
-      annotations: {{ toYaml .Values.node.podAnnotations | nindent 8 }}
+      {{- with .Values.controller.podAnnotations }}
+      annotations: {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
       hostNetwork: true
@@ -32,29 +32,27 @@ spec:
       {{- end }}
       nodeSelector:
         kubernetes.io/os: linux
-        {{- with .Values.nodeSelector }}
-        {{- . | toYaml | nindent 8 }}
+        {{- with .Values.controller.nodeSelector }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
       serviceAccountName: {{ include "aws-efs-csi-driver.serviceAccountName" . }}
       priorityClassName: system-cluster-critical
-      tolerations:
-        - operator: Exists
-        {{- with .Values.node.tolerations }}
-        {{- . | toYaml | nindent 8 }}
-        {{- end }}
+      {{- with .Values.controller.tolerations }}
+      tolerations: {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: efs-plugin
           securityContext:
             privileged: true
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - --endpoint=$(CSI_ENDPOINT)
             - --logtostderr
             {{- if .Values.controller.tags }}
             - --tags={{ include "aws-efs-csi-driver.tags" .Values.controller.tags }}
             {{- end }}
-            - --v={{ .Values.logLevel }}
+            - --v={{ .Values.controller.logLevel }}
             - --delete-access-point-root-dir={{ hasKey .Values.controller "deleteAccessPointRootDir" | ternary .Values.controller.deleteAccessPointRootDir false }}
           env:
             - name: CSI_ENDPOINT
@@ -74,11 +72,15 @@ spec:
             timeoutSeconds: 3
             periodSeconds: 10
             failureThreshold: 5
+          {{- with .Values.controller.resources }}
+          resources: {{ toYaml . | nindent 12 }}
+          {{- end }}
         - name: csi-provisioner
-          image: {{ printf "%s:%s" .Values.sidecars.csiProvisionerImage.repository .Values.sidecars.csiProvisionerImage.tag }}
+          image: {{ printf "%s:%s" .Values.sidecars.csiProvisioner.image.repository .Values.sidecars.csiProvisioner.image.tag }}
+          imagePullPolicy: {{ .Values.sidecars.csiProvisioner.image.pullPolicy }}
           args:
             - --csi-address=$(ADDRESS)
-            - --v={{ .Values.logLevel }}
+            - --v={{ .Values.controller.logLevel }}
             - --feature-gates=Topology=true
             - --leader-election
           env:
@@ -87,15 +89,25 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
+          {{- with .Values.sidecars.csiProvisioner.resources }}
+          resources: {{ toYaml . | nindent 12 }}
+          {{- end }}
         - name: liveness-probe
-          image: {{ printf "%s:%s" .Values.sidecars.livenessProbeImage.repository .Values.sidecars.livenessProbeImage.tag }}
+          image: {{ printf "%s:%s" .Values.sidecars.livenessProbe.image.repository .Values.sidecars.livenessProbe.image.tag }}
+          imagePullPolicy: {{ .Values.sidecars.livenessProbe.image.pullPolicy }}
           args:
             - --csi-address=/csi/csi.sock
             - --health-port=9909
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+          {{- with .Values.sidecars.livenessProbe.resources }}
+          resources: {{ toYaml . | nindent 12 }}
+          {{- end }}
       volumes:
         - name: socket-dir
           emptyDir: {}
+      {{- with .Values.controller.affinity }}
+      affinity: {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/charts/aws-efs-csi-driver/templates/controller-serviceaccount.yaml
+++ b/charts/aws-efs-csi-driver/templates/controller-serviceaccount.yaml
@@ -1,11 +1,11 @@
-{{- if .Values.serviceAccount.controller.create }}
+{{- if .Values.controller.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "aws-efs-csi-driver.serviceAccountName" . }}
   labels:
     app.kubernetes.io/name: {{ include "aws-efs-csi-driver.name" . }}
-  {{- with .Values.serviceAccount.controller.annotations }}
+  {{- with .Values.controller.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/aws-efs-csi-driver/templates/csidriver.yaml
+++ b/charts/aws-efs-csi-driver/templates/csidriver.yaml
@@ -1,4 +1,4 @@
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: {{ ternary "storage.k8s.io/v1" "storage.k8s.io/v1beta1" (semverCompare ">=1.18.0-0" .Capabilities.KubeVersion.Version) }}
 kind: CSIDriver
 metadata:
   name: efs.csi.aws.com

--- a/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
+++ b/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
@@ -21,9 +21,9 @@ spec:
       annotations: {{ toYaml .Values.node.podAnnotations | nindent 8 }}
       {{- end }}
     spec:
-    {{- if .Values.hostAliases }}
+    {{- with .Values.node.hostAliases }}
       hostAliases:
-      {{- range $k, $v := .Values.hostAliases }}
+      {{- range $k, $v := . }}
         - ip: {{ $v.ip }}
           hostnames:
             - {{ $k }}.efs.{{ $v.region }}.amazonaws.com
@@ -37,8 +37,8 @@ spec:
     {{- end }}
       nodeSelector:
         beta.kubernetes.io/os: linux
-        {{- with .Values.nodeSelector }}
-        {{- . | toYaml | nindent 8 }}
+        {{- with .Values.node.nodeSelector }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
       affinity:
         nodeAffinity:
@@ -50,28 +50,24 @@ spec:
                 values:
                 - fargate
       hostNetwork: true
-      {{- if .Values.dnsPolicy }}
-      dnsPolicy: "{{ .Values.dnsPolicy }}"
-      {{- end }}
-      {{- with .Values.dnsConfig }}
-      dnsConfig:
-        {{- toYaml . | nindent 8 }}
+      dnsPolicy: {{ .Values.node.dnsPolicy }}
+      {{- with .Values.node.dnsConfig }}
+      dnsConfig: {{- toYaml . | nindent 8 }}
       {{- end }}
       priorityClassName: system-node-critical
-      tolerations:
-        - operator: Exists
-        {{- with .Values.node.tolerations }}
-        {{- . | toYaml | nindent 8 }}
-        {{- end }}
+      {{- with .Values.node.tolerations }}
+      tolerations: {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: efs-plugin
           securityContext:
             privileged: true
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - --endpoint=$(CSI_ENDPOINT)
             - --logtostderr
-            - --v={{ .Values.logLevel }}
+            - --v={{ .Values.node.logLevel }}
           env:
             - name: CSI_ENDPOINT
               value: unix:/csi/csi.sock
@@ -99,12 +95,16 @@ spec:
             timeoutSeconds: 3
             periodSeconds: 2
             failureThreshold: 5
+          {{- with .Values.node.resources }}
+          resources: {{ toYaml . | nindent 12 }}
+          {{- end }}
         - name: csi-driver-registrar
-          image: {{ printf "%s:%s" .Values.sidecars.nodeDriverRegistrarImage.repository .Values.sidecars.nodeDriverRegistrarImage.tag }}
+          image: {{ printf "%s:%s" .Values.sidecars.nodeDriverRegistrar.image.repository .Values.sidecars.nodeDriverRegistrar.image.tag }}
+          imagePullPolicy: {{ .Values.sidecars.nodeDriverRegistrar.image.pullPolicy }}
           args:
             - --csi-address=$(ADDRESS)
             - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-            - --v={{ .Values.logLevel }}
+            - --v={{ .Values.node.logLevel }}
           env:
             - name: ADDRESS
               value: /csi/csi.sock
@@ -119,15 +119,22 @@ spec:
               mountPath: /csi
             - name: registration-dir
               mountPath: /registration
+          {{- with .Values.sidecars.nodeDriverRegistrar.resources }}
+          resources: {{ toYaml . | nindent 12 }}
+          {{- end }}
         - name: liveness-probe
-          image: {{ printf "%s:%s" .Values.sidecars.livenessProbeImage.repository .Values.sidecars.livenessProbeImage.tag }}
+          image: {{ printf "%s:%s" .Values.sidecars.livenessProbe.image.repository .Values.sidecars.livenessProbe.image.tag }}
+          imagePullPolicy: {{ .Values.sidecars.livenessProbe.image.pullPolicy }}
           args:
             - --csi-address=/csi/csi.sock
             - --health-port=9809
-            - --v={{ .Values.logLevel }}
+            - --v={{ .Values.node.logLevel }}
           volumeMounts:
             - name: plugin-dir
               mountPath: /csi
+          {{- with .Values.sidecars.livenessProbe.resources }}
+          resources: {{ toYaml . | nindent 12 }}
+          {{- end }}
       volumes:
         - name: kubelet-dir
           hostPath:

--- a/charts/aws-efs-csi-driver/templates/storageclass.yaml
+++ b/charts/aws-efs-csi-driver/templates/storageclass.yaml
@@ -16,5 +16,11 @@ mountOptions:
 parameters:
 {{ toYaml . | indent 2 }}
 {{- end }}
+{{- with .reclaimPolicy }}
+reclaimPolicy: {{ .reclaimPolicy  }}
+{{- end }}
+{{- with .volumeBindingMode }}
+volumeBindingMode: {{ .volumeBindingMode }}
+{{- end }}
 ---
 {{- end }}

--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -2,6 +2,9 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+nameOverride: ""
+fullnameOverride: ""
+
 replicaCount: 2
 
 image:
@@ -10,92 +13,102 @@ image:
   pullPolicy: IfNotPresent
 
 sidecars:
-  livenessProbeImage:
-    repository: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe
-    tag: v2.2.0-eks-1-18-2
-  nodeDriverRegistrarImage:
-    repository: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar
-    tag: v2.1.0-eks-1-18-2
-  csiProvisionerImage:
-    repository: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner
-    tag: v2.1.1-eks-1-18-2
+  livenessProbe:
+    image:
+      repository: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe
+      tag: v2.2.0-eks-1-18-2
+      pullPolicy: IfNotPresent
+    resources: {}
+  nodeDriverRegistrar:
+    image:
+      repository: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar
+      tag: v2.1.0-eks-1-18-2
+      pullPolicy: IfNotPresent
+    resources: {}
+  csiProvisioner:
+    image:
+      repository: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner
+      tag: v2.1.1-eks-1-18-2
+      pullPolicy: IfNotPresent
+    resources: {}
 
 imagePullSecrets: []
-nameOverride: ""
-fullnameOverride: ""
 
-podAnnotations: {}
-
-resources:
-  {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
-
-nodeSelector: {}
-
-tolerations: []
-
-affinity: {}
-
-node:
-  podAnnotations: {}
-  tolerations: []
-
-logLevel: 2
-
-hostAliases:
-  {}
-  # for cross VPC EFS, you need to poison or overwrite the DNS for the efs volume as per
-  # https://docs.aws.amazon.com/efs/latest/ug/efs-different-vpc.html#wt6-efs-utils-step3
-  # implementing the suggested solution found here:
-  # https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/240#issuecomment-676849346
-  # EFS Vol ID, IP, Region
-  # "fs-01234567":
-  #   ip: 10.10.2.2
-  #   region: us-east-2
-
-dnsPolicy: ""
-dnsConfig:
-  {}
-  # Example config which uses the AWS nameservers
-  # dnsPolicy: "None"
-  # dnsConfig:
-  #   nameservers:
-  #     - 169.254.169.253
-
-serviceAccount:
-  controller:
-    # Specifies whether a service account should be created
-    create: true
-    annotations: {}
-    ## Enable if EKS IAM for SA is used
-    #  eks.amazonaws.com/role-arn: arn:aws:iam::111122223333:role/efs-csi-role
-    name: efs-csi-controller-sa
+## Controller deployment variables
 
 controller:
+  # Specifies whether a deployment should be created
   create: true
+  # Number for the log level verbosity
+  logLevel: 2
   # Add additional tags to access points
-  tags:
-    {}
+  tags: {}
     # environment: prod
     # region: us-east-1
   # Enable if you want the controller to also delete the
   # path on efs when deleteing an access point
   deleteAccessPointRootDir: false
+  podAnnotations: {}
+  resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  # Specifies whether a service account should be created
+  serviceAccount:
+    create: true
+    ## Enable if EKS IAM for SA is used
+    #  eks.amazonaws.com/role-arn: arn:aws:iam::111122223333:role/efs-csi-role
+    name: efs-csi-controller-sa
+    annotations: {}
+
+## Node daemonset variables
+
+node:
+  # Number for the log level verbosity
+  logLevel: 2
+  hostAliases: {}
+    # For cross VPC EFS, you need to poison or overwrite the DNS for the efs volume as per
+    # https://docs.aws.amazon.com/efs/latest/ug/efs-different-vpc.html#wt6-efs-utils-step3
+    # implementing the suggested solution found here:
+    # https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/240#issuecomment-676849346
+    # EFS Vol ID, IP, Region
+    # "fs-01234567":
+    #   ip: 10.10.2.2
+    #   region: us-east-2
+  dnsPolicy: ClusterFirst
+  dnsConfig: {}
+    # Example config which uses the AWS nameservers
+    # dnsPolicy: "None"
+    # dnsConfig:
+    #   nameservers:
+    #     - 169.254.169.253
+  podAnnotations: {}
+  resources: {}
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+  nodeSelector: {}
+  tolerations:
+    - operator: Exists
 
 storageClasses: []
 # Add StorageClass resources like:
 # - name: efs-sc
-##  Use that annotation if you want this to your default storageclass
 #   annotations:
+#     # Use that annotation if you want this to your default storageclass
 #     storageclass.kubernetes.io/is-default-class: "true"
 #   mountOptions:
 #   - tls
@@ -106,3 +119,5 @@ storageClasses: []
 #     gidRangeStart: "1000"
 #     gidRangeEnd: "2000"
 #     basePath: "/dynamic_provisioning"
+#   reclaimPolicy: Delete
+#   volumeBindingMode: Immediate


### PR DESCRIPTION
**Is this a bug fix or adding new feature?** new chart release

**What is this PR about? / Why do we need it?** releases chart 2.0.0 currently sitting in master branch. https://github.com/kubernetes-sigs/aws-efs-csi-driver/pull/406

**What testing is done?** 
Install the existing chart 1.2.4 and try dynamic provisioning example
helm repo add aws-efs-csi-driver https://kubernetes-sigs.github.io/aws-efs-csi-driver/
helm repo update
helm upgrade --install aws-efs-csi-driver --namespace kube-system aws-efs-csi-driver/aws-efs-csi-driver
k apply -f ./examples/kubernetes/dynamic_provisioning/specs/
k exec -it efs-app -- cat /data/out

Upgrade to 2.0.0 (obviously this won't work if I set values that existed in old chart that were moved in new chart, hence major version got bumped from 1 to 2). and check example still works
helm upgrade --install aws-efs-csi-driver ./charts/aws-efs-csi-driver -n kube-system
k exec -it efs-app -- cat /data/out

Delete and recreate example and check it still works.
k delete -f ./examples/kubernetes/dynamic_provisioning/specs/
k apply -f ./examples/kubernetes/dynamic_provisioning/specs/
k exec -it efs-app -- cat /data/out