### PR TITLE
[release-1.3] Release v1.3.5: release helm chart v2.2.1 and update kustomize

### DIFF
--- a/charts/aws-efs-csi-driver/CHANGELOG.md
+++ b/charts/aws-efs-csi-driver/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Helm chart
 
+# v2.2.1
+* Bump app/driver version to `v1.3.5`
+
 # v2.2.0
 * Allow health ports to be configured
 * Add Missing "patch" permission for "events"

--- a/charts/aws-efs-csi-driver/Chart.yaml
+++ b/charts/aws-efs-csi-driver/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: aws-efs-csi-driver
-version: 2.2.0
-appVersion: 1.3.4
+version: 2.2.1
+appVersion: 1.3.5
 kubeVersion: ">=1.17.0-0"
 description: "A Helm chart for AWS EFS CSI Driver"
 home: https://github.com/kubernetes-sigs/aws-efs-csi-driver

--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -9,7 +9,7 @@ replicaCount: 2
 
 image:
   repository: amazon/aws-efs-csi-driver
-  tag: "v1.3.4"
+  tag: "v1.3.5"
   pullPolicy: IfNotPresent
 
 sidecars:

--- a/deploy/kubernetes/base/controller-deployment.yaml
+++ b/deploy/kubernetes/base/controller-deployment.yaml
@@ -30,7 +30,7 @@ spec:
         - name: efs-plugin
           securityContext:
             privileged: true
-          image: amazon/aws-efs-csi-driver:v1.3.4
+          image: amazon/aws-efs-csi-driver:v1.3.5
           imagePullPolicy: IfNotPresent
           args:
             - --endpoint=$(CSI_ENDPOINT)

--- a/deploy/kubernetes/base/node-daemonset.yaml
+++ b/deploy/kubernetes/base/node-daemonset.yaml
@@ -41,7 +41,7 @@ spec:
         - name: efs-plugin
           securityContext:
             privileged: true
-          image: amazon/aws-efs-csi-driver:v1.3.4
+          image: amazon/aws-efs-csi-driver:v1.3.5
           imagePullPolicy: IfNotPresent
           args:
             - --endpoint=$(CSI_ENDPOINT)

--- a/deploy/kubernetes/overlays/stable/ecr/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/ecr/kustomization.yaml
@@ -5,7 +5,7 @@ bases:
 images:
   - name: amazon/aws-efs-csi-driver
     newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/aws-efs-csi-driver
-    newTag: v1.3.4
+    newTag: v1.3.5
   - name: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe
     newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/livenessprobe
     newTag: v2.2.0

--- a/deploy/kubernetes/overlays/stable/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/kustomization.yaml
@@ -4,7 +4,7 @@ bases:
   - ../../base
 images:
   - name: amazon/aws-efs-csi-driver
-    newTag: v1.3.4
+    newTag: v1.3.5
   - name: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe
     newTag: v2.2.0-eks-1-18-2
   - name: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

**What is this PR about? / Why do we need it?** following https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/9b0780cced52c389220a12b70119490da0376f5f/docs/RELEASE.md#create-the-post-release-commit-in-the-release-branch, these changes to helm/kustomize can merge after the EFS images have been pushed (still waiting on ECR promotion)

/hold

**What testing is done?** 
