### PR TITLE
Avoid deprecation warnings. CSI is GA as of 1.13

### DIFF
--- a/charts/aws-efs-csi-driver/templates/csidriver.yaml
+++ b/charts/aws-efs-csi-driver/templates/csidriver.yaml
@@ -1,4 +1,4 @@
-apiVersion: {{ ternary "storage.k8s.io/v1" "storage.k8s.io/v1beta1" (semverCompare ">=1.18.0-0" .Capabilities.KubeVersion.Version) }}
+apiVersion: {{ ternary "storage.k8s.io/v1" "storage.k8s.io/v1beta1" (semverCompare ">=1.13.0-0" .Capabilities.KubeVersion.Version) }}
 kind: CSIDriver
 metadata:
   name: efs.csi.aws.com


### PR DESCRIPTION
According to https://kubernetes.io/blog/2019/01/15/container-storage-interface-ga/, CSI became GA in 1.13. As of 1.20, it's throwing deprecation warnings, triggering issue #396 . I'll admit to not knowing how the build process works for this project, so I haven't tested this. But this appears to be a reasonable place to reflect where GA actually happened so that the latest versions of the driver can stop throwing deprecation warnings.