### PR TITLE
Add node/daemonset service account to helm chart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,5 +104,6 @@ push-release:
 generate-kustomize: bin/helm
 	cd charts/aws-efs-csi-driver && ../../bin/helm template kustomize . -s templates/csidriver.yaml > ../../deploy/kubernetes/base/csidriver.yaml
 	cd charts/aws-efs-csi-driver && ../../bin/helm template kustomize . -s templates/node-daemonset.yaml -f values.yaml > ../../deploy/kubernetes/base/node-daemonset.yaml
+	cd charts/aws-efs-csi-driver && ../../bin/helm template kustomize . -s templates/node-serviceaccount.yaml -f values.yaml > ../../deploy/kubernetes/base/node-serviceaccount.yaml
 	cd charts/aws-efs-csi-driver && ../../bin/helm template kustomize . -s templates/controller-deployment.yaml -f values.yaml > ../../deploy/kubernetes/base/controller-deployment.yaml
 	cd charts/aws-efs-csi-driver && ../../bin/helm template kustomize . -s templates/controller-serviceaccount.yaml -f values.yaml > ../../deploy/kubernetes/base/controller-serviceaccount.yaml

--- a/charts/aws-efs-csi-driver/CHANGELOG.md
+++ b/charts/aws-efs-csi-driver/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Helm chart
 
+# v2.1.4
+* Add node.serviceAccount values for creating and/or specifying daemonset service account
+
 # v2.1.3
 * Bump app/driver version to `v1.3.2` 
 

--- a/charts/aws-efs-csi-driver/Chart.yaml
+++ b/charts/aws-efs-csi-driver/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: aws-efs-csi-driver
-version: 2.1.3
+version: 2.1.4
 appVersion: 1.3.2
 kubeVersion: ">=1.17.0-0"
 description: "A Helm chart for AWS EFS CSI Driver"

--- a/charts/aws-efs-csi-driver/templates/_helpers.tpl
+++ b/charts/aws-efs-csi-driver/templates/_helpers.tpl
@@ -45,17 +45,6 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
 
 {{/*
-Create the name of the service account to use
-*/}}
-{{- define "aws-efs-csi-driver.serviceAccountName" -}}
-{{- if .Values.controller.create -}}
-    {{ default (include "aws-efs-csi-driver.fullname" .) .Values.controller.serviceAccount.name }}
-{{- else -}}
-    {{ default "default" .Values.controller.serviceAccount.name }}
-{{- end -}}
-{{- end -}}
-
-{{/*
 Create a string out of the map for controller tags flag
 */}}
 {{- define "aws-efs-csi-driver.tags" -}}

--- a/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
+++ b/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
@@ -35,7 +35,7 @@ spec:
         {{- with .Values.controller.nodeSelector }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      serviceAccountName: {{ include "aws-efs-csi-driver.serviceAccountName" . }}
+      serviceAccountName: {{ .Values.controller.serviceAccount.name }}
       priorityClassName: system-cluster-critical
       {{- with .Values.controller.tolerations }}
       tolerations: {{- toYaml . | nindent 8 }}

--- a/charts/aws-efs-csi-driver/templates/controller-serviceaccount.yaml
+++ b/charts/aws-efs-csi-driver/templates/controller-serviceaccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "aws-efs-csi-driver.serviceAccountName" . }}
+  name: {{ .Values.controller.serviceAccount.name }}
   labels:
     app.kubernetes.io/name: {{ include "aws-efs-csi-driver.name" . }}
   {{- with .Values.controller.serviceAccount.annotations }}
@@ -54,7 +54,7 @@ metadata:
     app.kubernetes.io/name: {{ include "aws-efs-csi-driver.name" . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ include "aws-efs-csi-driver.serviceAccountName" . }}
+    name: {{ .Values.controller.serviceAccount.name }}
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole

--- a/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
+++ b/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
@@ -54,6 +54,7 @@ spec:
       {{- with .Values.node.dnsConfig }}
       dnsConfig: {{- toYaml . | nindent 8 }}
       {{- end }}
+      serviceAccountName: {{ .Values.node.serviceAccount.name }}
       priorityClassName: system-node-critical
       {{- with .Values.node.tolerations }}
       tolerations: {{- toYaml . | nindent 8 }}

--- a/charts/aws-efs-csi-driver/templates/node-serviceaccount.yaml
+++ b/charts/aws-efs-csi-driver/templates/node-serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.node.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.node.serviceAccount.name }}
+  labels:
+    app.kubernetes.io/name: {{ include "aws-efs-csi-driver.name" . }}
+  {{- with .Values.node.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -44,14 +44,16 @@ controller:
   # If set, add pv/pvc metadata to plugin create requests as parameters.
   extraCreateMetadata: true
   # Add additional tags to access points
-  tags: {}
+  tags:
+    {}
     # environment: prod
     # region: us-east-1
   # Enable if you want the controller to also delete the
   # path on efs when deleteing an access point
   deleteAccessPointRootDir: false
   podAnnotations: {}
-  resources: {}
+  resources:
+    {}
     # We usually recommend not to specify default resources and to leave this as a conscious
     # choice for the user. This also increases chances charts run on environments with little
     # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -78,7 +80,8 @@ controller:
 node:
   # Number for the log level verbosity
   logLevel: 2
-  hostAliases: {}
+  hostAliases:
+    {}
     # For cross VPC EFS, you need to poison or overwrite the DNS for the efs volume as per
     # https://docs.aws.amazon.com/efs/latest/ug/efs-different-vpc.html#wt6-efs-utils-step3
     # implementing the suggested solution found here:
@@ -88,14 +91,16 @@ node:
     #   ip: 10.10.2.2
     #   region: us-east-2
   dnsPolicy: ClusterFirst
-  dnsConfig: {}
+  dnsConfig:
+    {}
     # Example config which uses the AWS nameservers
     # dnsPolicy: "None"
     # dnsConfig:
     #   nameservers:
     #     - 169.254.169.253
   podAnnotations: {}
-  resources: {}
+  resources:
+    {}
     # limits:
     #   cpu: 100m
     #   memory: 128Mi
@@ -105,6 +110,13 @@ node:
   nodeSelector: {}
   tolerations:
     - operator: Exists
+  # Specifies whether a service account should be created
+  serviceAccount:
+    create: true
+    name: efs-csi-node-sa
+    annotations: {}
+    ## Enable if EKS IAM for SA is used
+    #  eks.amazonaws.com/role-arn: arn:aws:iam::111122223333:role/efs-csi-role
 
 storageClasses: []
 # Add StorageClass resources like:

--- a/deploy/kubernetes/base/controller-deployment.yaml
+++ b/deploy/kubernetes/base/controller-deployment.yaml
@@ -57,10 +57,12 @@ spec:
             failureThreshold: 5
         - name: csi-provisioner
           image: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner:v2.1.1-eks-1-18-2
+          imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)
             - --v=2
             - --feature-gates=Topology=true
+            - --extra-create-metadata
             - --leader-election
           env:
             - name: ADDRESS
@@ -70,6 +72,7 @@ spec:
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: liveness-probe
           image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.2.0-eks-1-18-2
+          imagePullPolicy: IfNotPresent
           args:
             - --csi-address=/csi/csi.sock
             - --health-port=9909

--- a/deploy/kubernetes/base/controller-serviceaccount.yaml
+++ b/deploy/kubernetes/base/controller-serviceaccount.yaml
@@ -36,9 +36,9 @@ rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["get", "watch", "list", "delete", "update", "create"]
-  - apiGroups: [""]
-    resources: ["secrets"]
-    verbs: ["get", "watch", "list"]
+  - apiGroups: [ "" ]
+    resources: [ "secrets" ]
+    verbs: [ "get", "watch", "list" ]
 ---
 # Source: aws-efs-csi-driver/templates/controller-serviceaccount.yaml
 kind: ClusterRoleBinding

--- a/deploy/kubernetes/base/csidriver.yaml
+++ b/deploy/kubernetes/base/csidriver.yaml
@@ -1,6 +1,6 @@
 ---
 # Source: aws-efs-csi-driver/templates/csidriver.yaml
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:
   name: efs.csi.aws.com

--- a/deploy/kubernetes/base/node-daemonset.yaml
+++ b/deploy/kubernetes/base/node-daemonset.yaml
@@ -32,6 +32,8 @@ spec:
                 values:
                 - fargate
       hostNetwork: true
+      dnsPolicy: ClusterFirst
+      serviceAccountName: efs-csi-node-sa
       priorityClassName: system-node-critical
       tolerations:
         - operator: Exists
@@ -40,6 +42,7 @@ spec:
           securityContext:
             privileged: true
           image: "amazon/aws-efs-csi-driver:v1.3.2"
+          imagePullPolicy: IfNotPresent
           args:
             - --endpoint=$(CSI_ENDPOINT)
             - --logtostderr
@@ -73,6 +76,7 @@ spec:
             failureThreshold: 5
         - name: csi-driver-registrar
           image: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar:v2.1.0-eks-1-18-2
+          imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)
             - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
@@ -93,6 +97,7 @@ spec:
               mountPath: /registration
         - name: liveness-probe
           image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.2.0-eks-1-18-2
+          imagePullPolicy: IfNotPresent
           args:
             - --csi-address=/csi/csi.sock
             - --health-port=9809

--- a/deploy/kubernetes/base/node-serviceaccount.yaml
+++ b/deploy/kubernetes/base/node-serviceaccount.yaml
@@ -1,0 +1,8 @@
+---
+# Source: aws-efs-csi-driver/templates/node-serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: efs-csi-node-sa
+  labels:
+    app.kubernetes.io/name: aws-efs-csi-driver


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

**What is this PR about? / Why do we need it?**

node should have option to have its own serviceaccount (besides "default"). Moreover there is a specific situation where you need to give the node permissions, so for EKS users the serviceaccount can be used for IAM for SA. https://github.com/kubernetes-sigs/aws-efs-csi-driver/tree/master/examples/kubernetes/cross_account_mount#prerequisite-setup
https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/503
https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/397
https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/316

**What testing is done?** 
