### PR TITLE
docs(static_provisioning): add a note that don't proceed to the next step until pv `STATUS` is `Bound`

### DIFF
--- a/examples/kubernetes/static_provisioning/README.md
+++ b/examples/kubernetes/static_provisioning/README.md
@@ -31,6 +31,26 @@ Create PV and persistent volume claim (PVC):
 ```sh
 >> kubectl apply -f examples/kubernetes/static_provisioning/specs/pv.yaml
 >> kubectl apply -f examples/kubernetes/static_provisioning/specs/claim.yaml
+```
+
+List the persistent volumes in the default namespace. Look for a persistent volume with the default/efs-claim claim.
+
+```sh
+kubectl get pv -w
+```
+
+The example output is as follows.
+
+```
+$ kubectl get pv -w
+NAME     CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM               STORAGECLASS   REASON   AGE
+efs-pv   5Gi        RWO            Retain           Bound    default/efs-claim                           3m31s
+```
+
+Don't proceed to the next step until the `STATUS` is `Bound`.
+
+Deploy the `app` sample applications
+```
 >> kubectl apply -f examples/kubernetes/static_provisioning/specs/pod.yaml
 ```
 


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

docs

**What is this PR about? / Why do we need it?**

ref) https://github.com/kubernetes-sigs/aws-efs-csi-driver/blob/2c8778273e14c29f1a2d150b9a05e174df1b4fca/examples/kubernetes/multiple_pods/README.md
```
2. List the persistent volumes in the default namespace. Look for a persistent volume with the default/efs-claim claim.

kubectl get pv -w
The example output is as follows.

NAME     CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM               STORAGECLASS   REASON   AGE
efs-pv   5Gi        RWX            Retain           Bound    default/efs-claim   efs-sc                  2m50s
Don't proceed to the next step until the STATUS is Bound.
```

ref) https://github.com/kubernetes-sigs/aws-efs-csi-driver/blob/2c8778273e14c29f1a2d150b9a05e174df1b4fca/examples/kubernetes/dynamic_provisioning/README.md
```
5. Confirm that a persistent volume was created with a status of Bound to a PersistentVolumeClaim:

kubectl get pv
```

**What testing is done?** 
