### PR TITLE
Add ability to configure daemonset affinity

### DIFF
--- a/charts/aws-efs-csi-driver/CHANGELOG.md
+++ b/charts/aws-efs-csi-driver/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Helm chart
-# V2.4.2
+# v2.4.3
+* Add ability to configure daemonset affinity
+# v2.4.2
 * Bump app/driver version to `v1.5.5` 
 # v2.4.1
 * Bump app/driver version to `v1.5.4`

--- a/charts/aws-efs-csi-driver/Chart.yaml
+++ b/charts/aws-efs-csi-driver/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: aws-efs-csi-driver
-version: 2.4.2
+version: 2.4.3
 appVersion: 1.5.5
 kubeVersion: ">=1.17.0-0"
 description: "A Helm chart for AWS EFS CSI Driver"

--- a/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
+++ b/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
@@ -44,15 +44,9 @@ spec:
         {{- with .Values.node.nodeSelector }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: eks.amazonaws.com/compute-type
-                operator: NotIn
-                values:
-                - fargate
+      {{- with .Values.node.affinity }}
+      affinity: {{- toYaml . | nindent 8 }}
+      {{- end }}
       hostNetwork: true
       dnsPolicy: {{ .Values.node.dnsPolicy }}
       {{- with .Values.node.dnsConfig }}

--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -119,6 +119,15 @@ node:
     # type: OnDelete
   tolerations:
     - operator: Exists
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: eks.amazonaws.com/compute-type
+                operator: NotIn
+                values:
+                  - fargate
   # Specifies whether a service account should be created
   serviceAccount:
     create: true


### PR DESCRIPTION
Signed-off-by: smcavallo <smcavallo@hotmail.com>

**Is this a bug fix or adding new feature?**
n/a

**What is this PR about? / Why do we need it?**
End users may not want the daemonset running on all nodes.  This PR exposes the daemonset affinity so it can be configurable via helm.

**What testing is done?** 
Before:
`helm template --values=values.yaml . > before.yaml`
After:
`helm template --values=values.yaml . > after.yaml`
Compare:
`diff before.yaml after.yaml`

