### PR TITLE
use common labels

### DIFF
--- a/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
+++ b/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
@@ -5,7 +5,7 @@ apiVersion: apps/v1
 metadata:
   name: efs-csi-controller
   labels:
-    app.kubernetes.io/name: {{ include "aws-efs-csi-driver.name" . }}
+    {{ include "aws-efs-csi-driver.labels" . }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
@@ -17,8 +17,7 @@ spec:
     metadata:
       labels:
         app: efs-csi-controller
-        app.kubernetes.io/name: {{ include "aws-efs-csi-driver.name" . }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
+        {{ include "aws-efs-csi-driver.labels" . }}
       {{- with .Values.controller.podAnnotations }}
       annotations: {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/aws-efs-csi-driver/templates/controller-serviceaccount.yaml
+++ b/charts/aws-efs-csi-driver/templates/controller-serviceaccount.yaml
@@ -4,7 +4,7 @@ kind: ServiceAccount
 metadata:
   name: {{ .Values.controller.serviceAccount.name }}
   labels:
-    app.kubernetes.io/name: {{ include "aws-efs-csi-driver.name" . }}
+    {{ include "aws-efs-csi-driver.labels" . }}
   {{- with .Values.controller.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
@@ -17,7 +17,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: efs-csi-external-provisioner-role
   labels:
-    app.kubernetes.io/name: {{ include "aws-efs-csi-driver.name" . }}
+    {{ include "aws-efs-csi-driver.labels" . }}
 rules:
   - apiGroups: [""]
     resources: ["persistentvolumes"]
@@ -51,7 +51,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: efs-csi-provisioner-binding
   labels:
-    app.kubernetes.io/name: {{ include "aws-efs-csi-driver.name" . }}
+    {{ include "aws-efs-csi-driver.labels" . }}
 subjects:
   - kind: ServiceAccount
     name: {{ .Values.controller.serviceAccount.name }}

--- a/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
+++ b/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 metadata:
   name: efs-csi-node
   labels:
-    app.kubernetes.io/name: {{ include "aws-efs-csi-driver.name" . }}
+    {{ include "aws-efs-csi-driver.labels" . }}
 spec:
   selector:
     matchLabels:
@@ -15,8 +15,7 @@ spec:
     metadata:
       labels:
         app: efs-csi-node
-        app.kubernetes.io/name: {{ include "aws-efs-csi-driver.name" . }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
+        {{ include "aws-efs-csi-driver.labels" . }}
       {{- if .Values.node.podAnnotations }}
       annotations: {{ toYaml .Values.node.podAnnotations | nindent 8 }}
       {{- end }}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Adding a new feature.

**What is this PR about? / Why do we need it?**
Making use of `aws-efs-csi-driver.labels` in metadata. Helm chart version is missing currently.

**What testing is done?** 
None
