### PR TITLE
feat : use --no-cache-dir flag to pip in dockerfiles to save space

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ RUN if [ "$EFSUTILSSOURCE" = "yum" ]; \
 RUN yum -y install wget && \
     wget https://bootstrap.pypa.io/get-pip.py -O /tmp/get-pip.py && \
     python3 /tmp/get-pip.py && \
-    pip3 install botocore || /usr/local/bin/pip3 install botocore && \
+    pip3 install --no-cache-dir botocore || /usr/local/bin/pip3 install --no-cache-dir botocore && \
     rm -rf /tmp/get-pip.py
 
 # At image build time, static files installed by efs-utils in the config directory, i.e. CAs file, need


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

Optimization

**What is this PR about? / Why do we need it?**

using the "--no-cache-dir" flag in pip install, make sure downloaded packages by pip don't cache on the system. This is a best practice that makes sure to fetch from a repo instead of using a local cached one. Further, in the case of Docker Containers, by restricting caching, we can reduce image size. In terms of stats, it depends upon the number of python packages multiplied by their respective size. e.g for heavy packages with a lot of dependencies it reduces a lot by don't cache pip packages.

Further, more detailed information can be found at

https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>

**What testing is done?** 
