### PR TITLE
Update deprecated NodeSelector

### DIFF
--- a/charts/aws-efs-csi-driver/Chart.yaml
+++ b/charts/aws-efs-csi-driver/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: aws-efs-csi-driver
 version: 2.2.9
-appVersion: 1.4.2
+appVersion: 1.4.3
 kubeVersion: ">=1.17.0-0"
 description: "A Helm chart for AWS EFS CSI Driver"
 home: https://github.com/kubernetes-sigs/aws-efs-csi-driver

--- a/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
+++ b/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
@@ -36,7 +36,7 @@ spec:
       {{- end }}
     {{- end }}
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
         {{- with .Values.node.nodeSelector }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/deploy/kubernetes/base/node-daemonset.yaml
+++ b/deploy/kubernetes/base/node-daemonset.yaml
@@ -21,7 +21,7 @@ spec:
         app.kubernetes.io/instance: kustomize
     spec:
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
Signed-off-by: dschunack <dschunack@web.de>

**Is this a bug fix or adding new feature?**

No, it replaced the deprecated NodeSelector labels #741 

**What is this PR about? / Why do we need it?**
It replaced the deprecated NodeSelector labels #741 

**What testing is done?** 
helm chart was applied on a test EKS