### PR TITLE
Bump the helm version to v2.4.5 to avoid losing track of state files …

### DIFF
--- a/charts/aws-efs-csi-driver/CHANGELOG.md
+++ b/charts/aws-efs-csi-driver/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Helm chart
+# v2.4.5
+* Bump helm version for change of state-dir path to avoid losing track of state files which exists already to `v2.4.5`
 # v2.4.4
 * Bump helm version to pick the latest side-car images `v2.4.4`
 # v2.4.3

--- a/charts/aws-efs-csi-driver/Chart.yaml
+++ b/charts/aws-efs-csi-driver/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: aws-efs-csi-driver
-version: 2.4.4
+version: 2.4.5
 appVersion: 1.5.6
 kubeVersion: ">=1.17.0-0"
 description: "A Helm chart for AWS EFS CSI Driver"


### PR DESCRIPTION
…which exists already.

**Is this a bug fix or adding new feature?**

**What is this PR about? / Why do we need it?**
Bump the helm version to v2.4.5 to avoid losing track of state files which exists already.

**What testing is done?** 
