### PR TITLE
Additional Controller Deployment features

### DIFF
--- a/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
+++ b/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
@@ -57,9 +57,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- if .Values.controller.dnsPolicy }}
-      dnsPolicy: {{ .Values.node.dnsPolicy }}
+      dnsPolicy: {{ .Values.controller.dnsPolicy }}
       {{- end }}
-      {{- with .Values.node.dnsConfig }}
+      {{- with .Values.controller.dnsConfig }}
       dnsConfig: {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:

--- a/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
+++ b/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
@@ -6,6 +6,9 @@ metadata:
   name: efs-csi-controller
   labels:
     app.kubernetes.io/name: {{ include "aws-efs-csi-driver.name" . }}
+    {{- with .Values.controller.additionalLabels }}
+    {{ toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
@@ -23,10 +26,16 @@ spec:
         app: efs-csi-controller
         app.kubernetes.io/name: {{ include "aws-efs-csi-driver.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- with .Values.controller.podLabels }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
       {{- with .Values.controller.podAnnotations }}
       annotations: {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      {{- if hasKey .Values.controller "hostNetwork" }}
+      hostNetwork: {{ .Values.controller.hostNetwork }}
+      {{- end }}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- range .Values.imagePullSecrets }}
@@ -39,7 +48,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       serviceAccountName: {{ .Values.controller.serviceAccount.name }}
-      priorityClassName: system-cluster-critical
+      priorityClassName: {{ .Values.controller.priorityClassName | default "system-cluster-critical" }}
       {{- with .Values.controller.tolerations }}
       tolerations: {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -47,10 +56,18 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.controller.dnsPolicy }}
+      dnsPolicy: {{ .Values.node.dnsPolicy }}
+      {{- end }}
+      {{- with .Values.node.dnsConfig }}
+      dnsConfig: {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: efs-plugin
+          {{- with .Values.controller.containerSecurityContext }}
           securityContext:
-            privileged: true
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           image: {{ printf "%s:%s" .Values.image.repository (default (printf "v%s" .Chart.AppVersion) (toString .Values.image.tag)) }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
@@ -105,6 +122,12 @@ spec:
             - --extra-create-metadata
             {{- end }}
             - --leader-election
+            {{- if hasKey .Values.controller "leaderElectionRenewDeadline" }}
+            - --leader-election-renew-deadline={{ .Values.controller.leaderElectionRenewDeadline }}
+            {{- end }}
+            {{- if hasKey .Values.controller "leaderElectionLeaseDuration" }}
+            - --leader-election-lease-duration={{ .Values.controller.leaderElectionLeaseDuration }}
+            {{- end }}
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock

--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -101,6 +101,7 @@ controller:
     runAsGroup: 0
     fsGroup: 0
   # securityContext on the controller container
+  # Setting privileged=false will cause the "delete-access-point-root-dir" controller option to fail
   containerSecurityContext:
     privileged: true
   leaderElectionRenewDeadline: 10s

--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -63,6 +63,12 @@ controller:
   # path on efs when deleteing an access point
   deleteAccessPointRootDir: false
   podAnnotations: {}
+  podLabel: {}
+  hostNetwork: false
+  priorityClassName: system-cluster-critical
+  dnsPolicy: ClusterFirst
+  dnsConfig: {}
+  additionalLabels: {}
   resources:
     {}
     # We usually recommend not to specify default resources and to leave this as a conscious
@@ -94,6 +100,11 @@ controller:
     runAsUser: 0
     runAsGroup: 0
     fsGroup: 0
+  # securityContext on the controller container
+  containerSecurityContext:
+    privileged: true
+  leaderElectionRenewDeadline: 10s
+  leaderElectionLeaseDuration: 15s
 
 
 ## Node daemonset variables


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
New feature

**What is this PR about? / Why do we need it?**
Adding following support/flexibility in Controller Deployment Helm chart template:
- additionalLabels: To append additional Deployment labels.
- podLabels: To append additional Pod labels.
- hostNetwork: For flexibility of defining true or false.
- priorityClassName:  For flexibility of defining custom priorityClassName.
- dnsPolicy:  For flexibility of defining different dnsPolicy.
- dnsConfig: For flexibility of defining custom dnsConfig.
- leaderElectionRenewDeadline & leaderElectionLeaseDuration: For defining csi-provisioner parameters.
- containerSecurityContext:  For flexibility of defining SecurityContext on container.


**What testing is done?** 
Manual/CI