### PR TITLE
Release helm chart v2.1.6

### DIFF
--- a/charts/aws-efs-csi-driver/Chart.yaml
+++ b/charts/aws-efs-csi-driver/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: aws-efs-csi-driver
-version: 2.1.5
+version: 2.1.6
 appVersion: 1.3.3
 kubeVersion: ">=1.17.0-0"
 description: "A Helm chart for AWS EFS CSI Driver"


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

**What is this PR about? / Why do we need it?** It seems CHANGELOG got updated but I forgot about updating the chart itself which is required for triggering a release. For completeness let's release v2.1.6 (even if I intend to release v2.2.0 right after) 
 

Here's the failed helm chart v2.1.6 release attempt https://github.com/kubernetes-sigs/aws-efs-csi-driver/runs/3488535351

**What testing is done?** 
