### PR TITLE
This PR adds a check to see if the "allocated gid" is the default Go …

### DIFF
--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -242,7 +242,9 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 
 	accessPointId, err := localCloud.CreateAccessPoint(ctx, volName, accessPointsOptions)
 	if err != nil {
-		d.gidAllocator.releaseGid(accessPointsOptions.FileSystemId, gid)
+		if allocatedGid != 0 {
+			d.gidAllocator.releaseGid(accessPointsOptions.FileSystemId, gid)
+		}
 		if err == cloud.ErrAccessDenied {
 			return nil, status.Errorf(codes.Unauthenticated, "Access Denied. Please ensure you have the right AWS permissions: %v", err)
 		}


### PR DESCRIPTION
…int value, and skips attempting to deallocate it if is so.

**Is this a bug fix or adding new feature?**
Bug fix

**What is this PR about? / Why do we need it?**
This PR adds a check to see if the "allocated gid" is the default Go int value, and skips attempting to deallocate it if is so.
if condition is added when allocated not equal to zero which is solving the null-pointer exception.

**What testing is done?** 
Before the code change which is causing the driver to crash
```

Name:                 efs-csi-controller-7f4f4458c-4zzfh
Namespace:            kube-system
Priority:             2000000000
Priority Class Name:  system-cluster-critical
Node:                 ip-192-168-45-229.ec2.internal/192.168.45.229
Start Time:           Wed, 07 Dec 2022 16:46:33 +0000
Labels:               app=efs-csi-controller
                      app.kubernetes.io/instance=kustomize
                      app.kubernetes.io/name=aws-efs-csi-driver
                      pod-template-hash=7f4f4458c
Annotations:          kubernetes.io/psp: eks.privileged
Status:               Running
IP:                   192.168.57.221
IPs:
  IP:           192.168.57.221
Controlled By:  ReplicaSet/efs-csi-controller-7f4f4458c
Containers:
  efs-plugin:
    Container ID:  docker://16199fa7784b054383b630f153a52fb1c4263492b6fbefe662d6704d3ae88f2a
    Image:         *************.dkr.ecr.us-east-1.amazonaws.com/aws-efs-csi-driver:NRT10
    Port:          9909/TCP
    Host Port:     0/TCP
    Args:
      --endpoint=$(CSI_ENDPOINT)
      --logtostderr
      --v=6
      --delete-access-point-root-dir=false
      --vol-metrics-opt-in=false
    State:          Waiting
      Reason:       CrashLoopBackOff
    Last State:     Terminated
      Reason:       Error
      Exit Code:    2
      Started:      Wed, 07 Dec 2022 16:47:37 +0000
      Finished:     Wed, 07 Dec 2022 16:48:13 +0000
    Ready:          False
    Restart Count:  2
    Liveness:       http-get http://:healthz/healthz delay=10s timeout=3s period=10s #success=1 #failure=5
    Environment:
      CSI_ENDPOINT:                 unix:///var/lib/csi/sockets/pluginproxy/csi.sock
      CSI_NODE_NAME:                 (v1:spec.nodeName)
      AWS_STS_REGIONAL_ENDPOINTS:   regional
      AWS_DEFAULT_REGION:           us-east-1
      AWS_REGION:                   us-east-1
```

After the code change we got the *Error while CreateAccessPoint : Access denied* which is valid error and even the driver looks fine.
```
kubectl logs efs-csi-controller-b4db8c9b6-vbvwl -n kube-system
Defaulted container "efs-plugin" out of: efs-plugin, csi-provisioner, liveness-probe
I1207 16:53:10.117202       1 config_dir.go:63] Mounted directories do not exist, creating directory at '/etc/amazon/efs'
I1207 16:53:10.118187       1 metadata.go:63] getting MetadataService...
I1207 16:53:10.120542       1 metadata.go:68] retrieving metadata from EC2 metadata service
I1207 16:53:10.121145       1 cloud.go:137] EFS Client created using the following endpoint: https://elasticfilesystem.us-east-1.amazonaws.com
I1207 16:53:10.121157       1 driver.go:84] Node Service capability for Get Volume Stats Not enabled
I1207 16:53:10.122296       1 driver.go:140] Did not find any input tags.
I1207 16:53:10.122445       1 driver.go:113] Registering Node Server
I1207 16:53:10.122456       1 driver.go:115] Registering Controller Server
I1207 16:53:10.122465       1 driver.go:118] Starting efs-utils watchdog
I1207 16:53:10.122530       1 efs_watch_dog.go:216] Copying /etc/amazon/efs/efs-utils.conf since it doesn't exist
I1207 16:53:10.122592       1 efs_watch_dog.go:216] Copying /etc/amazon/efs/efs-utils.crt since it doesn't exist
I1207 16:53:10.123627       1 driver.go:124] Starting reaper
I1207 16:53:10.123646       1 driver.go:127] Listening for connections on address: &net.UnixAddr{Name:"/var/lib/csi/sockets/pluginproxy/csi.sock", Net:"unix"}
I1207 16:53:10.211269       1 identity.go:37] GetPluginCapabilities: called with args {XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}
I1207 16:53:10.211801       1 controller.go:418] ControllerGetCapabilities: called with args {XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}
I1207 16:53:30.077030       1 controller.go:61] CreateVolume: called with args {Name:pvc-424ab27e-64a3-4046-bd05-6dc749e72a5e CapacityRange:required_bytes:5368709120  VolumeCapabilities:[mount:<> access_mode:<mode:MULTI_NODE_MULTI_WRITER > ] Parameters:map[basePath:/dynamic_provisioning csi.storage.k8s.io/pv/name:pvc-424ab27e-64a3-4046-bd05-6dc749e72a5e csi.storage.k8s.io/pvc/name:efs-claim csi.storage.k8s.io/pvc/namespace:default directoryPerms:700 fileSystemId:fs-01355e6f5147e6e17 gid:33 provisioningMode:efs-ap uid:33] Secrets:map[] VolumeContentSource:<nil> AccessibilityRequirements:<nil> XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}
I1207 16:53:30.077102       1 cloud.go:238] Calling DescribeFileSystems with input: {
  FileSystemId: "************
}
I1207 16:53:30.340100       1 cloud.go:177] Calling Create AP with input: {
  ClientToken: "pvc-424ab27e-64a3-4046-bd05-6dc749e72a5e",
  FileSystemId: "**************",
  PosixUser: {
    Gid: 33,
    Uid: 33
  },
  RootDirectory: {
    CreationInfo: {
      OwnerGid: 33,
      OwnerUid: 33,
      Permissions: "700"
    },
    Path: "/dynamic_provisioning/pvc-424ab27e-64a3-4046-bd05-6dc749e72a5e"
  },
  Tags: [{
      Key: "efs.csi.aws.com/cluster",
      Value: "true"
    }]
}
I1207 16:53:30.374487       1 controller.go:248] Error while CreateAccessPoint : Access denied
E1207 16:53:30.374505       1 driver.go:103] GRPC error: rpc error: code = Unauthenticated desc = Access Denied. Please ensure you have the right AWS permissions: Access denied
I1207 16:53:31.375417       1 controller.go:61] CreateVolume: called with args {Name:pvc-424ab27e-64a3-4046-bd05-6dc749e72a5e CapacityRange:required_bytes:5368709120  VolumeCapabilities:[mount:<> access_mode:<mode:MULTI_NODE_MULTI_WRITER > ] Parameters:map[basePath:/dynamic_provisioning csi.storage.k8s.io/pv/name:pvc-424ab27e-64a3-4046-bd05-6dc749e72a5e csi.storage.k8s.io/pvc/name:efs-claim csi.storage.k8s.io/pvc/namespace:default directoryPerms:700 fileSystemId:*********** gid:33 provisioningMode:efs-ap uid:33] Secrets:map[] VolumeContentSource:<nil> AccessibilityRequirements:<nil> XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}
I1207 16:53:31.375481       1 cloud.go:238] Calling DescribeFileSystems with input: {
  FileSystemId: "**************"
```

