### PR TITLE
Add CriticalAddonsOnly default toleration.

### DIFF
--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -77,7 +77,9 @@ controller:
     #   memory: 128Mi
   nodeSelector: {}
   updateStrategy: {}
-  tolerations: []
+  tolerations:
+    - key: CriticalAddonsOnly
+      operator: Exists
   affinity: {}
   # Specifies whether a service account should be created
   serviceAccount:

--- a/deploy/kubernetes/base/controller-deployment.yaml
+++ b/deploy/kubernetes/base/controller-deployment.yaml
@@ -25,6 +25,9 @@ spec:
         kubernetes.io/os: linux
       serviceAccountName: efs-csi-controller-sa
       priorityClassName: system-cluster-critical
+      tolerations:
+        - key: CriticalAddonsOnly
+          operator: Exists
       securityContext:
         fsGroup: 0
         runAsGroup: 0


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Response to [github issue with request for CriticalAddonsOnly to be set as the default toleration](https://github.com/aws/containers-roadmap/issues/2127)
**What is this PR about? / Why do we need it?**
Sets default toleration to CriticalAddonsOnly for the controller to avoid unintended eviction. ([Source](https://unofficial-kubernetes.readthedocs.io/en/latest/concepts/cluster-administration/guaranteed-scheduling-critical-addon-pods/))

**What testing is done?** 
