### PR TITLE
Add AWS_STS_REGIONAL_ENDPOINTS flag to controller

### DIFF
--- a/charts/aws-efs-csi-driver/CHANGELOG.md
+++ b/charts/aws-efs-csi-driver/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Helm chart
 
+# v2.2.1
+* Add STS regional endpoints flag to fix PV creation on private EKS
+
 # v2.2.0
 * Allow health ports to be configured
 * Add Missing "patch" permission for "events"

--- a/charts/aws-efs-csi-driver/Chart.yaml
+++ b/charts/aws-efs-csi-driver/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: aws-efs-csi-driver
-version: 2.2.0
+version: 2.2.1
 appVersion: 1.3.3
 kubeVersion: ">=1.17.0-0"
 description: "A Helm chart for AWS EFS CSI Driver"

--- a/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
+++ b/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
@@ -57,6 +57,10 @@ spec:
           env:
             - name: CSI_ENDPOINT
               value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+            {{- if .Values.controller.regionalStsEndpoints }}
+            - name: AWS_STS_REGIONAL_ENDPOINTS
+              value: regional
+            {{- end }}
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/

--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -75,6 +75,7 @@ controller:
     ## Enable if EKS IAM for SA is used
     #  eks.amazonaws.com/role-arn: arn:aws:iam::111122223333:role/efs-csi-role
   healthPort: 9909
+  regionalStsEndpoints: false
 
 ## Node daemonset variables
 


### PR DESCRIPTION
Conditionally added AWS_STS_REGIONAL_ENDPOINTS flag to controller's efs-plugin container.  

**Is this a bug fix or adding new feature?**
bug fix

**What is this PR about? / Why do we need it?**
Is needed to create persistent volumes on private EKS clusters.  Without this, dynamic pv creation errors: "Failed to fetch File System info: Describe File System failed" (see https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/433)

**What testing is done?** 

