### PR TITLE
Add envFrom to controller spec for adding ConfigMaps

### DIFF
--- a/charts/aws-efs-csi-driver/CHANGELOG.md
+++ b/charts/aws-efs-csi-driver/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Helm chart
+# v2.4.2
+* Bump app/driver version to `v1.5.5`
 # v2.4.1
 * Bump app/driver version to `v1.5.4`
 # v2.4.0

--- a/charts/aws-efs-csi-driver/Chart.yaml
+++ b/charts/aws-efs-csi-driver/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: aws-efs-csi-driver
-version: 2.4.1
-appVersion: 1.5.4
+version: 2.4.2
+appVersion: 1.5.5
 kubeVersion: ">=1.17.0-0"
 description: "A Helm chart for AWS EFS CSI Driver"
 home: https://github.com/kubernetes-sigs/aws-efs-csi-driver

--- a/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
+++ b/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
@@ -73,6 +73,10 @@ spec:
             - name: AWS_USE_FIPS_ENDPOINT
               value: "true"
             {{- end }}
+          {{- with .Values.controller.envFrom }}
+          envFrom:
+            {{- . | toYaml | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/

--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -80,6 +80,8 @@ controller:
     #  eks.amazonaws.com/role-arn: arn:aws:iam::111122223333:role/efs-csi-role
   healthPort: 9909
   regionalStsEndpoints: false
+  envFrom: []
+
 ## Node daemonset variables
 
 node:


### PR DESCRIPTION
update versions

**Is this a bug fix or adding new feature?**  
New feature

**What is this PR about? / Why do we need it?**
Adding the `envFrom` property provides a simple way to reference configMaps across multiple resources. This is especially helpful for environments that must route traffic through a http proxy.

**What testing is done?** 
Deployed the AWS EFS CSI driver using Helm with these changes made to the templates and referencing a configMap with values for http/s_proxy and no_proxy.
