### PR TITLE
Added DNS Config for Controller to support EFS Access Point deletion.

### DIFF
--- a/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
+++ b/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
@@ -23,7 +23,11 @@ spec:
       annotations: {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
-      hostNetwork: true 
+      hostNetwork: true
+      dnsPolicy: {{ .Values.controller.dnsPolicy }}
+      {{- with .Values.controller.dnsConfig }}
+      dnsConfig: {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- range .Values.imagePullSecrets }}

--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -70,6 +70,11 @@ controller:
     annotations: {}
     ## Enable if EKS IAM for SA is used
     #  eks.amazonaws.com/role-arn: arn:aws:iam::111122223333:role/efs-csi-role
+  # Example config which uses the AWS nameservers
+  # dnsPolicy: "None"
+  # dnsConfig:
+  #   nameservers:
+  #     - 169.254.169.253
 
 ## Node daemonset variables
 


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Bug fix according to me. Currently, only EFS Node supports DNS config allowing for file system DNS resolution. But the deletion of AccessPoints is controlled by EFS Controller which cannot resolve the file system domain name. 

**What is this PR about? / Why do we need it?**
This PR updates the EFS controller deployment template by adding DNS config support.

**What testing is done?** 
Deployed on EKS cluster and tested dynamic provisioning as well as auto-deletion of AccessPoints upon deletion of PersistentVolumeClaim.