### PR TITLE
make access to secrets configurable in Helm chart

### DIFF
--- a/charts/aws-efs-csi-driver/templates/controller-serviceaccount.yaml
+++ b/charts/aws-efs-csi-driver/templates/controller-serviceaccount.yaml
@@ -40,9 +40,6 @@ rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["get", "watch", "list", "delete", "update", "create"]
-  # - apiGroups: [ "" ]
-  #   resources: [ "secrets" ]
-  #   verbs: [ "get", "watch", "list" ]
 
 ---
 
@@ -60,3 +57,36 @@ roleRef:
   kind: ClusterRole
   name: efs-csi-external-provisioner-role
   apiGroup: rbac.authorization.k8s.io
+
+{{ range $namespace := .Values.controller.secretsNamespaces }}
+{{- with $ }}
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: efs-csi-external-provisioner-role
+  namespace: {{ $namespace }}
+  labels:
+    app.kubernetes.io/name: {{ include "aws-efs-csi-driver.name" . }}
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "secrets" ]
+    verbs: [ "get", "watch", "list" ]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: efs-csi-provisioner-binding
+  namespace: {{ $namespace }}
+  labels:
+    app.kubernetes.io/name: {{ include "aws-efs-csi-driver.name" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ $.Values.controller.serviceAccount.name }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: efs-csi-external-provisioner-role
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}
+{{- end }}

--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -75,6 +75,7 @@ controller:
     annotations: {}
     ## Enable if EKS IAM for SA is used
     #  eks.amazonaws.com/role-arn: arn:aws:iam::111122223333:role/efs-csi-role
+  secretsNamespaces: []
   healthPort: 9909
   regionalStsEndpoints: false
 ## Node daemonset variables


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

**What is this PR about? / Why do we need it?**
Due to security reason access to secrets was remove in  #677. This prevents usage of cross-account mount.

**What testing is done?** 
Render locally with following addition in `value.yaml`
```yaml
controller:
  secretsNamespaces: ["test", "kube-system"]
```
additional output
```yaml
# Source: aws-efs-csi-driver/templates/controller-serviceaccount.yaml
kind: Role
apiVersion: rbac.authorization.k8s.io/v1
metadata:
  name: efs-csi-external-provisioner-role
  namespace: test
  labels:
    app.kubernetes.io/name: aws-efs-csi-driver
rules:
  - apiGroups: [ "" ]
    resources: [ "secrets" ]
    verbs: [ "get", "watch", "list" ]
---
# Source: aws-efs-csi-driver/templates/controller-serviceaccount.yaml
kind: Role
apiVersion: rbac.authorization.k8s.io/v1
metadata:
  name: efs-csi-external-provisioner-role
  namespace: kube-system
  labels:
    app.kubernetes.io/name: aws-efs-csi-driver
rules:
  - apiGroups: [ "" ]
    resources: [ "secrets" ]
    verbs: [ "get", "watch", "list" ]
---
# Source: aws-efs-csi-driver/templates/controller-serviceaccount.yaml
kind: RoleBinding
apiVersion: rbac.authorization.k8s.io/v1
metadata:
  name: efs-csi-provisioner-binding
  namespace: test
  labels:
    app.kubernetes.io/name: aws-efs-csi-driver
subjects:
  - kind: ServiceAccount
    name: efs-csi-controller-sa
    namespace: kube-system
roleRef:
  kind: Role
  name: efs-csi-external-provisioner-role
  apiGroup: rbac.authorization.k8s.io
---
# Source: aws-efs-csi-driver/templates/controller-serviceaccount.yaml
kind: RoleBinding
apiVersion: rbac.authorization.k8s.io/v1
metadata:
  name: efs-csi-provisioner-binding
  namespace: kube-system
  labels:
    app.kubernetes.io/name: aws-efs-csi-driver
subjects:
  - kind: ServiceAccount
    name: efs-csi-controller-sa
    namespace: kube-system
roleRef:
  kind: Role
  name: efs-csi-external-provisioner-role
  apiGroup: rbac.authorization.k8s.io
```