### PR TITLE
Remove usage of 'echo' from log collector script

### DIFF
--- a/troubleshooting/log_collector.py
+++ b/troubleshooting/log_collector.py
@@ -45,7 +45,7 @@ with open(results_dir_path + "/driver_logs", "w") as f:
 def collect_driver_files_under_dir(dir_name, file):
     collect_driver_files_under_dir = (
         f"kubectl exec {driver_pod_name} -n kube-system -c efs-plugin -- find {dir_name} "
-        + r"-type f -exec echo {} \; -exec cat {} \; -exec echo \;"
+        + r"-type f -exec ls {} \; -exec cat {} \;"
     )
     execute(command=collect_driver_files_under_dir, file=file)
 


### PR DESCRIPTION
When building the minimal image for the efs-plugin container, we do not include the echo script anymore. Therefore, I replaced its usage with ls, which we still include.

(cherry picked from commit c3eeca72797a7c7a32ae05b435f031b77d0303a6)

**Is this a bug fix or adding new feature?**

**What is this PR about? / Why do we need it?**
When building the minimal image for the efs-plugin container, we do not include the echo executableanymore. Therefore, I replaced its usage with ls, which we still include.

**What testing is done?** 
ran the log collector script against a driver Pod and ensured that it was successful.
