### PR TITLE
Add standard labels to all resources

### DIFF
--- a/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
+++ b/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
@@ -5,7 +5,7 @@ apiVersion: apps/v1
 metadata:
   name: efs-csi-controller
   labels:
-    app.kubernetes.io/name: {{ include "aws-efs-csi-driver.name" . }}
+    {{- include "aws-efs-csi-driver.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/charts/aws-efs-csi-driver/templates/controller-serviceaccount.yaml
+++ b/charts/aws-efs-csi-driver/templates/controller-serviceaccount.yaml
@@ -4,7 +4,7 @@ kind: ServiceAccount
 metadata:
   name: {{ .Values.controller.serviceAccount.name }}
   labels:
-    app.kubernetes.io/name: {{ include "aws-efs-csi-driver.name" . }}
+    {{- include "aws-efs-csi-driver.labels" . | nindent 4 }}
   {{- with .Values.controller.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/aws-efs-csi-driver/templates/csidriver.yaml
+++ b/charts/aws-efs-csi-driver/templates/csidriver.yaml
@@ -2,6 +2,8 @@ apiVersion: {{ ternary "storage.k8s.io/v1" "storage.k8s.io/v1beta1" (semverCompa
 kind: CSIDriver
 metadata:
   name: efs.csi.aws.com
+  labels:
+    {{- include "aws-efs-csi-driver.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": pre-install, pre-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
+++ b/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 metadata:
   name: efs-csi-node
   labels:
-    app.kubernetes.io/name: {{ include "aws-efs-csi-driver.name" . }}
+    {{- include "aws-efs-csi-driver.labels" . | nindent 4 }}
 spec:
   selector:
     matchLabels:

--- a/charts/aws-efs-csi-driver/templates/node-serviceaccount.yaml
+++ b/charts/aws-efs-csi-driver/templates/node-serviceaccount.yaml
@@ -4,7 +4,7 @@ kind: ServiceAccount
 metadata:
   name: {{ .Values.node.serviceAccount.name }}
   labels:
-    app.kubernetes.io/name: {{ include "aws-efs-csi-driver.name" . }}
+    {{- include "aws-efs-csi-driver.labels" . | nindent 4 }}
   {{- with .Values.node.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/aws-efs-csi-driver/templates/storageclass.yaml
+++ b/charts/aws-efs-csi-driver/templates/storageclass.yaml
@@ -3,6 +3,10 @@ kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
   name: {{ .name }}
+  {{- with .labels }}
+  labels:
+  {{ toYaml . | indent 4 }}
+  {{- end }}
   {{- with .annotations }}
   annotations:
   {{ toYaml . | indent 4 }}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
It's a new feature fixing missing labels

**What is this PR about? / Why do we need it?**

Running helm against the current master branch, the following labels would be added to all resources defined by the chart:

```
helm.sh/chart: aws-efs-csi-driver-2.3.5
app.kubernetes.io/instance: aws-efs-csi-driver
app.kubernetes.io/version: "1.4.8"
app.kubernetes.io/managed-by: Helm
```

**What testing is done?** 

```
helm template aws-efs-csi-driver --namespace management ../../opensource/aws-efs-csi-driver/charts/aws-efs-csi-driver --output-dir base --values values.yaml
```

and validating that the change adds the desired labels