### PR TITLE
Fix ensureUniqueDirectory paramater at docs

### DIFF
--- a/examples/kubernetes/dynamic_provisioning/README.md
+++ b/examples/kubernetes/dynamic_provisioning/README.md
@@ -41,7 +41,7 @@ This example requires Kubernetes 1.17 or later and a driver version of 1.2.0 or 
       * `basePath` (Optional) - The path on the file system under which the access point root directory is created. If the path isn't provided, the access points root directory is created under the root of the file system.
       * `subPathPattern` (Optional) - A pattern that describes the subPath under which an access point should be created. So if the pattern were `${.PVC.namespace}/${PVC.name}`, the PVC namespace is `foo` and the PVC name is `pvc-123-456`, and the `basePath` is `/dynamic_provisioner` the access point would be
         created at `/dynamic_provisioner/foo/pvc-123-456`.
-      * `ensureUniqueDirectories` (Optional) - A boolean that ensures that, if set, a UUID is appended to the final element of
+      * `ensureUniqueDirectory` (Optional) - A boolean that ensures that, if set, a UUID is appended to the final element of
         any dynamically provisioned path, as in the above example. This can be turned off but this requires you as the
         administrator to ensure that your storage classes are set up correctly. Otherwise, it's possible that 2 pods could
         end up writing to the same directory by accident. **Please think very carefully before setting this to false!**


### PR DESCRIPTION
I noticed the name for `ensureUniqueDirectory` is wrong in the README, its correct at the example, but wrong here.

**Is this a bug fix or adding new feature?**

Fix in docs

**What is this PR about? / Why do we need it?**

The current docs mislead the parameter due to the wrong naming