### PR TITLE
Support ReadWriteOncePod

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,6 @@ test-e2e:
 .PHONY: test-e2e-external-eks
 test-e2e-external-eks:
 	CLUSTER_TYPE=eksctl \
-	K8S_VERSION="1.25" \
 	DRIVER_NAME=aws-efs-csi-driver \
 	HELM_VALUES_FILE="./hack/values_eksctl.yaml" \
 	CONTAINER_NAME=efs-plugin \

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -54,6 +54,7 @@ var (
 	// controllerCaps represents the capability of controller service
 	controllerCaps = []csi.ControllerServiceCapability_RPC_Type{
 		csi.ControllerServiceCapability_RPC_CREATE_DELETE_VOLUME,
+		csi.ControllerServiceCapability_RPC_SINGLE_NODE_MULTI_WRITER,
 	}
 )
 

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -35,6 +35,8 @@ var (
 	volumeCapAccessModes = []csi.VolumeCapability_AccessMode_Mode{
 		csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
 		csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER,
+		csi.VolumeCapability_AccessMode_SINGLE_NODE_SINGLE_WRITER,
+		csi.VolumeCapability_AccessMode_SINGLE_NODE_MULTI_WRITER,
 	}
 	volumeIdCounter  = make(map[string]int)
 	supportedFSTypes = []string{"efs", ""}

--- a/pkg/driver/node_test.go
+++ b/pkg/driver/node_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/golang/mock/gomock"
+
 	"github.com/kubernetes-sigs/aws-efs-csi-driver/pkg/driver/mocks"
 )
 
@@ -42,14 +43,13 @@ type errtyp struct {
 
 func setup(mockCtrl *gomock.Controller, volStatter VolStatter, volMetricsOptIn bool) (*mocks.MockMounter, *Driver, context.Context) {
 	mockMounter := mocks.NewMockMounter(mockCtrl)
-	nodeCaps := SetNodeCapOptInFeatures(volMetricsOptIn)
 	driver := &Driver{
 		endpoint:        "endpoint",
 		nodeID:          "nodeID",
 		mounter:         mockMounter,
 		volStatter:      volStatter,
 		volMetricsOptIn: true,
-		nodeCaps:        nodeCaps,
+		nodeCaps:        SetNodeCapOptInFeatures([]csi.NodeServiceCapability_RPC_Type{}, volMetricsOptIn),
 	}
 	ctx := context.Background()
 	return mockMounter, driver, ctx

--- a/pkg/driver/sanity_test.go
+++ b/pkg/driver/sanity_test.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/container-storage-interface/spec/lib/go/csi"
 	"k8s.io/mount-utils"
 
 	"github.com/golang/mock/gomock"
@@ -65,8 +66,6 @@ func TestSanityEFSCSI(t *testing.T) {
 	config.Address = endpoint
 	config.TestVolumeParameters = parameters
 
-	nodeCaps := SetNodeCapOptInFeatures(true)
-
 	mockCtrl := gomock.NewController(t)
 	drv := Driver{
 		endpoint:        endpoint,
@@ -74,7 +73,7 @@ func TestSanityEFSCSI(t *testing.T) {
 		mounter:         NewFakeMounter(),
 		efsWatchdog:     &mockWatchdog{},
 		cloud:           cloud.NewFakeCloudProvider(),
-		nodeCaps:        nodeCaps,
+		nodeCaps:        SetNodeCapOptInFeatures([]csi.NodeServiceCapability_RPC_Type{}, true),
 		volMetricsOptIn: true,
 		volStatter:      NewVolStatter(),
 		gidAllocator:    NewGidAllocator(),


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
New Feature, now that ReadWriteOncePod has entered Alpha testing we should add support for it in the driver.

**What is this PR about? / Why do we need it?**
This PR enables us to serve users that want to use ReadWriteOncePod in their manifests. It adds new E2E tests to cover the use cases the ReadWriteOncePod covers.

**What testing is done?** 
More E2E testing in Kops only, as EKS has no way to set the feature gates required. The first draft of this may not be exactly what's needed from E2E tests but I need to use the CI framework to run them and then debug.

fixes #540 

@chrishenzie tagging for visibility and assistance. 
