### PR TITLE
Put comments back in place inside the values file

### DIFF
--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -66,10 +66,10 @@ controller:
   # Specifies whether a service account should be created
   serviceAccount:
     create: true
-    ## Enable if EKS IAM for SA is used
-    #  eks.amazonaws.com/role-arn: arn:aws:iam::111122223333:role/efs-csi-role
     name: efs-csi-controller-sa
     annotations: {}
+    ## Enable if EKS IAM for SA is used
+    #  eks.amazonaws.com/role-arn: arn:aws:iam::111122223333:role/efs-csi-role
 
 ## Node daemonset variables
 


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

Not really a bug fix but it corrects a problem inside the chart value file. 

Ref: https://github.com/kubernetes-sigs/aws-efs-csi-driver/commit/008332a5abe988a3d6e7c9c2887229283ffce1bc#diff-56338152bc066c1274cc12e455c5d0585a0ce0cb30831547f47a758d2a750862L78-L80

**What is this PR about? / Why do we need it?**

The commented example has been moved to the wrong place.
Can be confusing for anyone who wants to use the annotation. 

**What testing is done?** 

None, just a moved comments.