### PR TITLE
Validate fstype on CreateVolume, but not NodePublishVolume

### DIFF
--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -76,6 +76,9 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 	if err := d.isValidVolumeCapabilities(volCaps); err != nil {
 		return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("Volume capabilities not supported: %s", err))
 	}
+	if err := d.validateFStype(volCaps); err != nil {
+		return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("Volume fstype not supported: %s", err))
+	}
 
 	var (
 		azName           string

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -319,9 +319,6 @@ func (d *Driver) isValidVolumeCapabilities(volCaps []*csi.VolumeCapability) erro
 		return err
 	}
 
-	if err := d.validateFStype(volCaps); err != nil {
-		return err
-	}
 	return nil
 }
 

--- a/pkg/driver/node_test.go
+++ b/pkg/driver/node_test.go
@@ -436,26 +436,6 @@ func TestNodePublishVolume(t *testing.T) {
 			},
 		},
 		{
-			name: "fail: unsupported volume fstype capability",
-			req: &csi.NodePublishVolumeRequest{
-				VolumeId: volumeId,
-				VolumeCapability: &csi.VolumeCapability{
-					AccessType: &csi.VolumeCapability_Mount{
-						Mount: &csi.VolumeCapability_MountVolume{FsType: "abc"},
-					},
-					AccessMode: &csi.VolumeCapability_AccessMode{
-						Mode: csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER,
-					},
-				},
-				TargetPath: targetPath,
-			},
-			expectMakeDir: false,
-			expectError: errtyp{
-				code:    "InvalidArgument",
-				message: "Volume capability not supported: invalid fstype: abc",
-			},
-		},
-		{
 			name: "fail: multiple unsupported volume capabilities",
 			req: &csi.NodePublishVolumeRequest{
 				VolumeId: volumeId,


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
bug
https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/1025

**What is this PR about? / Why do we need it?**

There are existing PVs that could have wrong fstype, adding new validation will break it. This change tries to workaround this to validate fstype during CreateVolume for new volumes, not on NodePublishVolume

**What testing is done?** 
unit test
