### PR TITLE
Updated the delete-access-point-root-dir argument in README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -161,8 +161,12 @@ helm upgrade --install aws-efs-csi-driver --namespace kube-system aws-efs-csi-dr
 | vol-metrics-opt-in          |        | false   | true     | Opt in to emit volume metrics.                                                                                                                                                                                                          |
 | vol-metrics-refresh-period  |        | 240     | true     | Refresh period for volume metrics in minutes.                                                                                                                                                                                           |
 | vol-metrics-fs-rate-limit   |        | 5       | true     | Volume metrics routines rate limiter per file system.                                                                                                                                                                                   |
- | delete-access-point-root-dir|        | false  | true     | Opt in to delete access point root directory by DeleteVolume. By default, DeleteVolume will delete the access point behind Persistent Volume and deleting access point will not delete the access point root directory or its contents. |
 | tags                         |       |         | true     | Space separated key:value pairs which will be added as tags for EFS resources. For example, '--tags=name:efs-tag-test date:Jan24'                                                                                                       |
+
+### Container Arguments for deployment(controller) 
+| Parameters                  | Values | Default | Optional | Description                                                                                                                                                                                                                            |
+|-----------------------------|--------|---------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| delete-access-point-root-dir|        | false  | true     | Opt in to delete access point root directory by DeleteVolume. By default, DeleteVolume will delete the access point behind Persistent Volume and deleting access point will not delete the access point root directory or its contents. |
 ### Upgrading the EFS CSI Driver
 
 


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

**What is this PR about? / Why do we need it?**
In the README `delete-access-point-root-dir` was wrongly given to specify under daemonset options rather than deployment. This PR has a change, a seperate table for deployment where the `delete-access-point-root-dir` is listed under it.

**What testing is done?** 
