### PR TITLE
Added AWS SDK client retry as a configurable flag

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -41,7 +41,8 @@ func main() {
 		volMetricsFsRateLimit    = flag.Int("vol-metrics-fs-rate-limit", 5, "Volume metrics routines rate limiter per file system")
 		deleteAccessPointRootDir = flag.Bool("delete-access-point-root-dir", false,
 			"Opt in to delete access point root directory by DeleteVolume. By default, DeleteVolume will delete the access point behind Persistent Volume and deleting access point will not delete the access point root directory or its contents.")
-		tags = flag.String("tags", "", "Space separated key:value pairs which will be added as tags for EFS resources. For example, 'environment:prod region:us-east-1'")
+		tags                = flag.String("tags", "", "Space separated key:value pairs which will be added as tags for EFS resources. For example, 'environment:prod region:us-east-1'")
+		efsClientMaxRetries = flag.Int("efs-client-max-retries", 3, "Number of max retries that will be performed for EFS client connection")
 	)
 	klog.InitFlags(nil)
 	flag.Parse()
@@ -60,7 +61,7 @@ func main() {
 	if err != nil {
 		klog.Fatalln(err)
 	}
-	drv := driver.NewDriver(*endpoint, etcAmazonEfs, *efsUtilsStaticFilesPath, *tags, *volMetricsOptIn, *volMetricsRefreshPeriod, *volMetricsFsRateLimit, *deleteAccessPointRootDir)
+	drv := driver.NewDriver(*endpoint, etcAmazonEfs, *efsUtilsStaticFilesPath, *tags, *volMetricsOptIn, *volMetricsRefreshPeriod, *volMetricsFsRateLimit, *deleteAccessPointRootDir, *efsClientMaxRetries)
 	if err := drv.Run(); err != nil {
 		klog.Fatalln(err)
 	}

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -502,15 +502,15 @@ func getCloud(secrets map[string]string, driver *Driver) (cloud.Cloud, string, e
 	var localCloud cloud.Cloud
 	var roleArn string
 	var err error
+	var efsClientMaxRetries = driver.efsClientMaxRetries
 
 	// Fetch aws role ARN for cross account mount from CSI secrets. Link to CSI secrets below
 	// https://kubernetes-csi.github.io/docs/secrets-and-credentials.html#csi-operation-secrets
 	if value, ok := secrets[RoleArn]; ok {
 		roleArn = value
 	}
-
 	if roleArn != "" {
-		localCloud, err = cloud.NewCloudWithRole(roleArn)
+		localCloud, err = cloud.NewCloudWithRole(roleArn, efsClientMaxRetries)
 		if err != nil {
 			return nil, "", status.Errorf(codes.Unauthenticated, "Unable to initialize aws cloud: %v. Please verify role has the correct AWS permissions for cross account mount", err)
 		}

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -48,10 +48,11 @@ type Driver struct {
 	gidAllocator             GidAllocator
 	deleteAccessPointRootDir bool
 	tags                     map[string]string
+	efsClientMaxRetries      int
 }
 
-func NewDriver(endpoint, efsUtilsCfgPath, efsUtilsStaticFilesPath, tags string, volMetricsOptIn bool, volMetricsRefreshPeriod float64, volMetricsFsRateLimit int, deleteAccessPointRootDir bool) *Driver {
-	cloud, err := cloud.NewCloud()
+func NewDriver(endpoint, efsUtilsCfgPath, efsUtilsStaticFilesPath, tags string, volMetricsOptIn bool, volMetricsRefreshPeriod float64, volMetricsFsRateLimit int, deleteAccessPointRootDir bool, efsClientMaxRetries int) *Driver {
+	cloud, err := cloud.NewCloud(efsClientMaxRetries)
 	if err != nil {
 		klog.Fatalln(err)
 	}
@@ -72,6 +73,7 @@ func NewDriver(endpoint, efsUtilsCfgPath, efsUtilsStaticFilesPath, tags string, 
 		gidAllocator:             NewGidAllocator(),
 		deleteAccessPointRootDir: deleteAccessPointRootDir,
 		tags:                     parseTagsFromStr(strings.TrimSpace(tags)),
+		efsClientMaxRetries:      efsClientMaxRetries,
 	}
 }
 


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Fixes #1024 

**What is this PR about? / Why do we need it?**
Added `efs-client-max-retries` flag to the executable which allows users to configure the AWS SDK client maxRetryAttempts

**What testing is done?** 
Nil