### PR TITLE
[release-1.3] Go 1.18: go get -> go install

### DIFF
--- a/hack/e2e/run.sh
+++ b/hack/e2e/run.sh
@@ -78,7 +78,7 @@ loudecho "Installing ginkgo to ${BIN_DIR}"
 GINKGO_BIN=${BIN_DIR}/ginkgo
 if [[ ! -e ${GINKGO_BIN} ]]; then
   pushd /tmp
-  GOPATH=${TEST_DIR} GOBIN=${BIN_DIR} GO111MODULE=on go get github.com/onsi/ginkgo/ginkgo@v1.12.0
+  GOPATH=${TEST_DIR} GOBIN=${BIN_DIR} GO111MODULE=on go install github.com/onsi/ginkgo/ginkgo@v1.12.0
   popd
 fi
 


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

/bug

**What is this PR about? / Why do we need it?**

See https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/1194 and https://go.dev/doc/go-get-install-deprecation

**What testing is done?**

CI is failing right now, with this change CI should pass.
