### PR TITLE
Bump the side-cars to the latest

### DIFF
--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -18,7 +18,7 @@ sidecars:
   livenessProbe:
     image:
       repository: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe
-      tag: v2.10.0-eks-1-27-3
+      tag: v2.10.0-eks-1-28-4
       pullPolicy: IfNotPresent
     resources: {}
     securityContext:
@@ -27,7 +27,7 @@ sidecars:
   nodeDriverRegistrar:
     image:
       repository: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar
-      tag: v2.8.0-eks-1-27-3
+      tag: v2.8.0-eks-1-28-4
       pullPolicy: IfNotPresent
     resources: {}
     securityContext:
@@ -36,7 +36,7 @@ sidecars:
   csiProvisioner:
     image:
       repository: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner
-      tag: v3.5.0-eks-1-27-3
+      tag: v3.5.0-eks-1-28-4
       pullPolicy: IfNotPresent
     resources: {}
     securityContext:

--- a/deploy/kubernetes/base/controller-deployment.yaml
+++ b/deploy/kubernetes/base/controller-deployment.yaml
@@ -64,7 +64,7 @@ spec:
             periodSeconds: 10
             failureThreshold: 5
         - name: csi-provisioner
-          image: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner:v3.5.0-eks-1-27-3
+          image: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner:v3.5.0-eks-1-28-4
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)
@@ -82,7 +82,7 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
         - name: liveness-probe
-          image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.10.0-eks-1-27-3
+          image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.10.0-eks-1-28-4
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=/csi/csi.sock

--- a/deploy/kubernetes/base/node-daemonset.yaml
+++ b/deploy/kubernetes/base/node-daemonset.yaml
@@ -87,7 +87,7 @@ spec:
             periodSeconds: 2
             failureThreshold: 5
         - name: csi-driver-registrar
-          image: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar:v2.8.0-eks-1-27-3
+          image: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar:v2.8.0-eks-1-28-4
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)
@@ -111,7 +111,7 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
         - name: liveness-probe
-          image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.10.0-eks-1-27-3
+          image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.10.0-eks-1-28-4
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=/csi/csi.sock

--- a/deploy/kubernetes/overlays/stable/ecr/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/ecr/kustomization.yaml
@@ -8,10 +8,10 @@ images:
     newTag: v1.7.0
   - name: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe
     newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/livenessprobe
-    newTag: v2.10.0-eks-1-27-3
+    newTag: v2.10.0-eks-1-28-4
   - name: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar
     newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-node-driver-registrar
-    newTag: v2.8.0-eks-1-27-3
+    newTag: v2.8.0-eks-1-28-4
   - name: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner
     newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-provisioner
-    newTag: v3.5.0-eks-1-27-3
+    newTag: v3.5.0-eks-1-28-4

--- a/deploy/kubernetes/overlays/stable/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/kustomization.yaml
@@ -6,8 +6,8 @@ images:
   - name: amazon/aws-efs-csi-driver
     newTag: v1.7.0
   - name: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe
-    newTag: v2.10.0-eks-1-27-3
+    newTag: v2.10.0-eks-1-28-4
   - name: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar
-    newTag: v2.8.0-eks-1-27-3
+    newTag: v2.8.0-eks-1-28-4
   - name: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner
-    newTag: v3.5.0-eks-1-27-3
+    newTag: v3.5.0-eks-1-28-4


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Bump the side-cars to the latest

**What is this PR about? / Why do we need it?**

**What testing is done?** 
 The e2e has this test case to test the private images and also manual testing
 ```
 Normal  Scheduled  38s   default-scheduler  Successfully assigned kube-system/efs-csi-node-w22v7 to ip-192-168-20-163.ec2.internal
  Normal  Pulled     38s   kubelet            Container image "602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/aws-efs-csi-driver:v1.7.0" already present on machine
  Normal  Created    38s   kubelet            Created container efs-plugin
  Normal  Started    38s   kubelet            Started container efs-plugin
  Normal  Pulled     38s   kubelet            Container image "602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-node-driver-registrar:v2.8.0-eks-1-28-4" already present on machine
  Normal  Created    38s   kubelet            Created container csi-driver-registrar
  Normal  Started    38s   kubelet            Started container csi-driver-registrar
  Normal  Pulled     38s   kubelet            Container image "602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/livenessprobe:v2.10.0-eks-1-28-4" already present on machine
  Normal  Created    38s   kubelet            Created container liveness-probe
  Normal  Started    37s   kubelet            Started container liveness-probe
```
