### PR TITLE
Disable running the efs-util mount watchdog in the control plane

### DIFF
--- a/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
+++ b/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
@@ -52,6 +52,7 @@ spec:
             - --tags={{ include "aws-efs-csi-driver.tags" .Values.controller.tags }}
             {{- end }}
             - --v={{ .Values.controller.logLevel }}
+            - --disable-efs-mount-watchdog={{ hasKey .Values.controller "disableEFSMountWatchdog" | ternary .Values.controller.disableEFSMountWatchdog false }}
             - --delete-access-point-root-dir={{ hasKey .Values.controller "deleteAccessPointRootDir" | ternary .Values.controller.deleteAccessPointRootDir false }}
             - --vol-metrics-opt-in={{ hasKey .Values.controller "volMetricsOptIn" | ternary .Values.controller.volMetricsOptIn false }}
           env:

--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -54,6 +54,7 @@ controller:
   # path on efs when deleteing an access point
   deleteAccessPointRootDir: false
   volMetricsOptIn: false
+  disableEFSMountWatchdog: true
   podAnnotations: {}
   resources:
     {}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -39,6 +39,7 @@ func main() {
 		volMetricsOptIn          = flag.Bool("vol-metrics-opt-in", false, "Opt in to emit volume metrics")
 		volMetricsRefreshPeriod  = flag.Float64("vol-metrics-refresh-period", 240, "Refresh period for volume metrics in minutes")
 		volMetricsFsRateLimit    = flag.Int("vol-metrics-fs-rate-limit", 5, "Volume metrics routines rate limiter per file system")
+		disableEFSMountWatchdog  = flag.Bool("disable-efs-mount-watchdog", false, "Set to true to skip running efs-utils mount watchdog")
 		deleteAccessPointRootDir = flag.Bool("delete-access-point-root-dir", false,
 			"Opt in to delete access point root directory by DeleteVolume. By default, DeleteVolume will delete the access point behind Persistent Volume and deleting access point will not delete the access point root directory or its contents.")
 		tags = flag.String("tags", "", "Space separated key:value pairs which will be added as tags for EFS resources. For example, 'environment:prod region:us-east-1'")
@@ -60,7 +61,7 @@ func main() {
 	if err != nil {
 		klog.Fatalln(err)
 	}
-	drv := driver.NewDriver(*endpoint, etcAmazonEfs, *efsUtilsStaticFilesPath, *tags, *volMetricsOptIn, *volMetricsRefreshPeriod, *volMetricsFsRateLimit, *deleteAccessPointRootDir)
+	drv := driver.NewDriver(*endpoint, etcAmazonEfs, *efsUtilsStaticFilesPath, *tags, *volMetricsOptIn, *volMetricsRefreshPeriod, *volMetricsFsRateLimit, *deleteAccessPointRootDir, *disableEFSMountWatchdog)
 	if err := drv.Run(); err != nil {
 		klog.Fatalln(err)
 	}

--- a/deploy/kubernetes/base/controller-deployment.yaml
+++ b/deploy/kubernetes/base/controller-deployment.yaml
@@ -35,6 +35,7 @@ spec:
             - --endpoint=$(CSI_ENDPOINT)
             - --logtostderr
             - --v=2
+            - --disable-efs-mount-watchdog=true
             - --delete-access-point-root-dir=false
             - --vol-metrics-opt-in=false
           env:

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -50,14 +50,14 @@ type Driver struct {
 	tags                     map[string]string
 }
 
-func NewDriver(endpoint, efsUtilsCfgPath, efsUtilsStaticFilesPath, tags string, volMetricsOptIn bool, volMetricsRefreshPeriod float64, volMetricsFsRateLimit int, deleteAccessPointRootDir bool) *Driver {
+func NewDriver(endpoint, efsUtilsCfgPath, efsUtilsStaticFilesPath, tags string, volMetricsOptIn bool, volMetricsRefreshPeriod float64, volMetricsFsRateLimit int, deleteAccessPointRootDir bool, disableEFSMountWatchdog bool) *Driver {
 	cloud, err := cloud.NewCloud()
 	if err != nil {
 		klog.Fatalln(err)
 	}
 
 	nodeCaps := SetNodeCapOptInFeatures(volMetricsOptIn)
-	watchdog := newExecWatchdog(efsUtilsCfgPath, efsUtilsStaticFilesPath, "amazon-efs-mount-watchdog")
+	watchdog := newExecWatchdog(disableEFSMountWatchdog, efsUtilsCfgPath, efsUtilsStaticFilesPath, "amazon-efs-mount-watchdog")
 	return &Driver{
 		endpoint:                 endpoint,
 		nodeID:                   cloud.GetMetadata().GetInstanceID(),

--- a/pkg/driver/efs_watch_dog.go
+++ b/pkg/driver/efs_watch_dog.go
@@ -135,6 +135,8 @@ type Watchdog interface {
 // execWatchdog is a watch dog that monitors a process and restart it
 // if it has crashed accidentally
 type execWatchdog struct {
+	// if set to true, the efs-mount-watchdog will be disabled
+	disableEFSMountWatchdog bool
 	// the command to be exec and monitored
 	execCmd string
 	// the command arguments
@@ -156,8 +158,9 @@ type efsUtilsConfig struct {
 	Region          string
 }
 
-func newExecWatchdog(efsUtilsCfgPath, efsUtilsStaticFilesPath, cmd string, arg ...string) Watchdog {
+func newExecWatchdog(disableEFSMountWatchdog bool, efsUtilsCfgPath, efsUtilsStaticFilesPath, cmd string, arg ...string) Watchdog {
 	return &execWatchdog{
+		disableEFSMountWatchdog: disableEFSMountWatchdog,
 		efsUtilsCfgPath:         efsUtilsCfgPath,
 		efsUtilsStaticFilesPath: efsUtilsStaticFilesPath,
 		execCmd:                 cmd,
@@ -169,6 +172,10 @@ func newExecWatchdog(efsUtilsCfgPath, efsUtilsStaticFilesPath, cmd string, arg .
 func (w *execWatchdog) start() error {
 	if err := w.setup(GetVersion().EfsClientSource); err != nil {
 		return err
+	}
+
+	if w.disableEFSMountWatchdog {
+		return nil
 	}
 
 	go w.runLoop(w.stopCh)

--- a/pkg/driver/efs_watch_dog_test.go
+++ b/pkg/driver/efs_watch_dog_test.go
@@ -118,7 +118,7 @@ func TestExecWatchdog(t *testing.T) {
 	defer os.RemoveAll(configDirName)
 	defer os.RemoveAll(staticFileDirName)
 
-	w := newExecWatchdog(configDirName, staticFileDirName, "sleep", "300")
+	w := newExecWatchdog(false, configDirName, staticFileDirName, "sleep", "300")
 	if err := w.start(); err != nil {
 		t.Fatalf("Failed to start %v", err)
 	}
@@ -159,7 +159,7 @@ func TestSetupWithEmptyConfigDirectory(t *testing.T) {
 	fileBContent := "dummyB"
 	createFile(t, staticFileDirName, fileBName, fileBContent)
 
-	w := newExecWatchdog(configDirName, staticFileDirName, "sleep", "300").(*execWatchdog)
+	w := newExecWatchdog(false, configDirName, staticFileDirName, "sleep", "300").(*execWatchdog)
 	efsClient := "k8s"
 	configFilePath := filepath.Join(configDirName, configFileName)
 	if err := w.setup(efsClient); err != nil {
@@ -192,7 +192,7 @@ func TestSetupWithNonEmptyConfigDirectory(t *testing.T) {
 	differentContent := "differentDummy"
 	createFile(t, configDirName, fileBName, differentContent)
 
-	w := newExecWatchdog(configDirName, staticFileDirName, "sleep", "300").(*execWatchdog)
+	w := newExecWatchdog(false, configDirName, staticFileDirName, "sleep", "300").(*execWatchdog)
 	efsClient := "k8s"
 	configFilePath := filepath.Join(configDirName, configFileName)
 	if err := w.setup(efsClient); err != nil {
@@ -210,7 +210,7 @@ func TestSetupWithNonexistentConfigDirectory(t *testing.T) {
 	configDirName := ""
 	staticFileDirName := createTempDir(t)
 	defer os.RemoveAll(staticFileDirName)
-	w := newExecWatchdog(configDirName, staticFileDirName, "sleep", "300").(*execWatchdog)
+	w := newExecWatchdog(false, configDirName, staticFileDirName, "sleep", "300").(*execWatchdog)
 	efsClient := "k8s"
 	if err := w.setup(efsClient); err == nil {
 		t.Fatalf("Expected failure since static files directory doesn't exist.")
@@ -221,7 +221,7 @@ func TestSetupWithNonexistentStaticFilesDirectory(t *testing.T) {
 	configDirName := createTempDir(t)
 	defer os.RemoveAll(configDirName)
 	staticFileDirName := ""
-	w := newExecWatchdog(configDirName, staticFileDirName, "sleep", "300").(*execWatchdog)
+	w := newExecWatchdog(false, configDirName, staticFileDirName, "sleep", "300").(*execWatchdog)
 	efsClient := "k8s"
 	if err := w.setup(efsClient); err == nil {
 		t.Fatalf("Expected failure since config directory doesn't exist.")
@@ -238,7 +238,7 @@ func TestSetupWithAdditionalDirectoryInStaticFilesDirectory(t *testing.T) {
 	_, err := ioutil.TempDir(staticFileDirName, "")
 	checkError(t, err)
 
-	w := newExecWatchdog(configDirName, staticFileDirName, "sleep", "300").(*execWatchdog)
+	w := newExecWatchdog(false, configDirName, staticFileDirName, "sleep", "300").(*execWatchdog)
 	efsClient := "k8s"
 	if err := w.setup(efsClient); err == nil {
 		t.Fatalf("Expected failure since config directory contains another directory.")


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
/feature

**What is this PR about? / Why do we need it?**
Fixes https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/830
