### PR TITLE
Fix typo in gid check

### DIFF
--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -164,7 +164,7 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 		if err != nil {
 			return nil, status.Errorf(codes.InvalidArgument, "Failed to parse invalid %v: %v", Gid, err)
 		}
-		if uid < 0 {
+		if gid < 0 {
 			return nil, status.Errorf(codes.InvalidArgument, "%v must be greater or equal than 0", Gid)
 		}
 	}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

Bug fix for https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/1091

**What is this PR about? / Why do we need it?**

Without the PR the gid check does not work properly

**What testing is done?** 

Ran make to build the docker container and make test to run system tests.