### PR TITLE
Remove SSH from CI && bump K8S_VERSION for test cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ test-e2e:
 .PHONY: test-e2e-external-eks
 test-e2e-external-eks:
 	CLUSTER_TYPE=eksctl \
-	K8S_VERSION="1.20" \
+	K8S_VERSION="1.22" \
 	DRIVER_NAME=aws-efs-csi-driver \
 	HELM_VALUES_FILE="./hack/values_eksctl.yaml" \
 	CONTAINER_NAME=efs-plugin \

--- a/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
+++ b/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
@@ -27,6 +27,7 @@ spec:
       annotations: {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      hostNetwork: true
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- range .Values.imagePullSecrets }}

--- a/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
+++ b/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
@@ -76,6 +76,10 @@ spec:
           env:
             - name: CSI_ENDPOINT
               value: unix:/csi/csi.sock
+            - name: CSI_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
             {{- if .Values.useFIPS }}
             - name: AWS_USE_FIPS_ENDPOINT
               value: "true"

--- a/deploy/kubernetes/base/controller-deployment.yaml
+++ b/deploy/kubernetes/base/controller-deployment.yaml
@@ -21,6 +21,7 @@ spec:
         app.kubernetes.io/name: aws-efs-csi-driver
         app.kubernetes.io/instance: kustomize
     spec:
+      hostNetwork: true
       nodeSelector:
         kubernetes.io/os: linux
       serviceAccountName: efs-csi-controller-sa

--- a/deploy/kubernetes/base/node-daemonset.yaml
+++ b/deploy/kubernetes/base/node-daemonset.yaml
@@ -53,6 +53,10 @@ spec:
           env:
             - name: CSI_ENDPOINT
               value: unix:/csi/csi.sock
+            - name: CSI_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
           volumeMounts:
             - name: kubelet-dir
               mountPath: /var/lib/kubelet

--- a/hack/e2e/eksctl.sh
+++ b/hack/e2e/eksctl.sh
@@ -13,19 +13,16 @@ function eksctl_install() {
 }
 
 function eksctl_create_cluster() {
-  SSH_KEY_PATH=${1}
-  CLUSTER_NAME=${2}
-  BIN=${3}
-  ZONES=${4}
-  INSTANCE_TYPE=${5}
-  K8S_VERSION=${6}
-  CLUSTER_FILE=${7}
-  KUBECONFIG=${8}
-  EKSCTL_PATCH_FILE=${9}
-  EKSCTL_ADMIN_ROLE=${10}
-  WINDOWS=${11}
-
-  generate_ssh_key "${SSH_KEY_PATH}"
+  CLUSTER_NAME=${1}
+  BIN=${2}
+  ZONES=${3}
+  INSTANCE_TYPE=${4}
+  K8S_VERSION=${5}
+  CLUSTER_FILE=${6}
+  KUBECONFIG=${7}
+  EKSCTL_PATCH_FILE=${8}
+  EKSCTL_ADMIN_ROLE=${9}
+  WINDOWS=${10}
 
   CLUSTER_NAME="${CLUSTER_NAME//./-}"
 
@@ -74,8 +71,7 @@ function eksctl_create_cluster() {
       -n ng-windows \
       -m 1 \
       -M 1 \
-      --ssh-access \
-      --ssh-public-key "${SSH_KEY_PATH}".pub
+      --ssh-access=false \
     ${BIN} utils install-vpc-controllers --cluster="${CLUSTER_NAME}" --approve
   fi
 

--- a/hack/e2e/eksctl.sh
+++ b/hack/e2e/eksctl.sh
@@ -33,8 +33,7 @@ function eksctl_create_cluster() {
     loudecho "Creating cluster $CLUSTER_NAME with $CLUSTER_FILE (dry run)"
     ${BIN} create cluster \
       --managed \
-      --ssh-access \
-      --ssh-public-key "${SSH_KEY_PATH}".pub \
+      --ssh-access=false \
       --zones "${ZONES}" \
       --nodes=3 \
       --instance-types="${INSTANCE_TYPE}" \

--- a/hack/e2e/kops.sh
+++ b/hack/e2e/kops.sh
@@ -18,20 +18,17 @@ function kops_install() {
 }
 
 function kops_create_cluster() {
-  SSH_KEY_PATH=${1}
-  CLUSTER_NAME=${2}
-  BIN=${3}
-  ZONES=${4}
-  NODE_COUNT=${5}
-  INSTANCE_TYPE=${6}
-  K8S_VERSION=${7}
-  CLUSTER_FILE=${8}
-  KUBECONFIG=${9}
-  KOPS_PATCH_FILE=${10}
-  KOPS_PATCH_NODE_FILE=${11}
-  KOPS_STATE_FILE=${12}
-
-  generate_ssh_key "${SSH_KEY_PATH}"
+  CLUSTER_NAME=${1}
+  BIN=${2}
+  ZONES=${3}
+  NODE_COUNT=${4}
+  INSTANCE_TYPE=${5}
+  K8S_VERSION=${6}
+  CLUSTER_FILE=${7}
+  KUBECONFIG=${8}
+  KOPS_PATCH_FILE=${9}
+  KOPS_PATCH_NODE_FILE=${10}
+  KOPS_STATE_FILE=${11}
 
   if kops_cluster_exists "${CLUSTER_NAME}" "${BIN}" "${KOPS_STATE_FILE}"; then
     loudecho "Replacing cluster $CLUSTER_NAME with $CLUSTER_FILE"
@@ -39,7 +36,6 @@ function kops_create_cluster() {
   else
     loudecho "Creating cluster $CLUSTER_NAME with $CLUSTER_FILE (dry run)"
     ${BIN} create cluster --state "${KOPS_STATE_FILE}" \
-      --ssh-public-key="${SSH_KEY_PATH}".pub \
       --zones "${ZONES}" \
       --node-count="${NODE_COUNT}" \
       --node-size="${INSTANCE_TYPE}" \
@@ -57,7 +53,6 @@ function kops_create_cluster() {
 
     loudecho "Creating cluster $CLUSTER_NAME with $CLUSTER_FILE"
     ${BIN} create --state "${KOPS_STATE_FILE}" -f "${CLUSTER_FILE}"
-    kops create secret --state "${KOPS_STATE_FILE}" --name "${CLUSTER_NAME}" sshpublickey admin -i "${SSH_KEY_PATH}".pub
   fi
 
   loudecho "Updating cluster $CLUSTER_NAME with $CLUSTER_FILE"

--- a/hack/e2e/run.sh
+++ b/hack/e2e/run.sh
@@ -49,14 +49,14 @@ IMAGE_TAG=${IMAGE_TAG:-${TEST_ID}}
 
 # kops: must include patch version (e.g. 1.19.1)
 # eksctl: mustn't include patch version (e.g. 1.19)
-K8S_VERSION=${K8S_VERSION:-1.20.8}
+K8S_VERSION=${K8S_VERSION:-1.22.3}
 
-KOPS_VERSION=${KOPS_VERSION:-1.23.0}
+KOPS_VERSION=${KOPS_VERSION:-1.22.3}
 KOPS_STATE_FILE=${KOPS_STATE_FILE:-s3://k8s-kops-csi-e2e}
 KOPS_PATCH_FILE=${KOPS_PATCH_FILE:-./hack/kops-patch.yaml}
 KOPS_PATCH_NODE_FILE=${KOPS_PATCH_NODE_FILE:-./hack/kops-patch-node.yaml}
 
-EKSCTL_VERSION=${EKSCTL_VERSION:-0.100.0}
+EKSCTL_VERSION=${EKSCTL_VERSION:-0.133.0}
 EKSCTL_PATCH_FILE=${EKSCTL_PATCH_FILE:-./hack/eksctl-patch.yaml}
 EKSCTL_ADMIN_ROLE=${EKSCTL_ADMIN_ROLE:-}
 # Creates a windows node group. The windows ami doesn't (yet) install csi-proxy

--- a/hack/e2e/run.sh
+++ b/hack/e2e/run.sh
@@ -34,7 +34,6 @@ CLUSTER_TYPE=${CLUSTER_TYPE:-kops}
 
 TEST_DIR=${BASE_DIR}/csi-test-artifacts
 BIN_DIR=${TEST_DIR}/bin
-SSH_KEY_PATH=${TEST_DIR}/id_rsa
 CLUSTER_FILE=${TEST_DIR}/${CLUSTER_NAME}.${CLUSTER_TYPE}.yaml
 KUBECONFIG=${KUBECONFIG:-"${TEST_DIR}/${CLUSTER_NAME}.${CLUSTER_TYPE}.kubeconfig"}
 
@@ -116,7 +115,6 @@ ecr_build_and_push "${REGION}" \
 
 if [[ "${CLUSTER_TYPE}" == "kops" ]]; then
   kops_create_cluster \
-    "$SSH_KEY_PATH" \
     "$CLUSTER_NAME" \
     "$KOPS_BIN" \
     "$ZONES" \
@@ -133,7 +131,6 @@ if [[ "${CLUSTER_TYPE}" == "kops" ]]; then
   fi
 elif [[ "${CLUSTER_TYPE}" == "eksctl" ]]; then
   eksctl_create_cluster \
-    "$SSH_KEY_PATH" \
     "$CLUSTER_NAME" \
     "$EKSCTL_BIN" \
     "$ZONES" \

--- a/hack/e2e/run.sh
+++ b/hack/e2e/run.sh
@@ -51,7 +51,7 @@ IMAGE_TAG=${IMAGE_TAG:-${TEST_ID}}
 # eksctl: mustn't include patch version (e.g. 1.19)
 K8S_VERSION=${K8S_VERSION:-1.20.8}
 
-KOPS_VERSION=${KOPS_VERSION:-1.21.0}
+KOPS_VERSION=${KOPS_VERSION:-1.23.0}
 KOPS_STATE_FILE=${KOPS_STATE_FILE:-s3://k8s-kops-csi-e2e}
 KOPS_PATCH_FILE=${KOPS_PATCH_FILE:-./hack/kops-patch.yaml}
 KOPS_PATCH_NODE_FILE=${KOPS_PATCH_NODE_FILE:-./hack/kops-patch-node.yaml}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Fix for test cluster creating failure in PR tests as SSH access is unnecessary for CI and introduces a potential flake point.


Will separate this PR into 2, one for remove SSH and the other for version upgrade
**What is this PR about? / Why do we need it?**

**What testing is done?** 
