### PR TITLE
Set efs-plugin container security context to true

### DIFF
--- a/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
+++ b/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
@@ -51,7 +51,7 @@ spec:
       containers:
         - name: efs-plugin
           securityContext:
-            privileged: false
+            privileged: true
           image: {{ printf "%s:%s" .Values.image.repository (default (printf "v%s" .Chart.AppVersion) (toString .Values.image.tag)) }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:

--- a/deploy/kubernetes/base/controller-deployment.yaml
+++ b/deploy/kubernetes/base/controller-deployment.yaml
@@ -34,7 +34,7 @@ spec:
       containers:
         - name: efs-plugin
           securityContext:
-            privileged: false
+            privileged: true
           image: amazon/aws-efs-csi-driver:v1.5.9
           imagePullPolicy: IfNotPresent
           args:


### PR DESCRIPTION
(cherry picked from commit d8326d4e0861b074b6145fd889fa1d2935932262)

**Is this a bug fix or adding new feature?**

**What is this PR about? / Why do we need it?**
This will allow the Controller Pods to mount the filesystem and delete the access point directory again. See https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/1077
**What testing is done?** 
