### PR TITLE
Add fsType "efs" in storageclass.yaml example

### DIFF
--- a/examples/kubernetes/dynamic_provisioning/specs/storageclass.yaml
+++ b/examples/kubernetes/dynamic_provisioning/specs/storageclass.yaml
@@ -6,6 +6,7 @@ provisioner: efs.csi.aws.com
 parameters:
   provisioningMode: efs-ap
   fileSystemId: fs-92107410
+  fsType: efs
   directoryPerms: "700"
   gidRangeStart: "1000" # optional
   gidRangeEnd: "2000" # optional


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

Bug. Fix #125 

**What is this PR about? / Why do we need it?**

`fsType` is required for kubelet to apply fsGroup. Unless, kubelet failed to change ownership.

**What testing is done?** 

I manually confirmed that POD with fsGroup is correctly applied when storage class has the parameter.
