### PR TITLE
add updateStrategy

### DIFF
--- a/charts/aws-efs-csi-driver/Chart.yaml
+++ b/charts/aws-efs-csi-driver/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: aws-efs-csi-driver
-version: 2.2.2
+version: 2.2.3
 appVersion: 1.3.5
 kubeVersion: ">=1.17.0-0"
 description: "A Helm chart for AWS EFS CSI Driver"

--- a/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
+++ b/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
@@ -13,6 +13,10 @@ spec:
       app: efs-csi-controller
       app.kubernetes.io/name: {{ include "aws-efs-csi-driver.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
+  {{- with .Values.controller.updateStrategy }}
+  strategy:
+    {{ toYaml . | nindent 4 }}
+  {{- end }}
   template:
     metadata:
       labels:

--- a/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
+++ b/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
@@ -11,6 +11,10 @@ spec:
       app: efs-csi-node
       app.kubernetes.io/name: {{ include "aws-efs-csi-driver.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
+  {{- with .Values.node.updateStrategy }}
+  strategy:
+    {{ toYaml . | nindent 4 }}
+  {{- end }}
   template:
     metadata:
       labels:

--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -106,10 +106,10 @@ node:
     #   nameservers:
     #     - 169.254.169.253
   podAnnotations: {}
-  updateStrategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxUnavailable: "10%"
+  updateStrategy: {}
+    # type: RollingUpdate
+    # rollingUpdate:
+    #   maxUnavailable: "10%"
   resources:
     {}
     # limits:

--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -53,6 +53,11 @@ controller:
   deleteAccessPointRootDir: false
   volMetricsOptIn: false
   podAnnotations: {}
+  updateStrategy: {}
+  # type: RollingUpdate
+  # rollingUpdate:
+  #   maxSurge: 0
+  #   maxUnavailable: 1
   resources:
     {}
     # We usually recommend not to specify default resources and to leave this as a conscious
@@ -101,6 +106,10 @@ node:
     #   nameservers:
     #     - 169.254.169.253
   podAnnotations: {}
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: "10%"
   resources:
     {}
     # limits:

--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -54,10 +54,10 @@ controller:
   volMetricsOptIn: false
   podAnnotations: {}
   updateStrategy: {}
-  # type: RollingUpdate
-  # rollingUpdate:
-  #   maxSurge: 0
-  #   maxUnavailable: 1
+    # type: RollingUpdate
+    # rollingUpdate:
+    #   maxSurge: 0
+    #   maxUnavailable: 1
   resources:
     {}
     # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

Feature

**What is this PR about? / Why do we need it?**

Added updateStrategy to controller and deamonset.
When deploying to a large number of nodes, the deployment speed can be faster.
Code referenced aws-ebs-csi-driver .

https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/charts/aws-ebs-csi-driver/templates/controller.yaml#L10

**What testing is done?** 
