### PR TITLE
Add hostnetwork back to Node Daemonset

### DIFF
--- a/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
+++ b/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
@@ -47,6 +47,7 @@ spec:
       {{- with .Values.node.affinity }}
       affinity: {{- toYaml . | nindent 8 }}
       {{- end }}
+      hostNetwork: true
       dnsPolicy: {{ .Values.node.dnsPolicy }}
       {{- with .Values.node.dnsConfig }}
       dnsConfig: {{- toYaml . | nindent 8 }}

--- a/deploy/kubernetes/base/node-daemonset.yaml
+++ b/deploy/kubernetes/base/node-daemonset.yaml
@@ -31,6 +31,7 @@ spec:
                 operator: NotIn
                 values:
                 - fargate
+      hostNetwork: true
       dnsPolicy: ClusterFirst
       serviceAccountName: efs-csi-node-sa
       priorityClassName: system-node-critical


### PR DESCRIPTION
Efs-utils requires IMDS to find the region of a file system. We will change this in a future release of efs-utils, but for now, we have to roll back and add host network back to the Node Daemonset.

**Is this a bug fix or adding new feature?**
This will fix https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/1111.

**More details, which I've copied from a comment on the above issue**:

> Ok, I think I figured out the issue. The CSI Driver [uses the region it pulls from Kubernetes metadata to build a client to the EFS API](https://github.com/kubernetes-sigs/aws-efs-csi-driver/blob/master/pkg/cloud/cloud.go#L153). This is working as expected. However, the utility that the csi driver uses under the hood for performing mounts to EFS, [efs-utils](https://github.com/aws/efs-utils), requires [IMDS to find the region](https://github.com/aws/efs-utils/blob/master/src/mount_efs/__init__.py#L356-L388), which it then uses to construct the DNS name for the mount target. 
>
> The reason that I didn't run into this issue when initially trying to recreate it was because my efs-utils configuration file had been hardcoded with the correct region, so IMDS was not needed.
>
> The immediate solution here is to add `hostNetwork=true` back into the Node Daemonset.
>
> And for the long term solution:
> I'd like to see us add a mount option in efs-utils to support configuring the region that way, instead of through the config file. There is already an open PR for this: https://github.com/aws/efs-utils/pull/171/files. Once that is merged, we can modify this driver to pass in the region it pulls from the Kubernetes Node spec as a mount option to efs-utils.
> 
> We will also need to update our testing infra to test against a IMDS disabled cluster. 


**What testing is done?** 
Tested applying static provisioning example with egress to IMDS blocked. 