### PR TITLE
Update log_collector.py

### DIFF
--- a/troubleshooting/log_collector.py
+++ b/troubleshooting/log_collector.py
@@ -45,7 +45,7 @@ with open(results_dir_path + "/driver_logs", "w") as f:
 def collect_driver_files_under_dir(dir_name, file):
     collect_driver_files_under_dir = (
         f"kubectl exec {driver_pod_name} -n kube-system -c efs-plugin -- find {dir_name} "
-        + r"-type f -exec echo {} \; -exec cat {} \; -exec echo \;"
+        + r"-type f -print -exec cat {} \;"
     )
     execute(command=collect_driver_files_under_dir, file=file)
 


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

Bug fix

**What is this PR about? / Why do we need it?**

Use find's print ability instead of a shell builtin.

Was using the projects debug scripts and noticed a bunch of 

```
kubectl exec efs-csi-node-468m4 -n kube-system -c efs-plugin -- find /var/log/amazon/efs -type f -exec echo {} \; -exec cat {} \; -exec echo \;

find: 'echo': No such file or directory
find: 'echo': No such file or directory
```

You could put the commands inside a sh command, but for what I surmised was the intended effect, I think this works a bit more legibly.  

**What testing is done?** 

Ran the script and verified the name of the file is printed as expected in the output