### PR TITLE
Add uid and gid parameters

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -31,8 +31,10 @@ The following CSI interfaces are implemented:
 | provisioningMode    | efs-ap |         | false     | Type of volume provisioned by efs. Currently, Access Points are supported. |
 | fileSystemId        |        |         | false     | File System under which access points are created. | 
 | directoryPerms      |        |         | false     | Directory permissions for [Access Point root directory](https://docs.aws.amazon.com/efs/latest/ug/efs-access-points.html#enforce-root-directory-access-point) creation. |
-| gidRangeStart       |        | 50000   | true      | Start range of the POSIX group Id to be applied for [Access Point root directory](https://docs.aws.amazon.com/efs/latest/ug/efs-access-points.html#enforce-root-directory-access-point) creation. |
-| gidRangeEnd         |        | 7000000 | true      | End range of the POSIX group Id. |
+| uid                 |        |         | true      | POSIX user Id to be applied for [Access Point root directory](https://docs.aws.amazon.com/efs/latest/ug/efs-access-points.html#enforce-root-directory-access-point) creation. |
+| gid                 |        |         | true      | POSIX group Id to be applied for [Access Point root directory](https://docs.aws.amazon.com/efs/latest/ug/efs-access-points.html#enforce-root-directory-access-point) creation. |
+| gidRangeStart       |        | 50000   | true      | Start range of the POSIX group Id to be applied for [Access Point root directory](https://docs.aws.amazon.com/efs/latest/ug/efs-access-points.html#enforce-root-directory-access-point) creation. Not used if uid/gid is set. |
+| gidRangeEnd         |        | 7000000 | true      | End range of the POSIX group Id. Not used if uid/gid is set. |
 | basePath            |        |         | true      | Path under which access points for dynamic provisioning is created. If this parameter is not specified, access points are created under the root directory of the file system |
 | az                  |        |   ""    | true      | Used for cross-account mount. `az` under storage class parameter is optional. If specified, mount target associated with the az will be used for cross-account mount. If not specified, a random mount target will be picked for cross account mount |
 


### PR DESCRIPTION
Release https://github.com/kubernetes-sigs/aws-efs-csi-driver/pull/434/ with v1.3.6

**Is this a bug fix or adding new feature?**
New feature


**What is this PR about? / Why do we need it?**
Add a parameter to set UID and GID on access point: #393

**What testing is done?** 
Tested on an eks cluster.

This feature also has passed internal Amazon security review
