### PR TITLE
Adding ability to set volMetricsOptIn on Daemonset

### DIFF
--- a/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
+++ b/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
@@ -62,7 +62,6 @@ spec:
             {{- end }}
             - --v={{ .Values.controller.logLevel }}
             - --delete-access-point-root-dir={{ hasKey .Values.controller "deleteAccessPointRootDir" | ternary .Values.controller.deleteAccessPointRootDir false }}
-            - --vol-metrics-opt-in={{ hasKey .Values.controller "volMetricsOptIn" | ternary .Values.controller.volMetricsOptIn false }}
           env:
             - name: CSI_ENDPOINT
               value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock

--- a/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
+++ b/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
@@ -72,6 +72,8 @@ spec:
             - --logtostderr
             - --v={{ .Values.node.logLevel }}
             - --vol-metrics-opt-in={{ hasKey .Values.node "volMetricsOptIn" | ternary .Values.node.volMetricsOptIn false }}
+            - --vol-metrics-refresh-period={{ hasKey .Values.node "volMetricsRefreshPeriod" | ternary .Values.node.volMetricsRefreshPeriod 240 }}
+            - --vol-metrics-fs-rate-limit={{ hasKey .Values.node "volMetricsFsRateLimit" | ternary .Values.node.volMetricsFsRateLimit 5 }}
           env:
             - name: CSI_ENDPOINT
               value: unix:/csi/csi.sock
@@ -166,7 +168,7 @@ spec:
             type: Directory
         - name: efs-state-dir
           hostPath:
-            path: /var/run/efs
+            path: /var/run/efs-csi-driver
             type: DirectoryOrCreate
         - name: efs-utils-config
           hostPath:

--- a/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
+++ b/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
@@ -71,6 +71,7 @@ spec:
             - --endpoint=$(CSI_ENDPOINT)
             - --logtostderr
             - --v={{ .Values.node.logLevel }}
+            - --vol-metrics-opt-in={{ hasKey .Values.node "volMetricsOptIn" | ternary .Values.node.volMetricsOptIn false }}
           env:
             - name: CSI_ENDPOINT
               value: unix:/csi/csi.sock

--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -102,6 +102,8 @@ node:
   # Number for the log level verbosity
   logLevel: 2
   volMetricsOptIn: false
+  volMetricsRefreshPeriod: 240
+  volMetricsFsRateLimit: 5
   hostAliases:
     {}
     # For cross VPC EFS, you need to poison or overwrite the DNS for the efs volume as per

--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -62,7 +62,6 @@ controller:
   # Enable if you want the controller to also delete the
   # path on efs when deleteing an access point
   deleteAccessPointRootDir: false
-  volMetricsOptIn: false
   podAnnotations: {}
   resources:
     {}

--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -102,6 +102,7 @@ controller:
 node:
   # Number for the log level verbosity
   logLevel: 2
+  volMetricsOptIn: false
   hostAliases:
     {}
     # For cross VPC EFS, you need to poison or overwrite the DNS for the efs volume as per

--- a/deploy/kubernetes/base/node-daemonset.yaml
+++ b/deploy/kubernetes/base/node-daemonset.yaml
@@ -31,17 +31,17 @@ spec:
                 operator: NotIn
                 values:
                 - fargate
-      securityContext:
-        fsGroup: 0
-        runAsGroup: 0
-        runAsNonRoot: false
-        runAsUser: 0
       hostNetwork: true
       dnsPolicy: ClusterFirst
       serviceAccountName: efs-csi-node-sa
       priorityClassName: system-node-critical
       tolerations:
         - operator: Exists
+      securityContext:
+        fsGroup: 0
+        runAsGroup: 0
+        runAsNonRoot: false
+        runAsUser: 0
       containers:
         - name: efs-plugin
           securityContext:


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
This is a bug-fix in response to #698. 

**What is this PR about? / Why do we need it?**
It seems as though `volMetricsOptIn` is set for the controller container when the code that uses the flag isn't executed in that context. I've added the flag to the daemonset as well in the first instance because I'm not 100% sure that the flag is never used in the context of the controller. If that is the case I'm happy to also delete those settings in a separate commit.

**What testing is done?** 
As this is a helm change that is very simple, and replicates code that already exists in the codebase, this is untested other than the automated tests that run as part of the PR. However if there are further tests you would like performing I'm happy to do so.

fixes #698 