### PR TITLE
Change the namespace for ClusterRoleBinding

### DIFF
--- a/deploy/kubernetes/base/controller-serviceaccount.yaml
+++ b/deploy/kubernetes/base/controller-serviceaccount.yaml
@@ -50,7 +50,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: efs-csi-controller-sa
-    namespace: default
+    namespace: kube-system
 roleRef:
   kind: ClusterRole
   name: efs-csi-external-provisioner-role


### PR DESCRIPTION
The namespace for `ClusterRoleBinding` is set to default, this lead to an issue after the deployment is completed. This is the failure. `error retrieving resource lock kube-system/efs-csi-aws-com: leases.coordination.k8s.io "efs-csi-aws-com" is forbidden: User "system:serviceaccount:kube-system:efs-csi-controller-sa" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"`

The issue is not encountered when deploying with helm as the field is parametrized to take the namespace provided at install time, which is `kube-system`

**Is this a bug fix or adding new feature?** 
bug

**What is this PR about? / Why do we need it?** 
Enable the successful deployment of the controller.

**What testing is done?** 
