### PR TITLE
Fix vulnerabilities in the release image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,8 +48,7 @@ RUN if [ "$EFSUTILSSOURCE" = "yum" ]; \
     fi
 
 # Install botocore required by efs-utils for cross account mount
-RUN yum -y install wget && \
-    wget https://bootstrap.pypa.io/get-pip.py -O /tmp/get-pip.py && \
+RUN curl -SL -O --output-dir /tmp https://bootstrap.pypa.io/get-pip.py && \
     python3 /tmp/get-pip.py && \
     pip3 install botocore || /usr/local/bin/pip3 install botocore && \
     rm -rf /tmp/get-pip.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN yum update -y
 ARG EFSUTILSSOURCE=github
 RUN if [ "$EFSUTILSSOURCE" = "yum" ]; \
     then echo "Installing efs-utils from Amazon Linux 2 yum repo" && \
-         yum -y install amazon-efs-utils-1.31.1-1.amzn2.noarch; \
+         yum -y install amazon-efs-utils; \
     else echo "Installing efs-utils from github using the latest git tag" && \
          yum -y install git rpm-build make && \
          git clone https://github.com/aws/efs-utils && \

--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ push: image
 
 .PHONY: image-release
 image-release:
-	docker build -t $(IMAGE):$(VERSION) .
+	docker build --build-arg EFSUTILSSOURCE=yum -t $(IMAGE):$(VERSION) .
 
 .PHONY: push-release
 push-release:

--- a/go.mod
+++ b/go.mod
@@ -9,12 +9,12 @@ require (
 	github.com/onsi/ginkgo v1.14.0
 	github.com/onsi/gomega v1.10.1
 	google.golang.org/grpc v1.38.0
-	k8s.io/api v0.22.1
-	k8s.io/apimachinery v0.22.1
-	k8s.io/client-go v0.22.1
+	k8s.io/api v0.22.2
+	k8s.io/apimachinery v0.22.2
+	k8s.io/client-go v0.22.2
 	k8s.io/klog v1.0.0
-	k8s.io/kubernetes v1.22.1
-	k8s.io/mount-utils v0.22.1
+	k8s.io/kubernetes v1.22.2
+	k8s.io/mount-utils v0.22.2
 )
 
 require (

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -888,7 +888,7 @@ k8s.io/kubectl/pkg/util/podutils
 # k8s.io/kubelet v0.0.0 => k8s.io/kubelet v0.22.1
 ## explicit; go 1.16
 k8s.io/kubelet/pkg/apis/stats/v1alpha1
-# k8s.io/kubernetes v1.22.1
+# k8s.io/kubernetes v1.22.2
 ## explicit; go 1.16
 k8s.io/kubernetes/pkg/api/legacyscheme
 k8s.io/kubernetes/pkg/api/service


### PR DESCRIPTION
This is a bug fix for the release image of EFS. Right now, multiple vulnerabilities are found in the container because there's know vulnerabilities in Kubernetes 1.22.1:
- https://security.snyk.io/vuln/SNYK-GOLANG-K8SIOKUBERNETES-1585630
- https://github.com/advisories/GHSA-f5f7-6478-qm6p

This pull request fixes several issues:
- Upgrade Kubernetes dependencies to 1.22.2
- Create a release image that doesn't have development tools installed by default
- Always install the latest version of the amazon-efs-utils package from the yum repo (with the latest security updates)
- Use curl (preinstalled) to download pip instead of installing wget to install pip

The final security scan was done with ECR scan (and Inspector2). The image was tested on an EKS cluster (version 1.21)
