### PR TITLE
Add support for on-premise Kubernetes environment

### DIFF
--- a/deploy/kubernetes/base/controller-deployment.yaml
+++ b/deploy/kubernetes/base/controller-deployment.yaml
@@ -42,6 +42,12 @@ spec:
           env:
             - name: CSI_ENDPOINT
               value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+            - name: instanceID
+              value: <change to your mock instanceID>
+            - name: region
+              value: <change to your mock region>
+            - name: availabilityZone
+              value: <change to your mock availabilityZone>
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/

--- a/deploy/kubernetes/base/controller-deployment.yaml
+++ b/deploy/kubernetes/base/controller-deployment.yaml
@@ -42,12 +42,6 @@ spec:
           env:
             - name: CSI_ENDPOINT
               value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
-            - name: instanceID
-              value: <change to your mock instanceID>
-            - name: region
-              value: <change to your mock region>
-            - name: availabilityZone
-              value: <change to your mock availabilityZone>
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/

--- a/docs/ON-PREMISE.md
+++ b/docs/ON-PREMISE.md
@@ -1,0 +1,58 @@
+## Notes for on-premise Kubernetes environment
+
+### Decouple EC2 metadata service (IMDS)
+Since on-premise Kubernetes environment cannot access Amazon EC2 metadata service and cannot get information about instanceID, region and availabilityZone, additional environment variables need to be set, otherwise it will throw "could not get metadata from AWS: EC2 instance metadata is not available" described in [issue 468](https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/468).
+
+Environment variables need to be added for efs-plugin container in [controller-deployment.yaml](../deploy/kubernetes/base/controller-deployment.yaml), specify onPremise to let driver know it's a on-premise Kubernetes environment, and then follow the deployment guide above. Examples are shown below (instanceID can be mocked):
+
+```
+...
+        - name: onPremise
+          value: "true"
+        - name: instanceID
+          value: i-0123456789012345
+        - name: region
+          value: us-east-1
+        - name: availabilityZone
+          value: us-east-1a
+...
+```
+For IAM permission, you could set it using environment variables with [AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html) or mount secret to container for [configuration and credential file settings](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html).
+
+### Configure region for efs-utils
+Besides, you might encounter errors when mounting file system "Output: Error retrieving region. Please set the "region" parameter in the efs-utils configuration file", the binary entrypoint aws-efs-csi-driver would dynamically generate configuration file, but the region information need to specify in the conf file which will be override by aws-efs-csi-driver. Follow below procedure to fix this issue:
+* Get the original efs-utils configuration file 
+```
+kubectl -n kube-system exec -it efs-csi-node-<id> -c efs-plugin cat /etc/amazon/efs/efs-utils.conf
+```
+* Configure region information `region = us-east-1` and add disable fetch ec2 metadata setting `disable_fetch_ec2_metadata_token = true`
+* Create new configmap 
+```
+kubectl -n kube-system create configmap efs-utils-conf --from-file=./efs-utils.conf
+```
+* Edit efs-plugin in daemon set efs-csi-node 
+```
+kubectl -n kube-system edit daemonsets.apps efs-csi-node
+```
+Add the configurations below:
+```
+...
+        lifecycle:
+          postStart:
+            exec:
+              command: ["/bin/sh", "-c", "cp -f /tmp/efs-utils.conf /etc/amazon/efs/efs-utils.conf"]
+...
+        - mountPath: /tmp/efs-utils.conf 
+          subPath: efs-utils.conf
+          name: efs-utils-conf
+...
+        - configMap:
+          name: efs-utils-conf
+        name: efs-utils-conf
+...
+```
+
+### DNS resolve issue
+And if you still got errors 'Output: Failed to resolve "fs-01234567.efs.us-east-1.amazonaws.com" - check that your file system ID is correct, and ensure that the VPC has an EFS mount target for this file system ID." Follow below procedure to fix this issue:
+* Configure IP address in /etc/hosts on each host, refer to [Walkthrough: Create and mount a file system on-premises with AWS Direct Connect and VPN](https://docs.aws.amazon.com/efs/latest/ug/efs-onpremises.html)
+* Or install botocore on each host and set `fall_back_to_mount_target_ip_address_enabled = true` in efs-utils.conf, refer to [Using botocore to retrieve mount target ip address when dns name cannot be resolved](https://github.com/aws/efs-utils).

--- a/docs/ON-PREMISE.md
+++ b/docs/ON-PREMISE.md
@@ -3,7 +3,7 @@
 ### Decouple EC2 metadata service (IMDS)
 Since on-premise Kubernetes environment cannot access Amazon EC2 metadata service and cannot get information about instanceID, region and availabilityZone, additional environment variables need to be set, otherwise it will throw "could not get metadata from AWS: EC2 instance metadata is not available" described in [issue 468](https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/468).
 
-Environment variables need to be added for efs-plugin container in [controller-deployment.yaml](../deploy/kubernetes/base/controller-deployment.yaml), specify onPremise to let driver know it's a on-premise Kubernetes environment, and then follow the deployment guide above. Examples are shown below (instanceID can be mocked):
+Environment variables need to be added for efs-plugin container in [controller-deployment.yaml](../deploy/kubernetes/base/controller-deployment.yaml), specify onPremise to let driver know it's a on-premise Kubernetes environment, and then follow the deployment guide in [README.md](./README.md). Examples are shown below (instanceID can be mocked):
 
 ```
 ...
@@ -21,16 +21,19 @@ For IAM permission, you could set it using environment variables with [AWS_ACCES
 
 ### Configure region for efs-utils
 Besides, you might encounter errors when mounting file system "Output: Error retrieving region. Please set the "region" parameter in the efs-utils configuration file", the binary entrypoint aws-efs-csi-driver would dynamically generate configuration file, but the region information need to specify in the conf file which will be override by aws-efs-csi-driver. Follow below procedure to fix this issue:
-* Get the original efs-utils configuration file 
+* Get the original efs-utils configuration file:
 ```
 kubectl -n kube-system exec -it efs-csi-node-<id> -c efs-plugin cat /etc/amazon/efs/efs-utils.conf
 ```
-* Configure region information `region = us-east-1` and add disable fetch ec2 metadata setting `disable_fetch_ec2_metadata_token = true`
-* Create new configmap 
+* Configure region information `region = us-east-1` and add disable fetch ec2 metadata setting:
+```
+disable_fetch_ec2_metadata_token = true
+```
+* Create new configmap:
 ```
 kubectl -n kube-system create configmap efs-utils-conf --from-file=./efs-utils.conf
 ```
-* Edit efs-plugin in daemon set efs-csi-node 
+* Edit efs-plugin in daemon set efs-csi-node:
 ```
 kubectl -n kube-system edit daemonsets.apps efs-csi-node
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -82,6 +82,8 @@ The following sections are Kubernetes specific. If you are a Kubernetes user, us
 **Notes**:
 * Since EFS is an elastic file system it doesn't really enforce any file system capacity. The actual storage capacity value in persistent volume and persistent volume claim is not used when creating the file system. However, since the storage capacity is a required field by Kubernetes, you must specify the value and you can use any valid value for the capacity.
 
+* If you are deploying Amazon EFS CSI Driver in on-premise environment, please refer to the doc [ON-PREMISE.md](./ON-PREMISE.md). 
+
 ### Installation
 #### Set up driver permission:
 The driver requires IAM permission to talk to Amazon EFS to manage the volume on user's behalf. There are several methods to grant driver IAM permission:

--- a/pkg/cloud/metadata.go
+++ b/pkg/cloud/metadata.go
@@ -67,9 +67,8 @@ func NewMetadataService(sess *session.Session) (MetadataService, error) {
 		region:           os.Getenv("region"),
 		availabilityZone: os.Getenv("availabilityZone"),
 		}, nil
-	}
+	} else if ecsContainerMetadataUri := os.Getenv(taskMetadataV4EnvName); ecsContainerMetadataUri != "" {
 	// check if it is running in ECS otherwise default fall back to ec2
-	else if ecsContainerMetadataUri := os.Getenv(taskMetadataV4EnvName); ecsContainerMetadataUri != "" {
 		return getTaskMetadata(&taskMetadata{})
 	} else {
 		return getEC2Metadata(ec2metadata.New(sess))

--- a/pkg/cloud/metadata.go
+++ b/pkg/cloud/metadata.go
@@ -63,12 +63,12 @@ func NewMetadataService(sess *session.Session) (MetadataService, error) {
 	// check if it is running in on-premise environment otherwise turn to ECS
 	if onPremiseEnv := os.Getenv("onPremise"); onPremiseEnv == "true" {
 		return &metadata{
-		instanceID:       os.Getenv("instanceID"),
-		region:           os.Getenv("region"),
-		availabilityZone: os.Getenv("availabilityZone"),
+			instanceID:       os.Getenv("instanceID"),
+			region:           os.Getenv("region"),
+			availabilityZone: os.Getenv("availabilityZone"),
 		}, nil
 	} else if ecsContainerMetadataUri := os.Getenv(taskMetadataV4EnvName); ecsContainerMetadataUri != "" {
-	// check if it is running in ECS otherwise default fall back to ec2
+		// check if it is running in ECS otherwise default fall back to ec2
 		return getTaskMetadata(&taskMetadata{})
 	} else {
 		return getEC2Metadata(ec2metadata.New(sess))

--- a/pkg/cloud/metadata.go
+++ b/pkg/cloud/metadata.go
@@ -60,7 +60,7 @@ func (m *metadata) GetAvailabilityZone() string {
 
 // NewMetadataService return either EC2, ECS Task MetadataServiceImplementation or on-premise using environment variables.
 func NewMetadataService(sess *session.Session) (MetadataService, error) {
-	// check if it is running in on-premise environment otherwise turn to to ECS
+	// check if it is running in on-premise environment otherwise turn to ECS
 	if onPremiseEnv := os.Getenv("onPremise"); onPremiseEnv == "true" {
 		return &metadata{
 		instanceID:       os.Getenv("instanceID"),

--- a/pkg/cloud/metadata.go
+++ b/pkg/cloud/metadata.go
@@ -17,12 +17,15 @@ limitations under the License.
 package cloud
 
 import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"os"
 )
 
 type EC2Metadata interface {
 	Available() bool
+	GetInstanceIdentityDocument() (ec2metadata.EC2InstanceIdentityDocument, error)
 }
 
 // MetadataService represents AWS metadata service.
@@ -55,12 +58,50 @@ func (m *metadata) GetAvailabilityZone() string {
 	return m.availabilityZone
 }
 
-// getEC2Metadata returns a new MetadataServiceImplementation.
+// NewMetadataService return either EC2 or ECS Task MetadataServiceImplementation.
 func NewMetadataService(sess *session.Session) (MetadataService, error) {
-
-	return &metadata{
+	// check if it is running in on-premise environment otherwise turn to to ECS
+	if onPremiseEnv := os.Getenv("onPremise"); onPremiseEnv == "true" {
+		return &metadata{
 		instanceID:       os.Getenv("instanceID"),
 		region:           os.Getenv("region"),
 		availabilityZone: os.Getenv("availabilityZone"),
+		}, nil
+	}
+	// check if it is running in ECS otherwise default fall back to ec2
+	else if ecsContainerMetadataUri := os.Getenv(taskMetadataV4EnvName); ecsContainerMetadataUri != "" {
+		return getTaskMetadata(&taskMetadata{})
+	} else {
+		return getEC2Metadata(ec2metadata.New(sess))
+	}
+}
+
+// getEC2Metadata returns a new MetadataServiceImplementation.
+func getEC2Metadata(svc EC2Metadata) (MetadataService, error) {
+	if !svc.Available() {
+		return nil, fmt.Errorf("EC2 instance metadata is not available")
+	}
+
+	doc, err := svc.GetInstanceIdentityDocument()
+	if err != nil {
+		return nil, fmt.Errorf("could not get EC2 instance identity metadata")
+	}
+
+	if len(doc.InstanceID) == 0 {
+		return nil, fmt.Errorf("could not get valid EC2 instance ID")
+	}
+
+	if len(doc.Region) == 0 {
+		return nil, fmt.Errorf("could not get valid EC2 region")
+	}
+
+	if len(doc.AvailabilityZone) == 0 {
+		return nil, fmt.Errorf("could not get valid EC2 availavility zone")
+	}
+
+	return &metadata{
+		instanceID:       doc.InstanceID,
+		region:           doc.Region,
+		availabilityZone: doc.AvailabilityZone,
 	}, nil
 }

--- a/pkg/cloud/metadata.go
+++ b/pkg/cloud/metadata.go
@@ -58,7 +58,7 @@ func (m *metadata) GetAvailabilityZone() string {
 	return m.availabilityZone
 }
 
-// NewMetadataService return either EC2 or ECS Task MetadataServiceImplementation.
+// NewMetadataService return either EC2, ECS Task MetadataServiceImplementation or on-premise using environment variables.
 func NewMetadataService(sess *session.Session) (MetadataService, error) {
 	// check if it is running in on-premise environment otherwise turn to to ECS
 	if onPremiseEnv := os.Getenv("onPremise"); onPremiseEnv == "true" {


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Yes, this is add feature for supporting on-premise Kubernetes environment to deploy Amazon EFS CSI Driver, and this is related to [issue 468](https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/468).

**What is this PR about? / Why do we need it?**
As on-premise Kubernetes users also would like to leverage Amazon EFS service for shared file system, while currently there are several issues when deploying to on-premise environment, like EC2 metadata service dependency.

**What testing is done?** 
I've tested using actual on-premise Kubernetes environment.
