### PR TITLE
Move python packages to location on sys.path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -88,7 +88,7 @@ RUN mv /newroot/etc/amazon/efs /newroot/etc/amazon/efs-static-files
 FROM public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-python:3.9.14-al2 AS linux-amazon
 
 COPY --from=rpm-installer /newroot /
-COPY --from=rpm-provider /root/.local/lib/python3.9/site-packages/ /usr/local/lib/python3.9/site-packages/
+COPY --from=rpm-provider /root/.local/lib/python3.9/site-packages/ /usr/lib/python3.9/site-packages/
 
 COPY --from=go-builder /go/src/github.com/kubernetes-sigs/aws-efs-csi-driver/bin/aws-efs-csi-driver /bin/aws-efs-csi-driver
 COPY THIRD-PARTY /


### PR DESCRIPTION
/usr/local/lib/python3.9/site-packages/ was not on the python3 path. Thus, botocore wasn't getting picked up.  I've confirmed that /usr/local/python3.9/site-packages is on the path.

**Is this a bug fix or adding new feature?**

**What is this PR about? / Why do we need it?**

**What testing is done?** 
