### PR TITLE
allow specifying timeout duration

### DIFF
--- a/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
+++ b/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
@@ -113,6 +113,7 @@ spec:
           args:
             - --csi-address=/csi/csi.sock
             - --health-port={{ .Values.controller.healthPort }}
+            - --probe-timeout={{ .Values.controller.timeout }}
           volumeMounts:
             - name: socket-dir
               mountPath: /csi

--- a/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
+++ b/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
@@ -109,6 +109,7 @@ spec:
           args:
             - --csi-address=$(ADDRESS)
             - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+            - --timeout={{ .Values.node.timeout }}
             - --v={{ .Values.node.logLevel }}
           env:
             - name: ADDRESS
@@ -133,6 +134,7 @@ spec:
           args:
             - --csi-address=/csi/csi.sock
             - --health-port={{ .Values.node.healthPort }}
+            - --probe-timeout={{ .Values.node.timeout }}
             - --v={{ .Values.node.logLevel }}
           volumeMounts:
             - name: plugin-dir

--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -80,6 +80,7 @@ controller:
     #  eks.amazonaws.com/role-arn: arn:aws:iam::111122223333:role/efs-csi-role
   healthPort: 9909
   regionalStsEndpoints: false
+  timeout: 1s
 ## Node daemonset variables
 
 node:
@@ -123,6 +124,7 @@ node:
     ## Enable if EKS IAM for SA is used
     #  eks.amazonaws.com/role-arn: arn:aws:iam::111122223333:role/efs-csi-role
   healthPort: 9809
+  timeout: 1s
 
 storageClasses: []
 # Add StorageClass resources like:


### PR DESCRIPTION
On an EKS cluster we experienced some node pods entering crashloop while volumes were actually correctly attached to nodes and mounted on pods. This was due to the liveness probe taking too long (its default timeout is 1s), failing with a timeout and not managing to recover. The probe continued to fail even after the container is restarted.

AWS support (case 10734780791) suggested increasing timeouts which was performed by manual updates on the daemonset and pods are running fine since then. But those timeouts could not be defined in the Helm chart.

Add timeout values in the Helm chart with default values set to their current default.

**Is this a bug fix or adding new feature?**

Feature

**What is this PR about? / Why do we need it?**

CSI pods randomly entering crashloop on some clusters

**What testing is done?** 

Change applied on one of our cluster