### PR TITLE
Add IAM mount option.

### DIFF
--- a/examples/kubernetes/multiple_pods/specs/pv.yaml
+++ b/examples/kubernetes/multiple_pods/specs/pv.yaml
@@ -3,6 +3,8 @@ kind: PersistentVolume
 metadata:
   name: efs-pv
 spec:
+  mountOptions:
+    - iam
   capacity:
     storage: 5Gi
   volumeMode: Filesystem


### PR DESCRIPTION
In order to make this work with EFS, we need to add this option as per https://repost.aws/knowledge-center/eks-troubleshoot-efs-volume-mount-issues

**Is this a bug fix or adding new feature?**
- Bugfix

**What is this PR about? / Why do we need it?**
- I was recently using your examples to build part of our infrastructure and noticed the pods were not starting and were giving me an error like:
```bash
Mounting arguments: -t efs -o tls fs-0XXXXXXXXX:/ /var/lib/kubelet/pods/XXX-XXX-X-XXXXX/volumes/kubernetes.io~csi/efs-pv/mount
Output: Could not start amazon-efs-mount-watchdog, unrecognized init system "aws-efs-csi-dri"
b'mount.nfs4: access denied by server while mounting 127.0.0.1:/'
```

**What testing is done?** 
I validated it using my own setup and it's working as expected.
