### PR TITLE
Create e2e test for subpath pattern correctness

### DIFF
--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -360,8 +360,95 @@ var _ = ginkgo.Describe("[efs-csi] EFS CSI", func() {
 			encryptInTransit := false
 			testEncryptInTransit(f, &encryptInTransit)
 		})
+
+		ginkgo.It("should create an access point with the desired subpath pattern", func() {
+
+			ginkgo.By("Creating EFS Storage Class, PVC and associated PV")
+			pvName := "foo"
+			pvcName := "bar"
+			directoryCreated := fmt.Sprintf("/%s/%s", pvName, pvcName)
+			params := map[string]string{
+				"provisioningMode": "efs-ap",
+				"fileSystemId":     FileSystemId,
+				"directoryPerms":   "777",
+				"subPathPattern":   "${.PV.name}/${.PVC.name}",
+				"pvName":           pvName,
+				"pvcName":          pvcName,
+			}
+
+			sc := GetStorageClass(params)
+			sc, err := f.ClientSet.StorageV1().StorageClasses().Create(context.TODO(), sc, metav1.CreateOptions{})
+			framework.ExpectNoError(err, "creating storage class")
+			pvc, err := createEFSPVCPVDynamicProvisioning(f.ClientSet, f.Namespace.Name, pvcName, sc.Name)
+			framework.ExpectNoError(err)
+
+			ginkgo.By("Deploying a pod that applies the PVC to create an access point")
+			pod := e2epod.MakePod(f.Namespace.Name, nil, []*v1.PersistentVolumeClaim{pvc}, false, "while :; do echo '.'; sleep 5 ; done")
+			pod, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(context.TODO(), pod, metav1.CreateOptions{})
+			framework.ExpectNoError(err, "creating pod")
+			framework.ExpectNoError(e2epod.WaitForPodNameRunningInNamespace(f.ClientSet, pod.Name, f.Namespace.Name), "waiting for pod running")
+			defer func() {
+				_ = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(context.TODO(), pod.Name, metav1.DeleteOptions{})
+				_ = f.ClientSet.CoreV1().PersistentVolumeClaims(f.Namespace.Name).Delete(context.TODO(), pvc.Name, metav1.DeleteOptions{})
+			}()
+
+			ginkgo.By("Checking if access point's directory matches expected structure")
+			cmd := "cd mnt && cd volume1 && cd foo && cd bar && pwd"
+			actualDir := framework.RunKubectlOrDie(f.Namespace.Name, "exec", pod.Name, "--", "/bin/sh", "-c", cmd)
+			framework.Logf("%s", actualDir)
+
+			expectedDir := fmt.Sprintf("/mnt/volume1%s", directoryCreated)
+			if actualDir != expectedDir {
+				ginkgo.Fail("Subpath pattern directory structure does not match expected")
+			}
+		})
+
 	})
 })
+
+func createEFSPVCPVDynamicProvisioning(c clientset.Interface, namespace, name, storageClassName string) (*v1.PersistentVolumeClaim, error) {
+	pvc := makeEFSPVCDynamicProvisioning(namespace, name, storageClassName)
+	pvc, err := c.CoreV1().PersistentVolumeClaims(namespace).Create(context.TODO(), pvc, metav1.CreateOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return pvc, nil
+}
+
+func makeEFSPVCDynamicProvisioning(namespace, name string, storageClassName string) *v1.PersistentVolumeClaim {
+	return &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: v1.PersistentVolumeClaimSpec{
+			AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteMany},
+			Resources: v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceStorage: resource.MustParse("1Gi"),
+				},
+			},
+			StorageClassName: &storageClassName,
+		},
+	}
+}
+
+func GetStorageClass(params map[string]string) *storagev1.StorageClass {
+	parameters := params
+
+	generateName := fmt.Sprintf("efs-csi-dynamic-sc-test1234-")
+
+	defaultBindingMode := storagev1.VolumeBindingImmediate
+	return &storagev1.StorageClass{
+		ObjectMeta: metav1.ObjectMeta{
+			//GenerateName: generateName,
+			Name: generateName + generateRandomString(4),
+		},
+		Provisioner:       "efs.csi.aws.com",
+		Parameters:        parameters,
+		VolumeBindingMode: &defaultBindingMode,
+	}
+}
 
 func createEFSPVCPV(c clientset.Interface, namespace, name, path string, volumeAttributes map[string]string) (*v1.PersistentVolumeClaim, *v1.PersistentVolume, error) {
 	pvc, pv := makeEFSPVCPV(namespace, name, path, volumeAttributes)


### PR DESCRIPTION
Create e2e test for subpath pattern correctness

**Is this a bug fix or adding new feature?**
Adds a new e2e test.
**What is this PR about? / Why do we need it?**
This PR adds an e2e test to test correctness of the subpath pattern feature when creating new access points.
**What testing is done?** 
Submitting to run against github cluster