### PR TITLE
Removing the hostNetwork from chart

### DIFF
--- a/charts/aws-efs-csi-driver/Chart.yaml
+++ b/charts/aws-efs-csi-driver/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: aws-efs-csi-driver
 version: 2.4.1
-appVersion: 1.5.4
+appVersion: 1.5.6
 kubeVersion: ">=1.17.0-0"
 description: "A Helm chart for AWS EFS CSI Driver"
 home: https://github.com/kubernetes-sigs/aws-efs-csi-driver

--- a/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
+++ b/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
@@ -53,7 +53,6 @@ spec:
                 operator: NotIn
                 values:
                 - fargate
-      hostNetwork: true
       dnsPolicy: {{ .Values.node.dnsPolicy }}
       {{- with .Values.node.dnsConfig }}
       dnsConfig: {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Fixes #962 
**What is this PR about? / Why do we need it?**
As described in issue #962 the hostNetwork is still enabled in the DaemonSet
**What testing is done?** 
Running on EKS cluster successfully
