### PR TITLE
Update manifest paths in aws-efs-csi-driver/vendor/k8s.io/kubernetes/test/e2e/storage/testsuites/provisioning.go

### DIFF
--- a/vendor/k8s.io/kubernetes/test/e2e/storage/testsuites/provisioning.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/storage/testsuites/provisioning.go
@@ -267,9 +267,9 @@ func (p *provisioningTestSuite) DefineTests(driver storageframework.TestDriver, 
 
 		ginkgo.By("Deploying validator")
 		valManifests := []string{
-			"test/e2e/testing-manifests/storage-csi/any-volume-datasource/crd/populator.storage.k8s.io_volumepopulators.yaml",
-			"test/e2e/testing-manifests/storage-csi/any-volume-datasource/volume-data-source-validator/rbac-data-source-validator.yaml",
-			"test/e2e/testing-manifests/storage-csi/any-volume-datasource/volume-data-source-validator/setup-data-source-validator.yaml",
+			"vendor/k8s.io/kubernetes/test/e2e/testing-manifests/storage-csi/any-volume-datasource/crd/populator.storage.k8s.io_volumepopulators.yaml",
+			"vendor/k8s.io/kubernetes/test/e2e/testing-manifests/storage-csi/any-volume-datasource/volume-data-source-validator/rbac-data-source-validator.yaml",
+			"vendor/k8s.io/kubernetes/test/e2e/testing-manifests/storage-csi/any-volume-datasource/volume-data-source-validator/setup-data-source-validator.yaml",
 		}
 		valCleanup, err := storageutils.CreateFromManifests(f, valNamespace,
 			func(item interface{}) error { return nil },
@@ -291,8 +291,8 @@ func (p *provisioningTestSuite) DefineTests(driver storageframework.TestDriver, 
 
 		ginkgo.By("Deploying hello-populator")
 		popManifests := []string{
-			"test/e2e/testing-manifests/storage-csi/any-volume-datasource/crd/hello-populator-crd.yaml",
-			"test/e2e/testing-manifests/storage-csi/any-volume-datasource/hello-populator-deploy.yaml",
+			"vendor/k8s.io/kubernetes/test/e2e/testing-manifests/storage-csi/any-volume-datasource/crd/hello-populator-crd.yaml",
+			"vendor/k8s.io/kubernetes/test/e2e/testing-manifests/storage-csi/any-volume-datasource/hello-populator-deploy.yaml",
 		}
 		popCleanup, err := storageutils.CreateFromManifests(f, popNamespace,
 			func(item interface{}) error {


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Bug Fix
**What is this PR about? / Why do we need it?**
This PR aims to fix the issue of EFS CSI Driver e2e tests failing when run against a local EKS cluster. This was done by updating the paths of the manifest files in aws-efs-csi-driver/vendor/k8s.io/kubernetes/test/e2e/storage/testsuites/provisioning.go. 

Previously, these paths were set incorrectly causing the local builds to fail claiming that the affected manifest files could not be found.

**What testing is done?** 
Got e2e tests passing against local EKS Cluster