### PR TITLE
Delegate`fsGroup` to driver rather than Kubelet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ test-e2e:
 	K8S_VERSION="1.22.9" \
 	DRIVER_NAME=aws-efs-csi-driver \
 	CONTAINER_NAME=efs-plugin \
-	TEST_EXTRA_FLAGS='--cluster-name=$$CLUSTER_NAME' \
+	TEST_EXTRA_FLAGS='--cluster-name=$$CLUSTER_NAME --created-by=kops' \
 	AWS_REGION=us-west-2 \
 	AWS_AVAILABILITY_ZONES=us-west-2a,us-west-2b,us-west-2c \
 	TEST_PATH=./test/e2e/... \
@@ -133,7 +133,7 @@ test-e2e-external-eks:
 	DRIVER_NAME=aws-efs-csi-driver \
 	HELM_VALUES_FILE="./hack/values_eksctl.yaml" \
 	CONTAINER_NAME=efs-plugin \
-	TEST_EXTRA_FLAGS='--cluster-name=$$CLUSTER_NAME' \
+	TEST_EXTRA_FLAGS='--cluster-name=$$CLUSTER_NAME --created-by=eksctl' \
 	AWS_REGION=us-west-2 \
 	AWS_AVAILABILITY_ZONES=us-west-2a,us-west-2b,us-west-2c \
 	TEST_PATH=./test/e2e/... \

--- a/Makefile
+++ b/Makefile
@@ -116,6 +116,7 @@ test:
 
 .PHONY: test-e2e
 test-e2e:
+	K8S_VERSION="1.22.9" \
 	DRIVER_NAME=aws-efs-csi-driver \
 	CONTAINER_NAME=efs-plugin \
 	TEST_EXTRA_FLAGS='--cluster-name=$$CLUSTER_NAME' \
@@ -128,7 +129,7 @@ test-e2e:
 .PHONY: test-e2e-external-eks
 test-e2e-external-eks:
 	CLUSTER_TYPE=eksctl \
-	K8S_VERSION="1.20" \
+	K8S_VERSION="1.22" \
 	DRIVER_NAME=aws-efs-csi-driver \
 	HELM_VALUES_FILE="./hack/values_eksctl.yaml" \
 	CONTAINER_NAME=efs-plugin \

--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -16,19 +16,19 @@ sidecars:
   livenessProbe:
     image:
       repository: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe
-      tag: v2.2.0-eks-1-18-13
+      tag: v2.7.0-eks-1-22-8
       pullPolicy: IfNotPresent
     resources: {}
   nodeDriverRegistrar:
     image:
       repository: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar
-      tag: v2.1.0-eks-1-18-13
+      tag: v2.5.1-eks-1-22-8
       pullPolicy: IfNotPresent
     resources: {}
   csiProvisioner:
     image:
       repository: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner
-      tag: v2.1.1-eks-1-18-13
+      tag: v3.1.1-eks-1-22-8
       pullPolicy: IfNotPresent
     resources: {}
 

--- a/deploy/kubernetes/base/controller-deployment.yaml
+++ b/deploy/kubernetes/base/controller-deployment.yaml
@@ -60,7 +60,7 @@ spec:
             periodSeconds: 10
             failureThreshold: 5
         - name: csi-provisioner
-          image: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner:v2.1.1-eks-1-18-13
+          image: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner:v3.1.1-eks-1-22-8
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)
@@ -75,7 +75,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: liveness-probe
-          image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.2.0-eks-1-18-13
+          image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.7.0-eks-1-22-8
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=/csi/csi.sock

--- a/deploy/kubernetes/base/node-daemonset.yaml
+++ b/deploy/kubernetes/base/node-daemonset.yaml
@@ -75,7 +75,7 @@ spec:
             periodSeconds: 2
             failureThreshold: 5
         - name: csi-driver-registrar
-          image: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar:v2.1.0-eks-1-18-13
+          image: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar:v2.5.1-eks-1-22-8
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)
@@ -96,7 +96,7 @@ spec:
             - name: registration-dir
               mountPath: /registration
         - name: liveness-probe
-          image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.2.0-eks-1-18-13
+          image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.7.0-eks-1-22-8
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=/csi/csi.sock

--- a/hack/e2e/run.sh
+++ b/hack/e2e/run.sh
@@ -50,9 +50,9 @@ IMAGE_TAG=${IMAGE_TAG:-${TEST_ID}}
 
 # kops: must include patch version (e.g. 1.19.1)
 # eksctl: mustn't include patch version (e.g. 1.19)
-K8S_VERSION=${K8S_VERSION:-1.20.8}
+K8S_VERSION=${K8S_VERSION:-1.22.9}
 
-KOPS_VERSION=${KOPS_VERSION:-1.21.0}
+KOPS_VERSION=${KOPS_VERSION:-1.23.2}
 KOPS_STATE_FILE=${KOPS_STATE_FILE:-s3://k8s-kops-csi-e2e}
 KOPS_PATCH_FILE=${KOPS_PATCH_FILE:-./hack/kops-patch.yaml}
 KOPS_PATCH_NODE_FILE=${KOPS_PATCH_NODE_FILE:-./hack/kops-patch-node.yaml}

--- a/hack/e2e/run.sh
+++ b/hack/e2e/run.sh
@@ -189,10 +189,10 @@ fi
 loudecho "Driver deployment complete, time used: $secondUsed seconds"
 
 loudecho "Testing focus ${GINKGO_FOCUS}"
-eval "EXPANDED_TEST_EXTRA_FLAGS=$TEST_EXTRA_FLAGS"
+eval "EXPANDED_TEST_EXTRA_FLAGS=\"$TEST_EXTRA_FLAGS\""
 set -x
 set +e
-${GINKGO_BIN} -p -nodes="${GINKGO_NODES}" -v --focus="${GINKGO_FOCUS}" --skip="${GINKGO_SKIP}" "${TEST_PATH}" -- -kubeconfig="${KUBECONFIG}" -report-dir="${ARTIFACTS}" -gce-zone="${FIRST_ZONE}" "${EXPANDED_TEST_EXTRA_FLAGS}"
+${GINKGO_BIN} -p -nodes="${GINKGO_NODES}" -v --focus="${GINKGO_FOCUS}" --skip="${GINKGO_SKIP}" "${TEST_PATH}" -- -kubeconfig="${KUBECONFIG}" -report-dir="${ARTIFACTS}" -gce-zone="${FIRST_ZONE}" ${EXPANDED_TEST_EXTRA_FLAGS}
 TEST_PASSED=$?
 set -e
 set +x

--- a/hack/kops-patch-node.yaml
+++ b/hack/kops-patch-node.yaml
@@ -1,0 +1,3 @@
+spec:
+  instanceMetadata:
+    httpTokens: optional

--- a/hack/kops-patch.yaml
+++ b/hack/kops-patch.yaml
@@ -13,3 +13,18 @@ spec:
           "Resource": "*"
         }
       ]
+  kubeAPIServer:
+    featureGates:
+      DelegateFSGroupToCSIDriver: "true"
+  kubeControllerManager:
+    featureGates:
+      DelegateFSGroupToCSIDriver: "true"
+  kubeProxy:
+    featureGates:
+      DelegateFSGroupToCSIDriver: "true"
+  kubeScheduler:
+    featureGates:
+      DelegateFSGroupToCSIDriver: "true"
+  kubelet:
+    featureGates:
+      DelegateFSGroupToCSIDriver: "true"

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -184,7 +184,7 @@ func (d *Driver) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolu
 
 	fsGroup := volCap.GetMount().VolumeMountGroup
 	if fsGroup != "" {
-		fsGroupParsed, _ := strconv.ParseInt(fsGroup, 10, 64)
+		fsGroupParsed, _ := strconv.Atoi(fsGroup)
 		klog.V(5).Infof("NodePublishVolume: changing GID of %s to %s", target, fsGroup)
 		os.Chown(target, -1, int(fsGroupParsed))
 	}

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -132,6 +132,12 @@ func (d *Driver) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolu
 		mountOptions = append(mountOptions, "ro")
 	}
 
+	fsGroup := volCap.GetMount().VolumeMountGroup
+	if fsGroup != "" {
+		klog.V(5).Infof("Adding fsGroup parameter of %s to mount call", fsGroup)
+		mountOptions = append(mountOptions, fmt.Sprintf("gid=%s", fsGroup))
+	}
+
 	if m := volCap.GetMount(); m != nil {
 		for _, f := range m.MountFlags {
 			// Special-case check for access point

--- a/pkg/driver/node_test.go
+++ b/pkg/driver/node_test.go
@@ -353,8 +353,8 @@ func TestNodePublishVolume(t *testing.T) {
 				TargetPath: targetPath,
 			},
 			expectMakeDir: true,
-			mountArgs:     []interface{}{volumeId + ":/", targetPath, "efs", []string{"tls", "gid=1000"}},
 			mountSuccess:  true,
+			mountArgs:     []interface{}{volumeId + ":/", targetPath, "efs", []string{"tls"}},
 		},
 		{
 			name: "fail: conflicting access point in volume handle and mount options",

--- a/pkg/driver/sanity_test.go
+++ b/pkg/driver/sanity_test.go
@@ -23,10 +23,12 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/container-storage-interface/spec/lib/go/csi"
 	"k8s.io/mount-utils"
 
 	"github.com/golang/mock/gomock"
 	"github.com/kubernetes-csi/csi-test/pkg/sanity"
+
 	"github.com/kubernetes-sigs/aws-efs-csi-driver/pkg/cloud"
 )
 
@@ -64,8 +66,6 @@ func TestSanityEFSCSI(t *testing.T) {
 		TestVolumeParameters: parameters,
 	}
 
-	nodeCaps := SetNodeCapOptInFeatures(true)
-
 	mockCtrl := gomock.NewController(t)
 	drv := Driver{
 		endpoint:        endpoint,
@@ -73,7 +73,7 @@ func TestSanityEFSCSI(t *testing.T) {
 		mounter:         NewFakeMounter(),
 		efsWatchdog:     &mockWatchdog{},
 		cloud:           cloud.NewFakeCloudProvider(),
-		nodeCaps:        nodeCaps,
+		nodeCaps:        SetNodeCapOptInFeatures([]csi.NodeServiceCapability_RPC_Type{}, true),
 		volMetricsOptIn: true,
 		volStatter:      NewVolStatter(),
 		gidAllocator:    NewGidAllocator(),

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -29,6 +29,7 @@ var (
 	// Parameters that are expected to be set by consumers of this package.
 	ClusterName                 string
 	Region                      string
+	CreatedBy                   string
 	FileSystemId                string
 	FileSystemName              string
 	MountTargetSecurityGroupIds []string

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -382,9 +382,10 @@ var _ = ginkgo.Describe("[efs-csi] EFS CSI", func() {
 				_ = f.ClientSet.CoreV1().PersistentVolumes().Delete(context.TODO(), pv.Name, metav1.DeleteOptions{})
 			}()
 			pod := e2epod.MakePod(f.Namespace.Name, nil, []*v1.PersistentVolumeClaim{pvc}, false, "")
+
 			pod.Spec.RestartPolicy = v1.RestartPolicyNever
 			var fsGroup int64 = 1000
-			pod.Spec.SecurityContext.FSGroup = &fsGroup
+			pod.Spec.SecurityContext = e2epod.GeneratePodSecurityContext(&fsGroup, nil)
 			pod, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(context.TODO(), pod, metav1.CreateOptions{})
 			framework.ExpectNoError(err, "creating pod")
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -65,6 +65,7 @@ func init() {
 
 	flag.StringVar(&ClusterName, "cluster-name", "", "the cluster name")
 	flag.StringVar(&Region, "region", "us-west-2", "the region")
+	flag.StringVar(&CreatedBy, "created-by", "", "the tool used to create the cluster")
 	flag.StringVar(&FileSystemId, "file-system-id", "", "the ID of an existing file system")
 	flag.StringVar(&FileSystemName, "file-system-name", "", "name to use for provisioned EFS file system, only used if -file-system-id is not set")
 	flag.BoolVar(&CreateFileSystem, "create-file-system", true, "provision a file system for the test with name -file-system-name. Requires -cluster-name and -region. Either this should be true or file-system-id should be set to an existing file system, otherwise tests will fail")


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
New feature

**What is this PR about? / Why do we need it?**
The new feature of CSI documented here: https://kubernetes-csi.github.io/docs/support-fsgroup.html#delegate-fsgroup-to-csi-driver, allows us to get the fsGroup from the pod that wants to use the PVC specified. This will be particularly helpful to solve issues like #125 and #300 or at least give a slightly better route to solving them. This is a bit of a speculative feature at the minute as the feature in Kubernetes doesn't go Beta till 1.23, not supported by EKS till August but it would be good to have this on the slate for when 1.23 rolls out.

**What testing is done?** 
This has had new Unit Tests and E2E tests added and I plan to spin this up on my own cluster and will post results as that happens. The E2E might not be quite right yet but once this PR is approved for testing I'll iterate on them at that point.