### PR TITLE
feat: add node.volMetricsOptIn for emitting volume metrics

### DIFF
--- a/charts/aws-efs-csi-driver/CHANGELOG.md
+++ b/charts/aws-efs-csi-driver/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Helm chart
+# v2.3.7
+* Add node.volMetricsOptIn for emitting volume metrics
+* Remove controller.volMetricsOptIn as its the wrong place
 # v2.3.6
 * Bump app/driver version to `v1.4.9`
 # v2.3.5

--- a/charts/aws-efs-csi-driver/Chart.yaml
+++ b/charts/aws-efs-csi-driver/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: aws-efs-csi-driver
-version: 2.3.6
+version: 2.3.7
 appVersion: 1.4.9
 kubeVersion: ">=1.17.0-0"
 description: "A Helm chart for AWS EFS CSI Driver"

--- a/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
+++ b/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
@@ -53,7 +53,6 @@ spec:
             {{- end }}
             - --v={{ .Values.controller.logLevel }}
             - --delete-access-point-root-dir={{ hasKey .Values.controller "deleteAccessPointRootDir" | ternary .Values.controller.deleteAccessPointRootDir false }}
-            - --vol-metrics-opt-in={{ hasKey .Values.controller "volMetricsOptIn" | ternary .Values.controller.volMetricsOptIn false }}
           env:
             - name: CSI_ENDPOINT
               value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock

--- a/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
+++ b/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
@@ -69,6 +69,7 @@ spec:
             - --endpoint=$(CSI_ENDPOINT)
             - --logtostderr
             - --v={{ .Values.node.logLevel }}
+            - --vol-metrics-opt-in={{ hasKey .Values.node "volMetricsOptIn" | ternary .Values.node.volMetricsOptIn false }}
           env:
             - name: CSI_ENDPOINT
               value: unix:/csi/csi.sock

--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -53,7 +53,6 @@ controller:
   # Enable if you want the controller to also delete the
   # path on efs when deleteing an access point
   deleteAccessPointRootDir: false
-  volMetricsOptIn: false
   podAnnotations: {}
   resources:
     {}
@@ -102,6 +101,7 @@ node:
     # dnsConfig:
     #   nameservers:
     #     - 169.254.169.253
+  volMetricsOptIn: false
   podAnnotations: {}
   resources:
     {}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Fixes #698 and removes wrongly introduced controller values in #560

**What is this PR about? / Why do we need it?**
It introduces the possibility to opt-in for kubelet volume metrics when using the helm chart.

**What testing is done?** 
Tested it manually in our AWS EKS clusters.
