### PR TITLE
Fix block provisioning

### DIFF
--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -18,6 +18,7 @@ package driver
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"strconv"
 	"strings"
@@ -70,8 +71,8 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 		return nil, status.Error(codes.InvalidArgument, "Volume capabilities not provided")
 	}
 
-	if !d.isValidVolumeCapabilities(volCaps) {
-		return nil, status.Error(codes.InvalidArgument, "Volume capabilities not supported")
+	if err := d.isValidVolumeCapabilities(volCaps); err != nil {
+		return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("Volume capabilities not supported: %s", err))
 	}
 
 	var (
@@ -358,7 +359,7 @@ func (d *Driver) ValidateVolumeCapabilities(ctx context.Context, req *csi.Valida
 	}
 
 	var confirmed *csi.ValidateVolumeCapabilitiesResponse_Confirmed
-	if d.isValidVolumeCapabilities(volCaps) {
+	if err := d.isValidVolumeCapabilities(volCaps); err == nil {
 		confirmed = &csi.ValidateVolumeCapabilitiesResponse_Confirmed{VolumeCapabilities: volCaps}
 	}
 	return &csi.ValidateVolumeCapabilitiesResponse{

--- a/pkg/driver/node_test.go
+++ b/pkg/driver/node_test.go
@@ -392,7 +392,7 @@ func TestNodePublishVolume(t *testing.T) {
 			expectMakeDir: false,
 			expectError: errtyp{
 				code:    "InvalidArgument",
-				message: "Volume capability not supported",
+				message: "Volume capability not supported: invalid access mode: SINGLE_NODE_READER_ONLY",
 			},
 		},
 		{
@@ -412,7 +412,7 @@ func TestNodePublishVolume(t *testing.T) {
 			expectMakeDir: false,
 			expectError: errtyp{
 				code:    "InvalidArgument",
-				message: "Volume capability access type must be mount",
+				message: "Volume capability not supported: only filesystem volumes are supported",
 			},
 		},
 		{


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
/kind bug
Fixes: #547

**What is this PR about? / Why do we need it?**
Return error when CO requests a block volume to be dynamically provisioned. EFS does not support them. When at it, add more error reporting when validating volume capabilities, so the caller (or user) knows what's wrong with a capability instead of generic "Volume capability not supported".

**What testing is done?** 
Tested with the Kubernetes external CSI tests.