### PR TITLE
Helm chart: fix reclaimPolicy and volumeBindingMode

### DIFF
--- a/charts/aws-efs-csi-driver/templates/storageclass.yaml
+++ b/charts/aws-efs-csi-driver/templates/storageclass.yaml
@@ -17,10 +17,10 @@ parameters:
 {{ toYaml . | indent 2 }}
 {{- end }}
 {{- with .reclaimPolicy }}
-reclaimPolicy: {{ .reclaimPolicy  }}
+reclaimPolicy: {{ . }}
 {{- end }}
 {{- with .volumeBindingMode }}
-volumeBindingMode: {{ .volumeBindingMode }}
+volumeBindingMode: {{ . }}
 {{- end }}
 ---
 {{- end }}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

Bug Fix

**What is this PR about? / Why do we need it?**

Fixes: https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/461
Uses the base values for reclaimPolicy and volumeBindingMode in StorageClasses as opposed to looking for a nested value of the same name.

**What testing is done?** 

- `helm template -f values.yaml`
- Successfully installed the chart on our cluster with values defined in the values.yaml:

```
  reclaimPolicy: Retain
  volumeBindingMode: Immediate
```

This change only affects the helm chart.