### PR TITLE
Add note on EFS mount target security group

### DIFF
--- a/docs/efs-create-filesystem.md
+++ b/docs/efs-create-filesystem.md
@@ -50,6 +50,10 @@ You must complete the following steps in the same terminal because variables are
           --port 2049 \
           --cidr $cidr_range
       ```
+
+   > [!NOTE]
+   > If using [custom networking](https://aws.github.io/aws-eks-best-practices/networking/custom-networking/) in EKS, you may need to add Security Group ingress rules for your secondary CIDR ranges.
+   
 **Important**  
 To further restrict access to your file system, you can use the CIDR for your subnet instead of the VPC.
 


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Documentation enhancement

**What is this PR about? / Why do we need it?**
Add a note clarifying that the EFS mount target security group may require additional ingress rules for secondary CIDR ranges when secondary networking configurations are used.

**What testing is done?** 
Just finished troubleshooting an EFS CSI driver configuration on a cluster that uses secondary networking. 