### PR TITLE
Set efs-plugin container security context to true

### DIFF
--- a/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
+++ b/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
@@ -50,7 +50,7 @@ spec:
       containers:
         - name: efs-plugin
           securityContext:
-            privileged: false
+            privileged: true
           image: {{ printf "%s:%s" .Values.image.repository (default (printf "v%s" .Chart.AppVersion) (toString .Values.image.tag)) }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:

--- a/deploy/kubernetes/base/controller-deployment.yaml
+++ b/deploy/kubernetes/base/controller-deployment.yaml
@@ -33,7 +33,7 @@ spec:
       containers:
         - name: efs-plugin
           securityContext:
-            privileged: false
+            privileged: true
           image: amazon/aws-efs-csi-driver:v1.5.9
           imagePullPolicy: IfNotPresent
           args:


### PR DESCRIPTION
Is this a bug fix or adding new feature?
Bug fix
What is this PR about? / Why do we need it?
This will allow the Controller Pods to mount the filesystem and delete the access point directory again. See https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/1077
What testing is done?