### PR TITLE
feat: allow to don't use helm hooks for CSIDriver creation

### DIFF
--- a/charts/aws-efs-csi-driver/templates/csidriver.yaml
+++ b/charts/aws-efs-csi-driver/templates/csidriver.yaml
@@ -3,8 +3,10 @@ kind: CSIDriver
 metadata:
   name: efs.csi.aws.com
   annotations:
+    {{- if .Values.useHelmHooksForCSIDriver }}
     "helm.sh/hook": pre-install, pre-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
+    {{- end }}
     "helm.sh/resource-policy": keep
 spec:
   attachRequired: false

--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -95,7 +95,6 @@ controller:
     runAsGroup: 0
     fsGroup: 0
 
-
 ## Node daemonset variables
 
 node:
@@ -132,7 +131,8 @@ node:
     #   cpu: 100m
     #   memory: 128Mi
   nodeSelector: {}
-  updateStrategy: {}
+  updateStrategy:
+    {}
     # Override default strategy (RollingUpdate) to speed up deployment.
     # This can be useful if helm timeouts are observed.
     # type: OnDelete
@@ -180,3 +180,6 @@ storageClasses: []
 #     basePath: "/dynamic_provisioning"
 #   reclaimPolicy: Delete
 #   volumeBindingMode: Immediate
+
+# Specifies wether to use helm hooks to apply the CSI driver
+useHelmHooksForCSIDriver: true


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

Fixes #765 
Fixes #325

**What is this PR about? / Why do we need it?**

According to how external tools are executing the hooks, there can be a possibility that the CSIDriver gets deleted but never created. This PR adds a flag, so that the CSIDriver can be added without using helm hooks. This has the benefit that the CSIDriver gets constantly recreated on each update of the chart.

Adds a flag `useHelmHooksForCSIDriver` to Values, which can be used to disable usage of hooks.

Currently, does not change the default behaviour to not impact existing users.

**What testing is done?** 

Verified that the sources does not show up as deleted
