### PR TITLE
Allow to specify init containers for efs-csi-node pods

### DIFF
--- a/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
+++ b/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
@@ -61,6 +61,13 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.node.initContainers }}
+      {{- range $key, $value := .Values.node.initContainers }}
+      initContainers:
+      - name: "{{ $key }}"
+{{ toYaml $value | indent 8 }}
+      {{- end }}
+      {{- end }}
       containers:
         - name: efs-plugin
           securityContext:

--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -162,6 +162,13 @@ node:
     runAsUser: 0
     runAsGroup: 0
     fsGroup: 0
+  initContainers: {}
+    # Add your own init container. Example:
+    # myInitContainer:
+    #   image: "busybox:latest"
+    #   command:
+    #     - "/bin/sh"
+    #   args: ["-c", "echo 'Doing important things here!'"]
 
 storageClasses: []
 # Add StorageClass resources like:


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Helps to have a workaround for [683](https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/683)

**What is this PR about? / Why do we need it?**
The issue is in open state for almost a year. We verified that [workaround](https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/683#issuecomment-1109892312) from comment works for our cluster, but we have to clone csi driver chart to our repo in order to add initContainer there. This PR will allow to add whatever init containers we need.

**What testing is done?** 
Uncommented initContainer example from values.yaml, executed `helm template aws-efs-csi-driver . ` command.
Output contains the following:
initContainers:
      - name: "myInitContainer"
        args:
        - -c
        - echo 'Doing important things here!'
        command:
        - /bin/sh
        image: busybox:latest
