### PR TITLE
Update security context parameter. Helm version

### DIFF
--- a/charts/aws-efs-csi-driver/Chart.yaml
+++ b/charts/aws-efs-csi-driver/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: aws-efs-csi-driver
-version: 2.4.8
+version: 2.4.9
 appVersion: 1.5.9
 kubeVersion: ">=1.17.0-0"
 description: "A Helm chart for AWS EFS CSI Driver"

--- a/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
+++ b/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
@@ -51,7 +51,7 @@ spec:
       containers:
         - name: efs-plugin
           securityContext:
-            privileged: false
+            privileged: true
           image: {{ printf "%s:%s" .Values.image.repository (default (printf "v%s" .Chart.AppVersion) (toString .Values.image.tag)) }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:

--- a/deploy/kubernetes/base/controller-deployment.yaml
+++ b/deploy/kubernetes/base/controller-deployment.yaml
@@ -34,7 +34,7 @@ spec:
       containers:
         - name: efs-plugin
           securityContext:
-            privileged: false
+            privileged: true
           image: amazon/aws-efs-csi-driver:v1.5.9
           imagePullPolicy: IfNotPresent
           args:


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Bug Fix 
**What is this PR about? / Why do we need it?**
This will allow the Controller Pods to mount the filesystem and delete the access point directory again. See [this issue](https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/1077
)
**What testing is done?** 
-