### PR TITLE
Bump the livenessProbe sidcare to v2.6.0-eks-1-18-17

### DIFF
--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -16,7 +16,7 @@ sidecars:
   livenessProbe:
     image:
       repository: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe
-      tag: v2.2.0-eks-1-18-13
+      tag: v2.6.0-eks-1-18-17
       pullPolicy: IfNotPresent
     resources: {}
   nodeDriverRegistrar:


### PR DESCRIPTION


**Is this a bug fix or adding new feature?**

bugfix

**What is this PR about? / Why do we need it?**

Solves #564. There is a proposed solution for this with #595, but
it changes the container registry and is therefore a bigger change
then just go with the next release version (which fixes the issue)
from the same registry as already used.

It might be wise, to just bump all the requirements from currently
1-18-13 to 1-18-17. I am not doing this in this PR, since this
only aims at resolving #564 which is really annoying for us.

For the time of this not being fixed, one can easily replace the
default livenessProbe sidecare version with the following:
https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/564#issuecomment-1118496793

**What testing is done?** 

Tested and verified on an EKS K8s Cluster running 1.21.x.