### PR TITLE
Disable getting all secrets from ns by default

### DIFF
--- a/charts/aws-efs-csi-driver/templates/controller-serviceaccount.yaml
+++ b/charts/aws-efs-csi-driver/templates/controller-serviceaccount.yaml
@@ -40,10 +40,9 @@ rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["get", "watch", "list", "delete", "update", "create"]
-  - apiGroups: [ "" ]
-    resources: [ "secrets" ]
-    verbs: [ "get", "watch", "list" ]
-
+  # - apiGroups: [ "" ]
+  #   resources: [ "secrets" ]
+  #   verbs: [ "get", "watch", "list" ]
 ---
 
 kind: ClusterRoleBinding


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Disable getting all secrets from namespace by default due to security concern
**What is this PR about? / Why do we need it?**

**What testing is done?** 
