### PR TITLE
Allow support for custom CA bundles

### DIFF
--- a/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
+++ b/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
@@ -100,10 +100,10 @@ spec:
               mountPath: /var/amazon/efs
             - name: efs-utils-config-legacy
               mountPath: /etc/amazon/efs-legacy
-            {{- if .Values.node.caBundle }}
+          {{- if .Values.node.caBundle }}
             - name: custom-ca-bundle
               mountPath: {{ .Values.node.caBundle.mountPath }}
-            {{- end }}
+          {{- end }}
           ports:
             - name: healthz
               containerPort: {{ .Values.node.healthPort }}
@@ -189,11 +189,11 @@ spec:
           hostPath:
             path: /etc/amazon/efs
             type: DirectoryOrCreate
-        {{- if .Values.node.caBundle }}
+      {{- if .Values.node.caBundle }}
         - name: custom-ca-bundle
           configMap:
             name: {{ .Values.node.caBundle.name }}
             items:
               - key: {{ .Values.node.caBundle.key }}
                 path: {{ .Values.node.caBundle.path }}
-        {{- end }}
+      {{- end }}

--- a/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
+++ b/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
@@ -83,7 +83,11 @@ spec:
             {{- if .Values.useFIPS }}
             - name: AWS_USE_FIPS_ENDPOINT
               value: "true"
-            {{- end }}
+          {{- end }}
+          {{- if .Values.node.caBundle }}
+            - name: AWS_CA_BUNDLE
+              value: {{ .Values.node.caBundle.mountPath }}/{{ .Values.node.caBundle.path }}
+          {{- end }}
           volumeMounts:
             - name: kubelet-dir
               mountPath: /var/lib/kubelet
@@ -96,6 +100,10 @@ spec:
               mountPath: /var/amazon/efs
             - name: efs-utils-config-legacy
               mountPath: /etc/amazon/efs-legacy
+            {{- if .Values.node.caBundle }}
+            - name: custom-ca-bundle
+              mountPath: {{ .Values.node.caBundle.mountPath }}
+            {{- end }}
           ports:
             - name: healthz
               containerPort: {{ .Values.node.healthPort }}
@@ -181,3 +189,11 @@ spec:
           hostPath:
             path: /etc/amazon/efs
             type: DirectoryOrCreate
+        {{- if .Values.node.caBundle }}
+        - name: custom-ca-bundle
+          configMap:
+            name: {{ .Values.node.caBundle.name }}
+            items:
+              - key: {{ .Values.node.caBundle.key }}
+                path: {{ .Values.node.caBundle.path }}
+        {{- end }}

--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -162,6 +162,12 @@ node:
     runAsUser: 0
     runAsGroup: 0
     fsGroup: 0
+  ## Set this if using the driver in a disconnected region or partition, and you have to provide a custom CA bundle.
+  #caBundle:
+  #  name: custom-bundle-configmap-name
+  #  key: custom-bundle-configmap-key
+  #  path: custom-bundle-path
+  #  mountPath: path-to-mount-bundle-in-container
 
 storageClasses: []
 # Add StorageClass resources like:


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
This is a new feature, which allows a custom CA bundle to be specified to the driver, as suggested by @zonybob in #699

**What is this PR about? / Why do we need it?**
When the driver runs in disconnected regions/partitions it needs custom CA certificates to be provided, but at present the driver has no way of doing that. This PR adds that capability and consequently configures the driver to use those certificates.

**What testing is done?** 
Have run the driver through `helm` template to ensure it renders correctly and have installed it into a local KiND cluster to ensure the driver boots but no more testing other than that. @zonybob if you wanted to take this branch and see if it solves your problem/have any comments I'd be eager to hear them!

fixes #699 