### PR TITLE
add daemonset affinity control

### DIFF
--- a/charts/aws-efs-csi-driver/CHANGELOG.md
+++ b/charts/aws-efs-csi-driver/CHANGELOG.md
@@ -17,6 +17,9 @@
 # v2.3.0
 * Bump app/driver version to `v1.4.3`
 
+# v2.2.10
+* Add control over daemnoset affinity
+
 # v2.2.9
 * Bump app/driver version to `v1.4.2`
 

--- a/charts/aws-efs-csi-driver/Chart.yaml
+++ b/charts/aws-efs-csi-driver/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: aws-efs-csi-driver
-version: 2.3.5
+version: 2.3.6
 appVersion: 1.4.8
 kubeVersion: ">=1.17.0-0"
 description: "A Helm chart for AWS EFS CSI Driver"

--- a/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
+++ b/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
@@ -41,14 +41,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: eks.amazonaws.com/compute-type
-                operator: NotIn
-                values:
-                - fargate
+        {{-  toYaml .Values.node.affinity | nindent 8 }}
       hostNetwork: true
       dnsPolicy: {{ .Values.node.dnsPolicy }}
       {{- with .Values.node.dnsConfig }}

--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -122,6 +122,16 @@ node:
     ## Enable if EKS IAM for SA is used
     #  eks.amazonaws.com/role-arn: arn:aws:iam::111122223333:role/efs-csi-role
   healthPort: 9809
+  # Default affinity - don't run on Fargate nodes
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: eks.amazonaws.com/compute-type
+            operator: NotIn
+            values:
+            - fargate
 
 storageClasses: []
 # Add StorageClass resources like:


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
New feature

**What is this PR about? / Why do we need it?**
Add possiblity to control daemonset's affinity. 
In my setup I don't need EFS support on control-plane nodes so I would like to modify affinity. 

**What testing is done?** 
I run `helm template` of the helm chart. It was identical with original one. 
 