### PR TITLE
Release helm charts from master branch, release chart 2.2.2

### DIFF
--- a/.github/workflows/helm-chart-release.yaml
+++ b/.github/workflows/helm-chart-release.yaml
@@ -3,7 +3,7 @@ name: Release Helm Charts
 on:
   push:
     branches:
-      - "release-*"
+      - master
     paths:
       - "charts/**"
 

--- a/charts/aws-efs-csi-driver/CHANGELOG.md
+++ b/charts/aws-efs-csi-driver/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Helm chart
 
-# master (unreleased)
+# v2.2.2
 * Add controller.volMetricsOptIn for emitting volume metrics
 
 # v2.2.1

--- a/charts/aws-efs-csi-driver/Chart.yaml
+++ b/charts/aws-efs-csi-driver/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: aws-efs-csi-driver
-version: 2.2.1
+version: 2.2.2
 appVersion: 1.3.5
 kubeVersion: ">=1.17.0-0"
 description: "A Helm chart for AWS EFS CSI Driver"


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

**What is this PR about? / Why do we need it?** see https://github.com/kubernetes-sigs/aws-efs-csi-driver/pull/601#discussion_r766267687 for context. It was worth trying this pattern where helm chart is branched together with the driver, but i think overall it is better for helm chart to be "mastered" in master branch while the driver gets "mastered" in release-x.y branches.

If somehow there is a repeat scenario of the dynamic provisioning case where the helm chart is tightly coupled with driver and it would be easier to version them in the same branch....the workaround would be to make the chart more complicated so it is backwards compatible with unreleased `master` driver versions AND released versions. 


It's likely none of the above makes sense, so it is simpler point out:

ebs releases charts from master branch without issue
https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/.github/workflows/helm-chart-release.yaml#L6
fsx releases charts from master branch without issue
https://github.com/kubernetes-sigs/aws-fsx-csi-driver/blob/master/.github/workflows/helm-chart-release.yaml#L6

so efs should go back to releasing charts from master branch too!
 
**What testing is done?** 
