### PR TITLE
Increase AP max limit to 1000

### DIFF
--- a/pkg/driver/controller_test.go
+++ b/pkg/driver/controller_test.go
@@ -428,7 +428,8 @@ func TestCreateVolume(t *testing.T) {
 				}
 
 				accessPoints := []*cloud.AccessPoint{}
-				for i := 0; i < 119; i++ {
+				accessPointLimit := 1000
+				for i := 0; i < accessPointLimit-1; i++ {
 					gidMax, err := strconv.Atoi(req.Parameters[GidMax])
 					if err != nil {
 						t.Fatalf("Failed to convert GidMax Parameter to int.")
@@ -480,7 +481,7 @@ func TestCreateVolume(t *testing.T) {
 				mockCloud.EXPECT().ListAccessPoints(gomock.Eq(ctx), gomock.Any()).Return(accessPoints, nil)
 				mockCloud.EXPECT().CreateAccessPoint(gomock.Eq(ctx), gomock.Any(), gomock.Any()).Return(lastAccessPoint, nil).AnyTimes()
 
-				// All 120 GIDs are taken now, internal limit should take effect causing CreateVolume to fail.
+				// All 1000 GIDs are taken now, internal limit should take effect causing CreateVolume to fail.
 				_, err = driver.CreateVolume(ctx, req)
 				if err == nil {
 					t.Fatalf("CreateVolume should have failed.")

--- a/pkg/driver/gid_allocator.go
+++ b/pkg/driver/gid_allocator.go
@@ -3,15 +3,16 @@ package driver
 import (
 	"context"
 	"fmt"
+	"sync"
+
 	"github.com/kubernetes-sigs/aws-efs-csi-driver/pkg/cloud"
 	"golang.org/x/exp/slices"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"k8s.io/klog/v2"
-	"sync"
 )
 
-var ACCESS_POINT_PER_FS_LIMIT int = 120
+var ACCESS_POINT_PER_FS_LIMIT int = 1000
 
 type FilesystemID struct {
 	gidMin int


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Updates the access point max limit

**What is this PR about? / Why do we need it?**
This is needed so customers can create up to 1000 access points.

**What testing is done?** 
