### PR TITLE
Add -v to controller liveness-probe container args

### DIFF
--- a/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
+++ b/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
@@ -106,6 +106,7 @@ spec:
           args:
             - --csi-address=/csi/csi.sock
             - --health-port={{ .Values.controller.healthPort }}
+            - --v={{ .Values.controller.logLevel }}
           volumeMounts:
             - name: socket-dir
               mountPath: /csi


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

Bug fix -- this flag is consistently applied to other Pods and containers, but not this one.

**What is this PR about? / Why do we need it?**

Liveness probes make very noisy logs

**What testing is done?** 

None, assumed to work as expected based on ample precedent.