### PR TITLE
release-1.2: fix: use base value, not a nested value & Bump helm chart to 2.0.1

### DIFF
--- a/charts/aws-efs-csi-driver/Chart.yaml
+++ b/charts/aws-efs-csi-driver/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: aws-efs-csi-driver
-version: 2.0.0
+version: 2.0.1
 appVersion: 1.2.1
 kubeVersion: ">=1.17.0-0"
 description: "A Helm chart for AWS EFS CSI Driver"

--- a/charts/aws-efs-csi-driver/templates/storageclass.yaml
+++ b/charts/aws-efs-csi-driver/templates/storageclass.yaml
@@ -17,10 +17,10 @@ parameters:
 {{ toYaml . | indent 2 }}
 {{- end }}
 {{- with .reclaimPolicy }}
-reclaimPolicy: {{ .reclaimPolicy  }}
+reclaimPolicy: {{ . }}
 {{- end }}
 {{- with .volumeBindingMode }}
-volumeBindingMode: {{ .volumeBindingMode }}
+volumeBindingMode: {{ . }}
 {{- end }}
 ---
 {{- end }}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

**What is this PR about? / Why do we need it?** https://github.com/kubernetes-sigs/aws-efs-csi-driver/pull/465/ https://github.com/kubernetes-sigs/aws-efs-csi-driver/pull/464/

**What testing is done?** 
