### PR TITLE
Remove usage of 'echo' from log collector script

### DIFF
--- a/troubleshooting/log_collector.py
+++ b/troubleshooting/log_collector.py
@@ -45,7 +45,7 @@ with open(results_dir_path + "/driver_logs", "w") as f:
 def collect_driver_files_under_dir(dir_name, file):
     collect_driver_files_under_dir = (
         f"kubectl exec {driver_pod_name} -n kube-system -c efs-plugin -- find {dir_name} "
-        + r"-type f -exec echo {} \; -exec cat {} \; -exec echo \;"
+        + r"-type f -exec ls {} \; -exec cat {} \;"
     )
     execute(command=collect_driver_files_under_dir, file=file)
 


### PR DESCRIPTION
When building the minimal image for the efs-plugin container, we do not include the `echo` executableanymore. Therefore, I replaced its usage with `ls`, which we still include.

**What testing is done?** 
I ran the log collector script against a driver Pod and ensured that it was successful.