### PR TITLE
Added extraCreateMetadata to the chart

### DIFF
--- a/charts/aws-efs-csi-driver/Chart.yaml
+++ b/charts/aws-efs-csi-driver/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: aws-efs-csi-driver
-version: 2.1.1
+version: 2.1.2
 appVersion: 1.3.1
 kubeVersion: ">=1.17.0-0"
 description: "A Helm chart for AWS EFS CSI Driver"

--- a/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
+++ b/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
@@ -82,6 +82,9 @@ spec:
             - --csi-address=$(ADDRESS)
             - --v={{ .Values.controller.logLevel }}
             - --feature-gates=Topology=true
+            {{- if .Values.controller.extraCreateMetadata }}
+            - --extra-create-metadata
+            {{- end }}
             - --leader-election
           env:
             - name: ADDRESS

--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -41,6 +41,8 @@ controller:
   create: true
   # Number for the log level verbosity
   logLevel: 2
+  # If set, add pv/pvc metadata to plugin create requests as parameters.
+  extraCreateMetadata: true
   # Add additional tags to access points
   tags: {}
     # environment: prod


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

New feature: added the chance to configure extraCreateMetadata in the CSI Provisioner container

**What is this PR about? / Why do we need it?**

Fixes #446 

**What testing is done?** 

Deployed on EKS cluster and tested