### PR TITLE
go.mod: fix non-existing k8s.io/kubernetes version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	k8s.io/apimachinery v0.18.10
 	k8s.io/client-go v0.18.10
 	k8s.io/klog v1.0.0
-	k8s.io/kubernetes v1.23.10
+	k8s.io/kubernetes v1.18.10
 	k8s.io/utils v0.0.0-20200324210504-a9aa75ae1b89
 )
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -773,7 +773,7 @@ k8s.io/kube-scheduler/extender/v1
 # k8s.io/kubectl v0.0.0 => k8s.io/kubectl v0.18.10
 ## explicit; go 1.13
 k8s.io/kubectl/pkg/scale
-# k8s.io/kubernetes v1.23.10
+# k8s.io/kubernetes v1.18.10
 ## explicit; go 1.13
 k8s.io/kubernetes/pkg/api/legacyscheme
 k8s.io/kubernetes/pkg/api/service


### PR DESCRIPTION
Builds based on the `release-1.3` branch are currently failing. The reason is an incorrect dependency version:

```
$ go mod tidy
go: downloading k8s.io/kubernetes v1.23.10
github.com/kubernetes-sigs/aws-efs-csi-driver/pkg/driver imports
	k8s.io/kubernetes/pkg/volume/util/fs: reading k8s.io/kubernetes/go.mod at revision v1.23.10: unknown revision v1.23.10
github.com/kubernetes-sigs/aws-efs-csi-driver/test/e2e imports
	k8s.io/kubernetes/test/e2e/framework: reading k8s.io/kubernetes/go.mod at revision v1.23.10: unknown revision v1.23.10
github.com/kubernetes-sigs/aws-efs-csi-driver/test/e2e imports
	k8s.io/kubernetes/test/e2e/framework/node: reading k8s.io/kubernetes/go.mod at revision v1.23.10: unknown revision v1.23.10
github.com/kubernetes-sigs/aws-efs-csi-driver/test/e2e imports
	k8s.io/kubernetes/test/e2e/framework/pod: reading k8s.io/kubernetes/go.mod at revision v1.23.10: unknown revision v1.23.10
github.com/kubernetes-sigs/aws-efs-csi-driver/test/e2e imports
	k8s.io/kubernetes/test/e2e/storage/testpatterns: reading k8s.io/kubernetes/go.mod at revision v1.23.10: unknown revision v1.23.10
github.com/kubernetes-sigs/aws-efs-csi-driver/test/e2e imports
	k8s.io/kubernetes/test/e2e/storage/testsuites: reading k8s.io/kubernetes/go.mod at revision v1.23.10: unknown revision v1.23.10
github.com/kubernetes-sigs/aws-efs-csi-driver/test/e2e imports
	k8s.io/kubernetes/test/e2e/storage/utils: reading k8s.io/kubernetes/go.mod at revision v1.23.10: unknown revision v1.23.10
github.com/kubernetes-sigs/aws-efs-csi-driver/test/e2e tested by
	github.com/kubernetes-sigs/aws-efs-csi-driver/test/e2e.test imports
	k8s.io/kubernetes/test/e2e/framework/config: reading k8s.io/kubernetes/go.mod at revision v1.23.10: unknown revision v1.23.10
github.com/kubernetes-sigs/aws-efs-csi-driver/test/e2e tested by
	github.com/kubernetes-sigs/aws-efs-csi-driver/test/e2e.test imports
	k8s.io/kubernetes/test/e2e/framework/testfiles: reading k8s.io/kubernetes/go.mod at revision v1.23.10: unknown revision v1.23.10
github.com/kubernetes-sigs/aws-efs-csi-driver/pkg/driver imports
	google.golang.org/grpc tested by
	google.golang.org/grpc.test imports
	google.golang.org/grpc/grpclog/glogger imports
	github.com/golang/glog: k8s.io/kubernetes@v1.23.10: reading k8s.io/kubernetes/go.mod at revision v1.23.10: unknown revision v1.23.10
github.com/kubernetes-sigs/aws-efs-csi-driver/pkg/driver imports
	k8s.io/utils/mount imports
	k8s.io/utils/path tested by
	k8s.io/utils/path.test imports
	github.com/spf13/afero: k8s.io/kubernetes@v1.23.10: reading k8s.io/kubernetes/go.mod at revision v1.23.10: unknown revision v1.23.10
github.com/kubernetes-sigs/aws-efs-csi-driver/pkg/driver tested by
	github.com/kubernetes-sigs/aws-efs-csi-driver/pkg/driver.test imports
	github.com/kubernetes-csi/csi-test/pkg/sanity imports
	gopkg.in/yaml.v2 tested by
	gopkg.in/yaml.v2.test imports
	gopkg.in/check.v1: k8s.io/kubernetes@v1.23.10: reading k8s.io/kubernetes/go.mod at revision v1.23.10: unknown revision v1.23.10
```

Version v1.23.10 doesn't exist yet. This patch reverts the k8s.io/kubernetes version to v1.18.10, which is the version pinned in all the other k8s dependencies.