### PR TITLE
feat(node/controller): allow to set updateStrategy

### DIFF
--- a/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
+++ b/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
@@ -13,6 +13,10 @@ spec:
       app: efs-csi-controller
       app.kubernetes.io/name: {{ include "aws-efs-csi-driver.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
+  {{- with .Values.controller.updateStrategy }}
+  strategy:
+    {{ toYaml . | nindent 4 }}
+  {{- end }}
   template:
     metadata:
       labels:

--- a/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
+++ b/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
@@ -11,6 +11,10 @@ spec:
       app: efs-csi-node
       app.kubernetes.io/name: {{ include "aws-efs-csi-driver.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
+  {{- with .Values.node.updateStrategy }}
+  updateStrategy:
+    {{ toYaml . | nindent 4 }}
+  {{- end }}
   template:
     metadata:
       labels:

--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -68,6 +68,7 @@ controller:
     #   cpu: 100m
     #   memory: 128Mi
   nodeSelector: {}
+  updateStrategy: {}
   tolerations: []
   affinity: {}
   # Specifies whether a service account should be created
@@ -112,6 +113,10 @@ node:
     #   cpu: 100m
     #   memory: 128Mi
   nodeSelector: {}
+  updateStrategy: {}
+    # Override default strategy (RollingUpdate) to speed up deployment.
+    # This can be useful if helm timeouts are observed.
+    # type: OnDelete
   tolerations:
     - operator: Exists
   # Specifies whether a service account should be created


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
(New Feature)
This PR allow to define `updateStrategy` for `controller deployment` and `node daemonset`

**What is this PR about? / Why do we need it?**
With default update strategy takes too long to update all the pods of the daemonset if you have many worker nodes. This results in helm timeout (after 300 second.)

We would like to have the option to tune the `updateStrategy` if needed. Selecting different `updateStrategy` type or tuning the default`RollingUpdate`.

ps: I see there is an [open PR](https://github.com/kubernetes-sigs/aws-efs-csi-driver/pull/615) already about it, but since is a bit old ,not sure if someone is still working on it. If that can be merged i can close mine.