### PR TITLE
Build target platform from build platform

### DIFF
--- a/.github/workflows/container-image.yaml
+++ b/.github/workflows/container-image.yaml
@@ -7,34 +7,34 @@ jobs:
     if: github.repository == 'kubernetes-sigs/aws-efs-csi-driver'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - name: Set up Docker Buildx
-      id: buildx
-      uses: crazy-max/ghaction-docker-buildx@v3
-      with:
-        buildx-version: latest
-        qemu-version: latest
-    - name: Push to Dockerhub registry
-      run: |
-        BRANCH=$(echo $GITHUB_REF | cut -d'/' -f3)
-        SHORT_SHA=$(echo $GITHUB_SHA | cut -c -7)
-        REPO=amazon/aws-efs-csi-driver
-        if [ "$BRANCH" = "master" ]; then
-          TAG=$SHORT_SHA
-        else
-          TAG=$BRANCH
-        fi
-        docker login -u ${{ secrets.DOCKERHUB_USER }} -p ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Push to Dockerhub registry
+        run: |
+          BRANCH=$(echo $GITHUB_REF | cut -d'/' -f3)
+          SHORT_SHA=$(echo $GITHUB_SHA | cut -c -7)
+          REPO=amazon/aws-efs-csi-driver
+          if [ "$BRANCH" = "master" ]; then
+            TAG=$SHORT_SHA
+          else
+            TAG=$BRANCH
+          fi
+          docker login -u ${{ secrets.DOCKERHUB_USER }} -p ${{ secrets.DOCKERHUB_TOKEN }}
 
-        docker buildx build \
-              -t $REPO:$TAG \
-              --platform=linux/amd64,linux/arm64 \
-              --progress plain \
-              --push .
-        if [ "$BRANCH" = "master" ]; then
           docker buildx build \
-                -t $REPO:master \
+                -t $REPO:$TAG \
                 --platform=linux/amd64,linux/arm64 \
                 --progress plain \
                 --push .
-        fi
+          if [ "$BRANCH" = "master" ]; then
+            docker buildx build \
+                  -t $REPO:master \
+                  --platform=linux/amd64,linux/arm64 \
+                  --progress plain \
+                  --push .
+          fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ ENV EFS_CLIENT_SOURCE=$client_source
 
 RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} make aws-efs-csi-driver
 
-FROM amazonlinux:2
+FROM amazonlinux:2 AS linux-amazon
 RUN yum update -y
 # Install efs-utils from github by default. It can be overriden to `yum` with --build-arg when building the Docker image.
 # If value of `EFSUTILSSOURCE` build arg is overriden with `yum`, docker will install efs-utils from Amazon Linux 2's yum repo.

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.13.4-stretch as builder
+FROM --platform=$BUILDPLATFORM golang:1.13.4-stretch as builder
 WORKDIR /go/src/github.com/kubernetes-sigs/aws-efs-csi-driver
 
 ARG TARGETOS

--- a/hack/e2e/ecr.sh
+++ b/hack/e2e/ecr.sh
@@ -18,7 +18,8 @@ function ecr_build_and_push() {
     set -e
     loudecho "Building and pushing test driver image to ${IMAGE_NAME}:${IMAGE_TAG}"
     aws ecr get-login-password --region "${REGION}" | docker login --username AWS --password-stdin "${AWS_ACCOUNT_ID}".dkr.ecr."${REGION}".amazonaws.com
-    docker build -t "${IMAGE_NAME}":"${IMAGE_TAG}" .
+    IMAGE=${IMAGE_NAME} TAG=${IMAGE_TAG} OS=linux ARCH=amd64 OSVERSION=amazon make image
+    docker tag "${IMAGE_NAME}":"${IMAGE_TAG}"-linux-amd64-amazon "${IMAGE_NAME}":"${IMAGE_TAG}"
     docker push "${IMAGE_NAME}":"${IMAGE_TAG}"
   fi
 }

--- a/hack/e2e/eksctl.sh
+++ b/hack/e2e/eksctl.sh
@@ -6,7 +6,7 @@ function eksctl_install() {
   INSTALL_PATH=${1}
   EKSCTL_VERSION=${2}
   if [[ ! -e ${INSTALL_PATH}/eksctl ]]; then
-    EKSCTL_DOWNLOAD_URL="https://github.com/weaveworks/eksctl/releases/download/${EKSCTL_VERSION}/eksctl_$(uname -s)_amd64.tar.gz"
+    EKSCTL_DOWNLOAD_URL="https://github.com/weaveworks/eksctl/releases/download/v${EKSCTL_VERSION}/eksctl_$(uname -s)_amd64.tar.gz"
     curl --silent --location "${EKSCTL_DOWNLOAD_URL}" | tar xz -C "${INSTALL_PATH}"
     chmod +x "${INSTALL_PATH}"/eksctl
   fi
@@ -68,6 +68,7 @@ function eksctl_create_cluster() {
 
   if [[ "$WINDOWS" == true ]]; then
     ${BIN} create nodegroup \
+      --managed=false \
       --cluster="${CLUSTER_NAME}" \
       --node-ami-family=WindowsServer2019FullContainer \
       -n ng-windows \

--- a/hack/e2e/run.sh
+++ b/hack/e2e/run.sh
@@ -42,7 +42,7 @@ REGION=${AWS_REGION:-us-west-2}
 ZONES=${AWS_AVAILABILITY_ZONES:-us-west-2a,us-west-2b,us-west-2c}
 FIRST_ZONE=$(echo "${ZONES}" | cut -d, -f1)
 NODE_COUNT=${NODE_COUNT:-3}
-INSTANCE_TYPE=${INSTANCE_TYPE:-c4.large}
+INSTANCE_TYPE=${INSTANCE_TYPE:-c5.large}
 
 AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
 IMAGE_NAME=${IMAGE_NAME:-${AWS_ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com/${DRIVER_NAME}}
@@ -57,7 +57,7 @@ KOPS_STATE_FILE=${KOPS_STATE_FILE:-s3://k8s-kops-csi-e2e}
 KOPS_PATCH_FILE=${KOPS_PATCH_FILE:-./hack/kops-patch.yaml}
 KOPS_PATCH_NODE_FILE=${KOPS_PATCH_NODE_FILE:-./hack/kops-patch-node.yaml}
 
-EKSCTL_VERSION=${EKSCTL_VERSION:-0.56.0-rc.1}
+EKSCTL_VERSION=${EKSCTL_VERSION:-0.69.0}
 EKSCTL_PATCH_FILE=${EKSCTL_PATCH_FILE:-./hack/eksctl-patch.yaml}
 EKSCTL_ADMIN_ROLE=${EKSCTL_ADMIN_ROLE:-}
 # Creates a windows node group. The windows ami doesn't (yet) install csi-proxy


### PR DESCRIPTION
**Is this a bug fix or adding new feature?** 

**What is this PR about? / Why do we need it?** https://github.com/kubernetes-sigs/aws-fsx-csi-driver/issues/218 this shoudl make the build faster since we can build arm (target) binaries from a amd (build) node/host: https://docs.docker.com/buildx/working-with-buildx/#build-multi-platform-images.

similar to fsx PR (trying to be consistent): https://github.com/kubernetes-sigs/aws-fsx-csi-driver/pull/221

**What testing is done?** 
