### PR TITLE
Disable sharing secret cross all namespaces by default & restrict secret sharing to designated namespace

### DIFF
--- a/charts/aws-efs-csi-driver/templates/controller-serviceaccount.yaml
+++ b/charts/aws-efs-csi-driver/templates/controller-serviceaccount.yaml
@@ -40,9 +40,11 @@ rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["get", "watch", "list", "delete", "update", "create"]
-  - apiGroups: [ "" ]
-    resources: [ "secrets" ]
-    verbs: [ "get", "watch", "list" ]
+  # The following rule should be uncommented for plugins that require secrets
+  # for provisioning/cross account mount 
+  # - apiGroups: [ "" ]
+  #   resources: [ "secrets" ]
+  #   verbs: [ "get", "watch", "list" ]
 
 ---
 
@@ -60,3 +62,18 @@ roleRef:
   kind: ClusterRole
   name: efs-csi-external-provisioner-role
   apiGroup: rbac.authorization.k8s.io
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: efs-secrets-user-bindings
+  namespace: efs-secrets
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: efs-csi-external-provisioner-role
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.controller.serviceAccount.name }}
+    namespace: {{ .Release.Namespace }}

--- a/examples/kubernetes/cross_account_mount/README.md
+++ b/examples/kubernetes/cross_account_mount/README.md
@@ -22,7 +22,7 @@ parameters:
   basePath: "/dynamic_provisioning"
   az: us-east-1a
   csi.storage.k8s.io/provisioner-secret-name: x-account
-  csi.storage.k8s.io/provisioner-secret-namespace: kube-system
+  csi.storage.k8s.io/provisioner-secret-namespace: efs-secrets
 ```
 
 ### Prerequisite setup


### PR DESCRIPTION
Disable sharing secret cross all namespaces by default & restrict secret sharing to designated namespace

**Is this a bug fix or adding new feature?**
Security update
**What is this PR about? / Why do we need it?**
Disable sharing secret cross all namespaces by default & restrict secret sharing to designated namespace
**What testing is done?** 
