### PR TITLE
Adds more permissions to avoid errors during deployment

### DIFF
--- a/docs/iam-policy-example.json
+++ b/docs/iam-policy-example.json
@@ -4,8 +4,16 @@
     {
       "Effect": "Allow",
       "Action": [
+        "ec2:DescribeAvailabilityZones"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
         "elasticfilesystem:DescribeAccessPoints",
-        "elasticfilesystem:DescribeFileSystems"
+        "elasticfilesystem:DescribeFileSystems",
+        "elasticfilesystem:DescribeMountTargets"
       ],
       "Resource": "*"
     },


### PR DESCRIPTION
This is an adjustment to the IAM policy example. During the deployment I received some errors by missing some permissions.
