### PR TITLE
Moving to livenessProbe 2.4 to stop logs being flooded with unnecessary messages

### DIFF
--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -15,8 +15,8 @@ image:
 sidecars:
   livenessProbe:
     image:
-      repository: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe
-      tag: v2.2.0-eks-1-18-13
+      repository: k8s.gcr.io/sig-storage/livenessprobe
+      tag: v2.4.0
       pullPolicy: IfNotPresent
     resources: {}
   nodeDriverRegistrar:

--- a/deploy/kubernetes/base/controller-deployment.yaml
+++ b/deploy/kubernetes/base/controller-deployment.yaml
@@ -72,7 +72,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: liveness-probe
-          image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.2.0-eks-1-18-13
+          image: k8s.gcr.io/sig-storage/livenessprobe:v2.4.0
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=/csi/csi.sock

--- a/deploy/kubernetes/base/node-daemonset.yaml
+++ b/deploy/kubernetes/base/node-daemonset.yaml
@@ -96,7 +96,7 @@ spec:
             - name: registration-dir
               mountPath: /registration
         - name: liveness-probe
-          image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.2.0-eks-1-18-13
+          image: k8s.gcr.io/sig-storage/livenessprobe:v2.4.0
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=/csi/csi.sock

--- a/deploy/kubernetes/overlays/stable/ecr/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/ecr/kustomization.yaml
@@ -8,7 +8,7 @@ images:
     newTag: v1.3.6
   - name: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe
     newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/livenessprobe
-    newTag: v2.2.0
+    newTag: v2.4.0
   - name: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar
     newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-node-driver-registrar
     newTag: v2.1.0

--- a/deploy/kubernetes/overlays/stable/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/kustomization.yaml
@@ -5,8 +5,8 @@ bases:
 images:
   - name: amazon/aws-efs-csi-driver
     newTag: v1.3.6
-  - name: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe
-    newTag: v2.2.0-eks-1-18-2
+  - name: k8s.gcr.io/sig-storage/livenessprobe
+    newTag: v2.4.0
   - name: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar
     newTag: v2.1.0-eks-1-18-2
   - name: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner


### PR DESCRIPTION
I've had a go at this one to resolve the issue mentioned below. I'm not enormously familiar with Kustomize and our reasons for not using `k8s.gcr.io/sig-storage/livenessprobe` so if I've done something wrong please let me know so we can move forward to fix it together! This is largely based on the [fix for the EBS driver](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/1054/files)

**Is this a bug fix or adding new feature?**
This is a bug fix to address the issues raised in #564, moving to a new version of the liveness probe will stop the large volume of logs being generated.

**What is this PR about? / Why do we need it?**
See above

**What testing is done?** 
Using the PR process to run the E2E tests will give confidence that this change will not break current installations. Once the PR is more stable/reviewed I will spin up the driver on my own EKS cluster to check the volume of logs is reduced as expected.


