### PR TITLE
Add Toggle for Controller to access secrets

### DIFF
--- a/charts/aws-efs-csi-driver/templates/controller-serviceaccount.yaml
+++ b/charts/aws-efs-csi-driver/templates/controller-serviceaccount.yaml
@@ -40,9 +40,11 @@ rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["get", "watch", "list", "delete", "update", "create"]
-  # - apiGroups: [ "" ]
-  #   resources: [ "secrets" ]
-  #   verbs: [ "get", "watch", "list" ]
+{{- if .Values.controller.crossAccountPermission }}
+  - apiGroups: [ "" ]
+    resources: [ "secrets" ]
+    verbs: [ "get", "watch", "list" ]
+{{- end }}
 
 ---
 

--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -50,6 +50,8 @@ imagePullSecrets: []
 controller:
   # Specifies whether a deployment should be created
   create: true
+  # Specifies whether the controller can access secrets required for cross account EFS mounting.
+  crossAccountPermission: false
   # Number for the log level verbosity
   logLevel: 2
   # If set, add pv/pvc metadata to plugin create requests as parameters.


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Response to: https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/1148.

**What is this PR about? / Why do we need it?**
Adds a new values.yaml flag to allow users to dynamically configure EFS CSI Driver with the `get/list/watch` secrets permission.

**What testing is done?** 
None
