### PR TITLE
Add support for cross account mount

### DIFF
--- a/charts/aws-efs-csi-driver/templates/controller-serviceaccount.yaml
+++ b/charts/aws-efs-csi-driver/templates/controller-serviceaccount.yaml
@@ -40,6 +40,9 @@ rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["get", "watch", "list", "delete", "update", "create"]
+  - apiGroups: [ "" ]
+    resources: [ "secrets" ]
+    verbs: [ "get", "watch", "list" ]
 
 ---
 

--- a/deploy/kubernetes/base/controller-serviceaccount.yaml
+++ b/deploy/kubernetes/base/controller-serviceaccount.yaml
@@ -36,6 +36,9 @@ rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["get", "watch", "list", "delete", "update", "create"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "watch", "list"]
 ---
 # Source: aws-efs-csi-driver/templates/controller-serviceaccount.yaml
 kind: ClusterRoleBinding

--- a/pkg/cloud/cloud_test.go
+++ b/pkg/cloud/cloud_test.go
@@ -12,6 +12,11 @@ import (
 	"github.com/kubernetes-sigs/aws-efs-csi-driver/pkg/cloud/mocks"
 )
 
+type errtyp struct {
+	code    string
+	message string
+}
+
 func TestCreateAccessPoint(t *testing.T) {
 	var (
 		arn                  = "arn:aws:elasticfilesystem:us-east-1:1234567890:access-point/fsap-abcd1234xyz987"
@@ -469,7 +474,7 @@ func TestDescribeFileSystem(t *testing.T) {
 				mockEfs.EXPECT().DescribeFileSystemsWithContext(gomock.Eq(ctx), gomock.Any()).Return(output, nil)
 				res, err := c.DescribeFileSystem(ctx, fsId)
 				if err != nil {
-					t.Fatalf("Describe Access Point failed: %v", err)
+					t.Fatalf("Describe File System failed: %v", err)
 				}
 
 				if res == nil {
@@ -594,5 +599,147 @@ func TestDescribeFileSystem(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, tc.testFunc)
+	}
+}
+
+func TestDescribeMountTargets(t *testing.T) {
+	var (
+		fsId = "fs-abcd1234"
+		az   = "us-east-1a"
+		mtId = "fsmt-abcd1234"
+	)
+
+	testCases := []struct {
+		name        string
+		mockOutput  *efs.DescribeMountTargetsOutput
+		mockError   error
+		expectError errtyp
+	}{
+		{
+			name: "Success: normal flow",
+			mockOutput: &efs.DescribeMountTargetsOutput{
+				MountTargets: []*efs.MountTargetDescription{
+					{
+						AvailabilityZoneId:   aws.String("az-id"),
+						AvailabilityZoneName: aws.String(az),
+						FileSystemId:         aws.String(fsId),
+						IpAddress:            aws.String("127.0.0.1"),
+						LifeCycleState:       aws.String("available"),
+						MountTargetId:        aws.String(mtId),
+						NetworkInterfaceId:   aws.String("eni-abcd1234"),
+						OwnerId:              aws.String("1234567890"),
+						SubnetId:             aws.String("subnet-abcd1234"),
+					},
+				},
+			},
+			expectError: errtyp{},
+		},
+		{
+			name: "Success: Mount target with preferred AZ does not exist. Pick random Az.",
+			mockOutput: &efs.DescribeMountTargetsOutput{
+				MountTargets: []*efs.MountTargetDescription{
+					{
+						AvailabilityZoneId:   aws.String("az-id"),
+						AvailabilityZoneName: aws.String("us-east-1f"),
+						FileSystemId:         aws.String(fsId),
+						IpAddress:            aws.String("127.0.0.1"),
+						LifeCycleState:       aws.String("available"),
+						MountTargetId:        aws.String(mtId),
+						NetworkInterfaceId:   aws.String("eni-abcd1234"),
+						OwnerId:              aws.String("1234567890"),
+						SubnetId:             aws.String("subnet-abcd1234"),
+					},
+				},
+			},
+			expectError: errtyp{},
+		},
+		{
+			name: "Fail: File system does not have any mount targets",
+			mockOutput: &efs.DescribeMountTargetsOutput{
+				MountTargets: []*efs.MountTargetDescription{},
+			},
+			expectError: errtyp{
+				code:    "",
+				message: "Cannot find mount targets for file system fs-abcd1234. Please create mount targets for file system.",
+			},
+		},
+		{
+			name: "Fail: File system does not have any mount targets in available life cycle state",
+			mockOutput: &efs.DescribeMountTargetsOutput{
+				MountTargets: []*efs.MountTargetDescription{
+					{
+						AvailabilityZoneId:   aws.String("az-id"),
+						AvailabilityZoneName: aws.String(az),
+						FileSystemId:         aws.String(fsId),
+						IpAddress:            aws.String("127.0.0.1"),
+						LifeCycleState:       aws.String("creating"),
+						MountTargetId:        aws.String(mtId),
+						NetworkInterfaceId:   aws.String("eni-abcd1234"),
+						OwnerId:              aws.String("1234567890"),
+						SubnetId:             aws.String("subnet-abcd1234"),
+					},
+				},
+			},
+			expectError: errtyp{
+				code:    "",
+				message: "No mount target for file system fs-abcd1234 is in available state. Please retry in 5 minutes.",
+			},
+		},
+		{
+			name:        "Fail: File System Not Found",
+			mockError:   awserr.New(efs.ErrCodeFileSystemNotFound, "File system not found", errors.New("File system not found")),
+			expectError: errtyp{message: "Resource was not found"},
+		},
+		{
+			name:        "Fail: Access Denied",
+			mockError:   awserr.New(AccessDeniedException, "Access Denied", errors.New("Access Denied")),
+			expectError: errtyp{message: "Access denied"},
+		},
+		{
+			name:        "Fail: Other",
+			mockError:   errors.New("DescribeMountTargetsWithContext failed"),
+			expectError: errtyp{message: "Describe Mount Targets failed: DescribeMountTargetsWithContext failed"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockctl := gomock.NewController(t)
+			defer mockctl.Finish()
+			mockEfs := mocks.NewMockEfs(mockctl)
+			c := &cloud{efs: mockEfs}
+			ctx := context.Background()
+
+			if tc.mockOutput != nil {
+				mockEfs.EXPECT().DescribeMountTargetsWithContext(gomock.Eq(ctx), gomock.Any(), gomock.Any()).Return(tc.mockOutput, nil)
+			}
+
+			if tc.mockError != nil {
+				mockEfs.EXPECT().DescribeMountTargetsWithContext(gomock.Eq(ctx), gomock.Any(), gomock.Any()).Return(nil, tc.mockError)
+			}
+
+			res, err := c.DescribeMountTargets(ctx, fsId, az)
+			testResult(t, "DescribeMountTargets", res, err, tc.expectError)
+
+		})
+	}
+}
+
+func testResult(t *testing.T, funcName string, ret interface{}, err error, expectError errtyp) {
+	if expectError.message == "" {
+		if err != nil {
+			t.Fatalf("%s is failed: %v", funcName, err)
+		}
+		if ret == nil {
+			t.Fatal("Expected non-nil return value")
+		}
+	} else {
+		if err == nil {
+			t.Fatalf("%s is not failed", funcName)
+		}
+
+		if err.Error() != expectError.message {
+			t.Fatalf("\nExpected error message: %s\nActual error message:   %s", expectError.message, err.Error())
+		}
 	}
 }

--- a/pkg/cloud/fakes.go
+++ b/pkg/cloud/fakes.go
@@ -11,6 +11,7 @@ type FakeCloudProvider struct {
 	m            *metadata
 	fileSystems  map[string]*FileSystem
 	accessPoints map[string]*AccessPoint
+	mountTargets map[string]*MountTarget
 }
 
 func NewFakeCloudProvider() *FakeCloudProvider {
@@ -18,6 +19,7 @@ func NewFakeCloudProvider() *FakeCloudProvider {
 		m:            &metadata{"instanceID", "region", "az"},
 		fileSystems:  make(map[string]*FileSystem),
 		accessPoints: make(map[string]*AccessPoint),
+		mountTargets: make(map[string]*MountTarget),
 	}
 }
 
@@ -76,5 +78,22 @@ func (c *FakeCloudProvider) DescribeFileSystem(ctx context.Context, fileSystemId
 		FileSystemId: fileSystemId,
 	}
 	c.fileSystems[fileSystemId] = fs
+
+	mt := &MountTarget{
+		AZName:        "us-east-1a",
+		AZId:          "mock-AZ-id",
+		MountTargetId: "fsmt-abcd1234",
+		IPAddress:     "127.0.0.1",
+	}
+
+	c.mountTargets[fileSystemId] = mt
 	return fs, nil
+}
+
+func (c *FakeCloudProvider) DescribeMountTargets(ctx context.Context, fileSystemId, az string) (mountTarget *MountTarget, err error) {
+	if mt, ok := c.mountTargets[fileSystemId]; ok {
+		return mt, nil
+	}
+
+	return nil, ErrNotFound
 }

--- a/pkg/cloud/mocks/mock_efs.go
+++ b/pkg/cloud/mocks/mock_efs.go
@@ -115,3 +115,23 @@ func (mr *MockEfsMockRecorder) DescribeFileSystemsWithContext(arg0, arg1 interfa
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeFileSystemsWithContext", reflect.TypeOf((*MockEfs)(nil).DescribeFileSystemsWithContext), varargs...)
 }
+
+// DescribeMountTargetsWithContext mocks base method.
+func (m *MockEfs) DescribeMountTargetsWithContext(arg0 context.Context, arg1 *efs.DescribeMountTargetsInput, arg2 ...request.Option) (*efs.DescribeMountTargetsOutput, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DescribeMountTargetsWithContext", varargs...)
+	ret0, _ := ret[0].(*efs.DescribeMountTargetsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeMountTargetsWithContext indicates an expected call of DescribeMountTargetsWithContext.
+func (mr *MockEfsMockRecorder) DescribeMountTargetsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeMountTargetsWithContext", reflect.TypeOf((*MockEfs)(nil).DescribeMountTargetsWithContext), varargs...)
+}

--- a/pkg/driver/efs_watch_dog.go
+++ b/pkg/driver/efs_watch_dog.go
@@ -71,6 +71,12 @@ port_range_upper_bound = 20449
 # Optimize read_ahead_kb for Linux 5.4+
 optimize_readahead = true
 
+# By default, we enable the feature to fallback to mount with mount target ip address when dns name cannot be resolved
+fall_back_to_mount_target_ip_address_enabled = true
+
+# By default, we use IMDSv2 to get the instance metadata, set this to true if you want to disable IMDSv2 usage
+disable_fetch_ec2_metadata_token = false
+
 
 [mount.cn-north-1]
 dns_name_suffix = amazonaws.com.cn

--- a/pkg/driver/efs_watch_dog_test.go
+++ b/pkg/driver/efs_watch_dog_test.go
@@ -61,6 +61,12 @@ port_range_upper_bound = 20449
 # Optimize read_ahead_kb for Linux 5.4+
 optimize_readahead = true
 
+# By default, we enable the feature to fallback to mount with mount target ip address when dns name cannot be resolved
+fall_back_to_mount_target_ip_address_enabled = true
+
+# By default, we use IMDSv2 to get the instance metadata, set this to true if you want to disable IMDSv2 usage
+disable_fetch_ec2_metadata_token = false
+
 
 [mount.cn-north-1]
 dns_name_suffix = amazonaws.com.cn

--- a/pkg/driver/mocks/mock_cloud.go
+++ b/pkg/driver/mocks/mock_cloud.go
@@ -94,6 +94,21 @@ func (mr *MockCloudMockRecorder) DescribeFileSystem(arg0, arg1 interface{}) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeFileSystem", reflect.TypeOf((*MockCloud)(nil).DescribeFileSystem), arg0, arg1)
 }
 
+// DescribeMountTargets mocks base method.
+func (m *MockCloud) DescribeMountTargets(ctx context.Context, fileSystemId, az string) (*cloud.MountTarget, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DescribeMountTargets", ctx, fileSystemId, az)
+	ret0, _ := ret[0].(*cloud.MountTarget)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeMountTargets indicates an expected call of DescribeMountTargets.
+func (mr *MockCloudMockRecorder) DescribeMountTargets(ctx, fileSystemId, az interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeMountTargets", reflect.TypeOf((*MockCloud)(nil).DescribeMountTargets), ctx, fileSystemId, az)
+}
+
 // GetMetadata mocks base method
 func (m *MockCloud) GetMetadata() cloud.MetadataService {
 	m.ctrl.T.Helper()

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -90,6 +90,9 @@ func (d *Driver) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolu
 			if err != nil {
 				return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("Volume context property %q must be a boolean value: %v", k, err))
 			}
+		case MountTargetIp:
+			ipAddr := volContext[MountTargetIp]
+			mountOptions = append(mountOptions, MountTargetIp+"="+ipAddr)
 		default:
 			return nil, status.Errorf(codes.InvalidArgument, "Volume context property %s not supported", k)
 		}

--- a/pkg/driver/node_test.go
+++ b/pkg/driver/node_test.go
@@ -304,6 +304,19 @@ func TestNodePublishVolume(t *testing.T) {
 			mountSuccess:  true,
 		},
 		{
+			name: "success: normal with volume context populated from dynamic provisioning",
+			req: &csi.NodePublishVolumeRequest{
+				VolumeId:         volumeId,
+				VolumeCapability: stdVolCap,
+				TargetPath:       targetPath,
+				VolumeContext: map[string]string{"storage.kubernetes.io/csiprovisioneridentity": "efs.csi.aws.com",
+					"mounttargetip": "127.0.0.1"},
+			},
+			expectMakeDir: true,
+			mountArgs:     []interface{}{volumeId + ":/", targetPath, "efs", []string{"mounttargetip=127.0.0.1", "tls"}},
+			mountSuccess:  true,
+		},
+		{
 			name: "fail: conflicting access point in volume handle and mount options",
 			req: &csi.NodePublishVolumeRequest{
 				VolumeId: volumeId + "::" + accessPointID,


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

New Feature

**What is this PR about? / Why do we need it?**

### Support for cross-account mount.

A new mount option was introduced to [mount-helper](https://github.com/aws/efs-utils) `mounttargetip`. This option allows users to pass the ip address of the desired mount target of the efs file system. This option also facilitates cross account mount support provided [vpc-peering](https://docs.aws.amazon.com/vpc/latest/peering/working-with-vpc-peering.html) has been established.

This PR adds cross account support using above mount option.

Pre-requisite steps to perform cross account mounts with EKS cluster in Account `A` & EFS in Account `B`:

1.  Perform [vpc-peering](https://docs.aws.amazon.com/vpc/latest/peering/working-with-vpc-peering.html) between EKS cluster `vpc` and EFS `vpc`.
2.  Create an IAM role in Account `B` which has a trust relationship with Account `A` and add an EFS policy with permissions to call `DescribeMountTargets`. This role will be used by CSI-Driver to determine the mount targets for file system in account `B`
3. Create kubenetes secret with `awsRoleArn` as the key and the role from step 2 as the value. For example, `kubectl create secret generic x-account --namespace=default --from-literal=awsRoleArn='arn:aws:iam::1234567890:role/EFSCrossAccountAccessRole'`
4. Create a service account with IAM role for the EKS cluster and attach it node-deamonset. Attach this IAM role with EFS client mount permission policy.
5. Create a [file system policy](https://docs.aws.amazon.com/efs/latest/ug/iam-access-control-nfs-efs.html#file-sys-policy-examples) for file system in account `B` which allows account `A` to perform mount on it.

Additionally, a new storage class parameter `az` allows users to specify preferred mount target for mount. If preferred AZ is unavailable, a random AZ will chosen.

Sample Storage class:

```bash
kind: StorageClass
apiVersion: storage.k8s.io/v1
metadata:
  name: efs-sc
provisioner: efs.csi.aws.com
mountOptions:
  - iam
  - az=us-east-1f # optional, allows cross AZ mount
parameters:
  provisioningMode: efs-ap
  fileSystemId: fs-01234abcd
  directoryPerms: "700"
  gidRangeStart: "1000" # optional
  gidRangeEnd: "2000" # optional
  basePath: "/dynamic_provisioning" # optional
  az: us-east-1f # optional, used by controller to provide a preferred mount-target AZ
  csi.storage.k8s.io/provisioner-secret-name: x-account # optional, required for cross-account mount. Should be unique per storage class
  csi.storage.k8s.io/provisioner-secret-namespace: kube-system # option, required for cross-account mount
```

**What testing is done?** 

Tested by spinning up EKS cluster in account `A` and performing cross account mount on file systems in different accounts.