### PR TITLE
release-1.3: Fix node-serviceaccount.yaml missing from kustomize

### DIFF
--- a/deploy/kubernetes/base/kustomization.yaml
+++ b/deploy/kubernetes/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: kube-system
 resources:
 - node-daemonset.yaml
+- node-serviceaccount.yaml
 - csidriver.yaml
 - controller-deployment.yaml
 - controller-serviceaccount.yaml


### PR DESCRIPTION
**Is this a bug fix or adding new feature?** /bug

**What is this PR about? / Why do we need it?** added the file to dir, but not to kustomization.yaml. 
fixes https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/519

**What testing is done?** 
