### PR TITLE
Revise awscredsuri validation to prefix check

### DIFF
--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -165,9 +165,9 @@ func (d *Driver) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolu
 				}
 			}
 
-			if f == "awscredsuri" {
+			if strings.HasPrefix(f, "awscredsuri") {
 				klog.Warning("awscredsuri mount option is not supported by efs-csi-driver.")
-				return nil, nil
+				continue
 			}
 
 			if !hasOption(mountOptions, f) {
@@ -425,6 +425,7 @@ func parseVolumeId(volumeId string) (fsid, subpath, apid string, err error) {
 	return
 }
 
+// Check and avoid adding duplicate mount options
 func hasOption(options []string, opt string) bool {
 	for _, o := range options {
 		if o == opt {


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Revise awscredsuri validation to prefix check
**What is this PR about? / Why do we need it?**

**What testing is done?** 
Manual test result - driver successfully rejected `awscredsuri` mount option and efs-utils is still able to mount success with this option filtered out
```
W0908 20:00:57.034174       1 node.go:169] awscredsuri mount option is not supported by efs-csi-driver.

I0908 20:00:57.034237       1 node.go:183] NodePublishVolume: mounting fs-0ed800ff4153f6ad8:/ at /var/lib/kubelet/pods/254909f8-1129-404f-bde4-85d922d645d4/volumes/kubernetes.io~csi/efs-pv/mount with options [tls iam]
```



```
wenyizha@test_credsuri % k get pods -A
NAMESPACE     NAME                                  READY   STATUS    RESTARTS   AGE

default       efs-app                               1/1     Running   0          8s

kube-system   aws-node-v6mhn                        1/1     Running   0          7d21h

kube-system   coredns-65bfc5645f-5dxfg              1/1     Running   0          7d21h

kube-system   coredns-65bfc5645f-s5kbl              1/1     Running   0          7d21h
kube-system   efs-csi-controller-665fbb9b55-4r8xl   3/3     Running   0          18s
kube-system   efs-csi-controller-665fbb9b55-bz6k2   3/3     Running   0          15s
kube-system   efs-csi-node-7jfsd                    3/3     Running   0          8s
kube-system   kube-proxy-b44jv                      1/1     Running   0          7d21h
```
