### PR TITLE
[release-1.3] Update ecr kustomize overlay to pull sidecars from private ecr, not public

### DIFF
--- a/deploy/kubernetes/overlays/stable/ecr/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/ecr/kustomization.yaml
@@ -6,3 +6,12 @@ images:
   - name: amazon/aws-efs-csi-driver
     newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/aws-efs-csi-driver
     newTag: v1.3.4
+  - name: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe
+    newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/livenessprobe
+    newTag: v2.2.0
+  - name: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar
+    newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-node-driver-registrar
+    newTag: v2.1.0
+  - name: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner
+    newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-provisioner
+    newTag: v2.1.1


### PR DESCRIPTION
copy of https://github.com/kubernetes-sigs/aws-efs-csi-driver/pull/549 on master branch

**Is this a bug fix or adding new feature?** addresses https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/294#issuecomment-865060883.

**What is this PR about? / Why do we need it?** some users are in airgapped vpc and cannot pull from public ecr. Instead of having the ecr overlay be a mix of public and private, make it refer to private registry listed at https://docs.aws.amazon.com/eks/latest/userguide/add-ons-images.html.

**What testing is done?** 

```
$ k apply -k ./deploy/kubernetes/overlays/stable/ecr
serviceaccount/efs-csi-controller-sa created
serviceaccount/efs-csi-node-sa created
clusterrole.rbac.authorization.k8s.io/efs-csi-external-provisioner-role created
clusterrolebinding.rbac.authorization.k8s.io/efs-csi-provisioner-binding created
deployment.apps/efs-csi-controller created
daemonset.apps/efs-csi-node created
csidriver.storage.k8s.io/efs.csi.aws.com created
$ k get po -n kube-system | grep efs
efs-csi-controller-7b5ff6d5b4-84jg2       3/3     Running   0          6s
efs-csi-node-wq4zd                        3/3     Running   0          6s
$ k get po -n kube-system efs-csi-node-wq4zd  -o yaml | grep image:
    image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/aws-efs-csi-driver:v1.3.3
    image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-node-driver-registrar:v2.1.0
    image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/livenessprobe:v2.2.0

$ k get po -n kube-system efs-csi-controller-7b5ff6d5b4-84jg2  -o yaml | grep image:
    image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/aws-efs-csi-driver:v1.3.3
    image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-provisioner:v2.1.1
    image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/livenessprobe:v2.2.0
```
