### PR TITLE
Ignore - wait: no child processes error when calling mount/umount

### DIFF
--- a/vendor/k8s.io/mount-utils/mount_linux.go
+++ b/vendor/k8s.io/mount-utils/mount_linux.go
@@ -45,6 +45,8 @@ const (
 	fsckErrorsCorrected = 1
 	// 'fsck' found errors but exited without correcting them
 	fsckErrorsUncorrected = 4
+	// Error thrown by exec cmd.Run() when process spawned by cmd.Start() completes before cmd.Wait() is called (see - k/k issue #103753)
+	errNoChildProcesses = "wait: no child processes"
 )
 
 // Mounter provides the default implementation of mount.Interface
@@ -181,6 +183,14 @@ func (mounter *Mounter) doMount(mounterPath string, mountCmd string, source stri
 	command := exec.Command(mountCmd, mountArgs...)
 	output, err := command.CombinedOutput()
 	if err != nil {
+		if err.Error() == errNoChildProcesses {
+			if command.ProcessState.Success() {
+				// We don't consider errNoChildProcesses an error if the process itself succeeded (see - k/k issue #103753).
+				return nil
+			}
+			// Rewrite err with the actual exit error of the process.
+			err = &exec.ExitError{ProcessState: command.ProcessState}
+		}
 		klog.Errorf("Mount failed: %v\nMounting command: %s\nMounting arguments: %s\nOutput: %s\n", err, mountCmd, mountArgsLogStr, string(output))
 		return fmt.Errorf("mount failed: %v\nMounting command: %s\nMounting arguments: %s\nOutput: %s",
 			err, mountCmd, mountArgsLogStr, string(output))
@@ -284,6 +294,14 @@ func (mounter *Mounter) Unmount(target string) error {
 	command := exec.Command("umount", target)
 	output, err := command.CombinedOutput()
 	if err != nil {
+		if err.Error() == errNoChildProcesses {
+			if command.ProcessState.Success() {
+				// We don't consider errNoChildProcesses an error if the process itself succeeded (see - k/k issue #103753).
+				return nil
+			}
+			// Rewrite err with the actual exit error of the process.
+			err = &exec.ExitError{ProcessState: command.ProcessState}
+		}
 		return fmt.Errorf("unmount failed: %v\nUnmounting arguments: %s\nOutput: %s", err, target, string(output))
 	}
 	return nil


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

**What is this PR about? / Why do we need it?**
Ignore - wait: no child processes error when calling mount/umount
**What testing is done?** 
[WIP] To be updated shortly