### PR TITLE
Add additional env vars to containers in Helm chart

### DIFF
--- a/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
+++ b/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
@@ -57,6 +57,9 @@ spec:
           env:
             - name: CSI_ENDPOINT
               value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+            {{- with .Values.controller.env.efsPlugin }}
+            {{- . | toYaml | nindent 12 }}
+            {{- end }}
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
@@ -86,6 +89,9 @@ spec:
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
+            {{- with .Values.controller.env.csiProvisioner }}
+            {{- . | toYaml | nindent 12 }}
+            {{- end }}
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/

--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -45,6 +45,10 @@ controller:
   tags: {}
     # environment: prod
     # region: us-east-1
+  # Add additional env to containers
+  env:
+    efsPlugin: []
+    csiProvisioner: []
   # Enable if you want the controller to also delete the
   # path on efs when deleteing an access point
   deleteAccessPointRootDir: false


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Feature

**What is this PR about? / Why do we need it?**
Add support in Helm chart to add custom env vars to efs-plugin and csi-provisioner containers

**What testing is done?** 
Deployed the Helm chart with custom env vars
