### PR TITLE
Add CSI_NODE_NAME to node Daemonset

### DIFF
--- a/deploy/kubernetes/base/node-daemonset.yaml
+++ b/deploy/kubernetes/base/node-daemonset.yaml
@@ -57,6 +57,10 @@ spec:
           env:
             - name: CSI_ENDPOINT
               value: unix:/csi/csi.sock
+            - name: CSI_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
           volumeMounts:
             - name: kubelet-dir
               mountPath: /var/lib/kubelet


### PR DESCRIPTION
We added CSI_NODE_NAME as an environment variable to the Helm Chart's node Daemonset, but we forget to add it to our kustomize deploy files as well. This is required for users who have IMDS disabled on their cluster, and who install the driver using kustomize.

This fixes https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/1111.

For more background, 

[This recent commit](https://github.com/kubernetes-sigs/aws-efs-csi-driver/commit/b5f141df327f2affa5a6c297c7edd43acab7da87) removed `hostNetwork = true` from the node daemonset. This means that the Node Daemonset Pods cannot use IMDS for getting the region. 

A while ago, [this commit was merged](https://github.com/kubernetes-sigs/aws-efs-csi-driver/commit/6ae114bc43ea5b4bdb9962ff786c08ca1eeddbf4) which allows us to pull EC2 info from Kubernetes instead of IMDS if IMDS is enabled. However, it requires the `CSI_NODE_NAME` env variable to be set. The author of this commit only added it to the Controller Deployment, but our Node Daemonset needs it as well. Thus, that's why the commit above, where `hostNetwork = true` was removed, also introduced this `CSI_NODE_NAME` to our Helm Chart. However, it wasn't added to the [Node daemonset spec that our Kustomize files use](https://github.com/kubernetes-sigs/aws-efs-csi-driver/blob/master/deploy/kubernetes/base/node-daemonset.yaml).

**Is this a bug fix or adding new feature?**
Bug fix


**What testing is done?** 
I applied a static provisioning example while enforcing IMDSv2 was used (which disabled IMDS).