### PR TITLE
Add controller.hostNetwork values for switching POD network mode

### DIFF
--- a/charts/aws-efs-csi-driver/CHANGELOG.md
+++ b/charts/aws-efs-csi-driver/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Helm chart
 
+# v2.2.6
+* Add controller.hostNetwork values for switching POD network mode
+
 # v2.2.5
 * Bump app/driver version to `v1.3.7`
 

--- a/charts/aws-efs-csi-driver/Chart.yaml
+++ b/charts/aws-efs-csi-driver/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: aws-efs-csi-driver
-version: 2.2.5
+version: 2.2.6
 appVersion: 1.3.7
 kubeVersion: ">=1.17.0-0"
 description: "A Helm chart for AWS EFS CSI Driver"

--- a/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
+++ b/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
@@ -23,7 +23,7 @@ spec:
       annotations: {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
-      hostNetwork: true
+      hostNetwork: {{ .Values.controller.hostNetwork }}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- range .Values.imagePullSecrets }}

--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -52,6 +52,8 @@ controller:
   # path on efs when deleteing an access point
   deleteAccessPointRootDir: false
   volMetricsOptIn: false
+  # Enable POD hostNetwork, If you use kiam it should be false
+  hostNetwork: true
   podAnnotations: {}
   resources:
     {}


### PR DESCRIPTION

**Is this a bug fix or adding new feature?**
- ref to https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/539

**What is this PR about? / Why do we need it?**
- When IAM is attached by kiam, it doesn't work because controller should use host network
**What testing is done?** 
hostNetwork: true
```
I0420 12:03:25.319649       1 controller.go:1332] provision "kube-system/efs-claim" class "efs-sc": started
I0420 12:03:25.319786       1 controller.go:731] CreateVolumeRequest name:"pvc-06d3e19c-946f-4f15-baac-b73f3fc7ed67" capacity_range:<required_bytes:5368709120 > volume_capabilities:<mount:<mount_flags:"tls" > access_mode:<mode:MULTI_NODE_MULTI_WRITER > > parameters:<key:"basePath" value:"/dynamic_provisioning" > parameters:<key:"directoryPerms" value:"700" > parameters:<key:"fileSystemId" value:"fs-0148daff742c320fa" > parameters:<key:"gidRangeEnd" value:"2000" > parameters:<key:"gidRangeStart" value:"1000" > parameters:<key:"provisioningMode" value:"efs-ap" >
I0420 12:03:25.320424       1 connection.go:182] GRPC call: /csi.v1.Controller/CreateVolume
I0420 12:03:25.320439       1 connection.go:183] GRPC request: {"capacity_range":{"required_bytes":5368709120},"name":"pvc-06d3e19c-946f-4f15-baac-b73f3fc7ed67","parameters":{"basePath":"/dynamic_provisioning","directoryPerms":"700","fileSystemId":"fs-0148daff742c320fa","gidRangeEnd":"2000","gidRangeStart":"1000","provisioningMode":"efs-ap"},"volume_capabilities":[{"AccessType":{"Mount":{"mount_flags":["tls"]}},"access_mode":{"mode":5}}]}
I0420 12:03:25.320897       1 event.go:282] Event(v1.ObjectReference{Kind:"PersistentVolumeClaim", Namespace:"kube-system", Name:"efs-claim", UID:"06d3e19c-946f-4f15-baac-b73f3fc7ed67", APIVersion:"v1", ResourceVersion:"494877023", FieldPath:""}): type: 'Normal' reason: 'Provisioning' External provisioner is provisioning volume for claim "kube-system/efs-claim"
I0420 12:03:25.487252       1 connection.go:185] GRPC response: {}
I0420 12:03:25.487304       1 connection.go:186] GRPC error: rpc error: code = Internal desc = Failed to fetch File System info: Describe File System failed: NoCredentialProviders: no valid providers in chain. Deprecated.
	For verbose messaging see aws.Config.CredentialsChainVerboseErrors
I0420 12:03:25.487332       1 controller.go:752] CreateVolume failed, supports topology = false, node selected false => may reschedule = false => state = Finished: rpc error: code = Internal desc = Failed to fetch File System info: Describe File System failed: NoCredentialProviders: no valid providers in chain. Deprecated.
	For verbose messaging see aws.Config.CredentialsChainVerboseErrors
I0420 12:03:25.487374       1 controller.go:1099] Final error received, removing PVC 06d3e19c-946f-4f15-baac-b73f3fc7ed67 from claims in progress
W0420 12:03:25.487391       1 controller.go:958] Retrying syncing claim "06d3e19c-946f-4f15-baac-b73f3fc7ed67", failure 5
E0420 12:03:25.487413       1 controller.go:981] error syncing claim "06d3e19c-946f-4f15-baac-b73f3fc7ed67": failed to provision volume with StorageClass "efs-sc": rpc error: code = Internal desc = Failed to fetch File System info: Describe File System failed: NoCredentialProviders: no valid providers in chain. Deprecated.
	For verbose messaging see aws.Config.CredentialsChainVerboseErrors
```	

hostNetwork: false
```
I0420 12:06:27.114457       1 controller.go:1332] provision "kube-system/efs-claim" class "efs-sc": started
I0420 12:06:27.114764       1 controller.go:731] CreateVolumeRequest name:"pvc-06d3e19c-946f-4f15-baac-b73f3fc7ed67" capacity_range:<required_bytes:5368709120 > volume_capabilities:<mount:<mount_flags:"tls" > access_mode:<mode:MULTI_NODE_MULTI_WRITER > > parameters:<key:"basePath" value:"/dynamic_provisioning" > parameters:<key:"directoryPerms" value:"700" > parameters:<key:"fileSystemId" value:"fs-0148daff742c320fa" > parameters:<key:"gidRangeEnd" value:"2000" > parameters:<key:"gidRangeStart" value:"1000" > parameters:<key:"provisioningMode" value:"efs-ap" >
I0420 12:06:27.168880       1 connection.go:182] GRPC call: /csi.v1.Controller/CreateVolume
I0420 12:06:27.168912       1 connection.go:183] GRPC request: {"capacity_range":{"required_bytes":5368709120},"name":"pvc-06d3e19c-946f-4f15-baac-b73f3fc7ed67","parameters":{"basePath":"/dynamic_provisioning","directoryPerms":"700","fileSystemId":"fs-0148daff742c320fa","gidRangeEnd":"2000","gidRangeStart":"1000","provisioningMode":"efs-ap"},"volume_capabilities":[{"AccessType":{"Mount":{"mount_flags":["tls"]}},"access_mode":{"mode":5}}]}
I0420 12:06:27.169940       1 event.go:282] Event(v1.ObjectReference{Kind:"PersistentVolumeClaim", Namespace:"kube-system", Name:"efs-claim", UID:"06d3e19c-946f-4f15-baac-b73f3fc7ed67", APIVersion:"v1", ResourceVersion:"494877023", FieldPath:""}): type: 'Normal' reason: 'Provisioning' External provisioner is provisioning volume for claim "kube-system/efs-claim"
I0420 12:06:27.636618       1 connection.go:185] GRPC response: {"volume":{"capacity_bytes":5368709120,"volume_id":"fs-0148daff742c320fa::fsap-0a0233310b98754f9"}}
I0420 12:06:27.636764       1 connection.go:186] GRPC error: <nil>
I0420 12:06:27.636781       1 controller.go:762] create volume rep: {CapacityBytes:5368709120 VolumeId:fs-0148daff742c320fa::fsap-0a0233310b98754f9 VolumeContext:map[] ContentSource:<nil> AccessibleTopology:[] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}
I0420 12:06:27.636840       1 controller.go:838] successfully created PV pvc-06d3e19c-946f-4f15-baac-b73f3fc7ed67 for PVC efs-claim and csi volume name fs-0148daff742c320fa::fsap-0a0233310b98754f9
I0420 12:06:27.636889       1 controller.go:854] successfully created PV {GCEPersistentDisk:nil AWSElasticBlockStore:nil HostPath:nil Glusterfs:nil NFS:nil RBD:nil ISCSI:nil Cinder:nil CephFS:nil FC:nil Flocker:nil FlexVolume:nil AzureFile:nil VsphereVolume:nil Quobyte:nil AzureDisk:nil PhotonPersistentDisk:nil PortworxVolume:nil ScaleIO:nil Local:nil StorageOS:nil CSI:&CSIPersistentVolumeSource{Driver:efs.csi.aws.com,VolumeHandle:fs-0148daff742c320fa::fsap-0a0233310b98754f9,ReadOnly:false,FSType:,VolumeAttributes:map[string]string{storage.kubernetes.io/csiProvisionerIdentity: 1650456367089-8081-efs.csi.aws.com,},ControllerPublishSecretRef:nil,NodeStageSecretRef:nil,NodePublishSecretRef:nil,ControllerExpandSecretRef:nil,}}
I0420 12:06:27.637060       1 controller.go:1439] provision "kube-system/efs-claim" class "efs-sc": volume "pvc-06d3e19c-946f-4f15-baac-b73f3fc7ed67" provisioned
I0420 12:06:27.637088       1 controller.go:1456] provision "kube-system/efs-claim" class "efs-sc": succeeded
```