### PR TITLE
Helm charts prefix image names with containerRegistry

### DIFF
--- a/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
+++ b/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
@@ -47,7 +47,7 @@ spec:
         - name: efs-plugin
           securityContext:
             privileged: true
-          image: {{ printf "%s:%s" .Values.image.repository (default (printf "v%s" .Chart.AppVersion) (toString .Values.image.tag)) }}
+          image: {{ printf "%s%s:%s" (default "" .Values.image.containerRegistry) .Values.image.repository (default (printf "v%s" .Chart.AppVersion) (.Values.image.tag | toString)) }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - --endpoint=$(CSI_ENDPOINT)
@@ -92,7 +92,7 @@ spec:
           resources: {{ toYaml . | nindent 12 }}
           {{- end }}
         - name: csi-provisioner
-          image: {{ printf "%s:%s" .Values.sidecars.csiProvisioner.image.repository .Values.sidecars.csiProvisioner.image.tag }}
+          image: {{ printf "%s%s:%s" (default "" .Values.image.containerRegistry) .Values.sidecars.csiProvisioner.image.repository .Values.sidecars.csiProvisioner.image.tag }}
           imagePullPolicy: {{ .Values.sidecars.csiProvisioner.image.pullPolicy }}
           args:
             - --csi-address=$(ADDRESS)
@@ -112,7 +112,7 @@ spec:
           resources: {{ toYaml . | nindent 12 }}
           {{- end }}
         - name: liveness-probe
-          image: {{ printf "%s:%s" .Values.sidecars.livenessProbe.image.repository .Values.sidecars.livenessProbe.image.tag }}
+          image: {{ printf "%s%s:%s" (default "" .Values.image.containerRegistry) .Values.sidecars.livenessProbe.image.repository .Values.sidecars.livenessProbe.image.tag }}
           imagePullPolicy: {{ .Values.sidecars.livenessProbe.image.pullPolicy }}
           args:
             - --csi-address=/csi/csi.sock

--- a/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
+++ b/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
@@ -67,7 +67,7 @@ spec:
         - name: efs-plugin
           securityContext:
             privileged: true
-          image: {{ printf "%s:%s" .Values.image.repository (default (printf "v%s" .Chart.AppVersion) (toString .Values.image.tag)) }}
+          image: {{ printf "%s%s:%s" (default "" .Values.image.containerRegistry) .Values.image.repository (default (printf "v%s" .Chart.AppVersion) (.Values.image.tag | toString)) }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - --endpoint=$(CSI_ENDPOINT)
@@ -108,7 +108,7 @@ spec:
           resources: {{ toYaml . | nindent 12 }}
           {{- end }}
         - name: csi-driver-registrar
-          image: {{ printf "%s:%s" .Values.sidecars.nodeDriverRegistrar.image.repository .Values.sidecars.nodeDriverRegistrar.image.tag }}
+          image: {{ printf "%s%s:%s" (default "" .Values.image.containerRegistry) .Values.sidecars.nodeDriverRegistrar.image.repository .Values.sidecars.nodeDriverRegistrar.image.tag }}
           imagePullPolicy: {{ .Values.sidecars.nodeDriverRegistrar.image.pullPolicy }}
           args:
             - --csi-address=$(ADDRESS)
@@ -132,7 +132,7 @@ spec:
           resources: {{ toYaml . | nindent 12 }}
           {{- end }}
         - name: liveness-probe
-          image: {{ printf "%s:%s" .Values.sidecars.livenessProbe.image.repository .Values.sidecars.livenessProbe.image.tag }}
+          image: {{ printf "%s%s:%s" (default "" .Values.image.containerRegistry) .Values.sidecars.livenessProbe.image.repository .Values.sidecars.livenessProbe.image.tag }}
           imagePullPolicy: {{ .Values.sidecars.livenessProbe.image.pullPolicy }}
           args:
             - --csi-address=/csi/csi.sock

--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -10,26 +10,28 @@ replicaCount: 2
 useFIPS: false
 
 image:
-  repository: amazon/aws-efs-csi-driver
+  repository: /efs-csi-driver/amazon/aws-efs-csi-driver
+  # Container registry to be used, will prefix all repositories (including sidecars)
+  containerRegistry: public.ecr.aws
   tag: "v1.5.4"
   pullPolicy: IfNotPresent
 
 sidecars:
   livenessProbe:
     image:
-      repository: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe
+      repository: /eks-distro/kubernetes-csi/livenessprobe
       tag: v2.8.0-eks-1-25-latest
       pullPolicy: IfNotPresent
     resources: {}
   nodeDriverRegistrar:
     image:
-      repository: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar
+      repository: /eks-distro/kubernetes-csi/node-driver-registrar
       tag: v2.6.2-eks-1-25-latest
       pullPolicy: IfNotPresent
     resources: {}
   csiProvisioner:
     image:
-      repository: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner
+      repository: /eks-distro/kubernetes-csi/external-provisioner
       tag: v3.3.0-eks-1-25-latest
       pullPolicy: IfNotPresent
     resources: {}


### PR DESCRIPTION
Added .values.containerRegistry to the values.yaml file, and prefixed all our images with the container registry.  Also modifed the csi driver image to pull from the aws public ecr instead of dockerhub.

This will require updating the helm installation documentation here as well: https://docs.aws.amazon.com/eks/latest/userguide/efs-csi.html. 

**Is this a bug fix or adding new feature?**
New feature

**What is this PR about? / Why do we need it?**
We need to be able to prefix all the images (sidecars + csi driver image )when using private ECR registries.

**What testing is done?** 
Deployed the helm chart without configuring any of the default values in values.yaml and made sure images pulled successfully.