### PR TITLE
Check if publish target path already mounted to be idempotent

### DIFF
--- a/hack/update-gomock
+++ b/hack/update-gomock
@@ -13,10 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 set -euo pipefail
 
 IMPORT_PATH=github.com/kubernetes-sigs/aws-efs-csi-driver
-mockgen -package=mocks -destination=./pkg/driver/mocks/mock_mount.go ${IMPORT_PATH}/pkg/driver Mounter 
-mockgen -package=mocks -destination=./pkg/cloud/mocks/mock_ec2metadata.go ${IMPORT_PATH}/pkg/cloud EC2Metadata
-mockgen -package=mocks -destination=./pkg/cloud/mocks/mock_taskmetadata.go ${IMPORT_PATH}/pkg/cloud TaskMetadataService
+mockgen -package=mocks -destination=./pkg/driver/mocks/mock_mount.go --build_flags=--mod=mod ${IMPORT_PATH}/pkg/driver Mounter
+mockgen -package=mocks -destination=./pkg/cloud/mocks/mock_ec2metadata.go --build_flags=--mod=mod ${IMPORT_PATH}/pkg/cloud EC2Metadata
+mockgen -package=mocks -destination=./pkg/cloud/mocks/mock_taskmetadata.go --build_flags=--mod=mod ${IMPORT_PATH}/pkg/cloud TaskMetadataService

--- a/pkg/driver/mocks/mock_mount.go
+++ b/pkg/driver/mocks/mock_mount.go
@@ -65,6 +65,20 @@ func (mr *MockMounterMockRecorder) GetMountRefs(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMountRefs", reflect.TypeOf((*MockMounter)(nil).GetMountRefs), arg0)
 }
 
+// IsCorruptedMnt mocks base method.
+func (m *MockMounter) IsCorruptedMnt(arg0 error) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsCorruptedMnt", arg0)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsCorruptedMnt indicates an expected call of IsCorruptedMnt.
+func (mr *MockMounterMockRecorder) IsCorruptedMnt(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsCorruptedMnt", reflect.TypeOf((*MockMounter)(nil).IsCorruptedMnt), arg0)
+}
+
 // IsLikelyNotMountPoint mocks base method.
 func (m *MockMounter) IsLikelyNotMountPoint(arg0 string) (bool, error) {
 	m.ctrl.T.Helper()
@@ -163,6 +177,21 @@ func (m *MockMounter) MountSensitiveWithoutSystemdWithMountFlags(arg0, arg1, arg
 func (mr *MockMounterMockRecorder) MountSensitiveWithoutSystemdWithMountFlags(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MountSensitiveWithoutSystemdWithMountFlags", reflect.TypeOf((*MockMounter)(nil).MountSensitiveWithoutSystemdWithMountFlags), arg0, arg1, arg2, arg3, arg4, arg5)
+}
+
+// PathExists mocks base method.
+func (m *MockMounter) PathExists(arg0 string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PathExists", arg0)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PathExists indicates an expected call of PathExists.
+func (mr *MockMounterMockRecorder) PathExists(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PathExists", reflect.TypeOf((*MockMounter)(nil).PathExists), arg0)
 }
 
 // Unmount mocks base method.

--- a/pkg/driver/mounter.go
+++ b/pkg/driver/mounter.go
@@ -22,7 +22,9 @@ import (
 // Mounter is an interface for mount operations
 type Mounter interface {
 	mount.Interface
+	IsCorruptedMnt(err error) bool
 	MakeDir(pathname string) error
+	PathExists(path string) (bool, error)
 	GetDeviceName(mountPath string) (string, int, error)
 }
 
@@ -48,4 +50,15 @@ func (m *NodeMounter) MakeDir(pathname string) error {
 
 func (m *NodeMounter) GetDeviceName(mountPath string) (string, int, error) {
 	return mount.GetDeviceNameFromMount(m, mountPath)
+}
+
+// IsCorruptedMnt return true if err is about corrupted mount point
+func (m NodeMounter) IsCorruptedMnt(err error) bool {
+	return mount.IsCorruptedMnt(err)
+}
+
+// This function is mirrored in ./sanity_test.go to make sure sanity test covered this block of code
+// Please mirror the change to func MakeFile in ./sanity_test.go
+func (m *NodeMounter) PathExists(path string) (bool, error) {
+	return mount.PathExists(path)
 }


### PR DESCRIPTION
**Is this a bug fix or adding new feature?** /bug

**What is this PR about? / Why do we need it?**
While debugging some kubelet issue and restarting kubelet a couple of times I noticed some errors from the driver like 
`x is already mounted or y busy`. kubelet might call NodePublish on the same volume multiple times, the spec says the driver must be idempotent. So to be idempotent, no-op if a target path is already mounted instead of printing errors.

The implementation is copied from EBS driver https://github.com/kubernetes-sigs/aws-ebs-csi-driver https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/1019

**What testing is done?** 
CI, plus WIP manual test to reproduce the issue.
