### PR TITLE
Fix storage class api version

### DIFF
--- a/examples/kubernetes/statefulset/specs/example.yaml
+++ b/examples/kubernetes/statefulset/specs/example.yaml
@@ -20,7 +20,7 @@ spec:
     driver: efs.csi.aws.com
     volumeHandle: fs-4af69aab
 ---
-apiVersion: v1
+apiVersion: storage.k8s.io/v1
 kind: PersistentVolumeClaim
 metadata:
   name: efs-claim

--- a/examples/kubernetes/static_provisioning/specs/storageclass.yaml
+++ b/examples/kubernetes/static_provisioning/specs/storageclass.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: efs-sc


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

bug fix

**What is this PR about? / Why do we need it?**

The previous yaml definition for storage classes were using a wrong api version which resulted in this error: `no matches for kind "StorageClass" in version "v1"`

This PR address this issue by replacing the API version for the storage class to use the right attribute: `storage.k8s.io/v1`

**What testing is done?** 

by using:
```
kubectl apply -f storage-class.yaml
```

it should apply your storage class correctly

verify that with:

```
$ kubectl get storageclass
NAME            PROVISIONER             RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE
efs-sc          efs.csi.aws.com         Delete          Immediate              false                  12m
```