### PR TITLE
Specify a list of IPs for a EFS fs id

### DIFF
--- a/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
+++ b/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
@@ -24,9 +24,10 @@ spec:
     {{- with .Values.node.hostAliases }}
       hostAliases:
       {{- range $k, $v := . }}
-        - ip: {{ $v.ip }}
+        - ip: {{ $ip }}
           hostnames:
             - {{ $k }}.efs.{{ $v.region }}.amazonaws.com
+      {{- end }}
       {{- end }}
     {{- end }}
     {{- if .Values.imagePullSecrets }}


### PR DESCRIPTION
According to https://glentomkowiak.medium.com/aws-efs-on-kubernetes-with-peered-vpc-2b4ad18c008c  , the EFS_CSI driver can fail to the next IP if the first one fails, so if multiple IP addresses exist in the /etc/hosts file, it should pick up the next one if the first fails.... as with an AZ failure.    This change can work in a values.yaml containing:
node:
  hostAliases:
    fs-xxxxxxxx:
      ip:
        - 0.0.0.1
        - 0.0.0.2
      region: us-west-2

or helm arguments of:  
--set node.hostAliases.fs-xxxxxxxx.ip[0]=0.0.0.1 --set node.hostAliases.fs-xxxxxxxx.ip[1]=0.0.0.2  --set node.hostAliases.fs-xxxxxxxx.region=us-west-2

**Is this a bug fix or adding new feature?**

**What is this PR about? / Why do we need it?**

**What testing is done?** 
