### PR TITLE
Skip deallocating Gid when static Gid set

### DIFF
--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -242,7 +242,9 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 
 	accessPointId, err := localCloud.CreateAccessPoint(ctx, volName, accessPointsOptions)
 	if err != nil {
-		d.gidAllocator.releaseGid(accessPointsOptions.FileSystemId, gid)
+		if allocatedGid != 0 {
+			d.gidAllocator.releaseGid(accessPointsOptions.FileSystemId, gid)
+		}
 		if err == cloud.ErrAccessDenied {
 			return nil, status.Errorf(codes.Unauthenticated, "Access Denied. Please ensure you have the right AWS permissions: %v", err)
 		}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Bug fix

**What is this PR about? / Why do we need it?**
The efs-plugin crashes with a segmentation fault if there was an error creating an access point if the storage class is defined with a fixed uid and gid because it attempts to deallocate the gid using an uninitialised gidAllocator, and does not log the error for the cluster admin to resolve, as the code to log the error occurs after the segfault.

This PR adds a check to see if the "allocated gid" is the default Go int value, and skips attempting to deallocate it if is so.

**What testing is done?**
Is captured by existing test case for fixed uid/gid allocation