### PR TITLE
Updating documentation and adding storage class

### DIFF
--- a/examples/kubernetes/statefulset/specs/example.yaml
+++ b/examples/kubernetes/statefulset/specs/example.yaml
@@ -1,4 +1,10 @@
 apiVersion: v1
+kind: StorageClass
+metadata:
+  name: efs-sc
+provisioner: efs.csi.aws.com
+---
+apiVersion: v1
 kind: PersistentVolume
 metadata:
   name: efs-pv

--- a/examples/kubernetes/static_provisioning/README.md
+++ b/examples/kubernetes/static_provisioning/README.md
@@ -14,6 +14,7 @@ spec:
   volumeMode: Filesystem
   accessModes:
     - ReadWriteOnce
+  storageClassName: efs-sc
   persistentVolumeReclaimPolicy: Retain
   csi:
     driver: efs.csi.aws.com
@@ -29,6 +30,7 @@ You can find it using AWS CLI:
 ### Deploy the Example Application
 Create PV and persistent volume claim (PVC):
 ```sh
+>> kubectl apply -f examples/kubernetes/static_provisioning/specs/storageclass.yaml
 >> kubectl apply -f examples/kubernetes/static_provisioning/specs/pv.yaml
 >> kubectl apply -f examples/kubernetes/static_provisioning/specs/claim.yaml
 >> kubectl apply -f examples/kubernetes/static_provisioning/specs/pod.yaml

--- a/examples/kubernetes/static_provisioning/specs/claim.yaml
+++ b/examples/kubernetes/static_provisioning/specs/claim.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
-  storageClassName: ""
+  storageClassName: efs-sc
   resources:
     requests:
       storage: 5Gi

--- a/examples/kubernetes/static_provisioning/specs/pv.yaml
+++ b/examples/kubernetes/static_provisioning/specs/pv.yaml
@@ -8,7 +8,7 @@ spec:
   volumeMode: Filesystem
   accessModes:
     - ReadWriteOnce
-  storageClassName: ""
+  storageClassName: efs-sc
   persistentVolumeReclaimPolicy: Retain
   csi:
     driver: efs.csi.aws.com

--- a/examples/kubernetes/static_provisioning/specs/storageclass.yaml
+++ b/examples/kubernetes/static_provisioning/specs/storageclass.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: StorageClass
+metadata:
+  name: efs-sc
+provisioner: efs.csi.aws.com


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Just a small documentation fix to add storage classes to two of the example as otherwise they will bind to the default StorageClass in EKS and fail to run.

**What is this PR about? / Why do we need it?**
See above, we want our examples to be easy to follow and clear.

**What testing is done?** 
Have run through the examples with a new cluster (1.22) and they all work fine now whereas without the storageClass they were a problem

fixes #639 