### PR TITLE
When listing AccessPoints, check if efs.PosixUser pointer is nil

### DIFF
--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -309,14 +309,21 @@ func (c *cloud) ListAccessPoints(ctx context.Context, fileSystemId string) (acce
 		return
 	}
 
+	var posixUser *PosixUser
 	for _, accessPointDescription := range res.AccessPoints {
+		if accessPointDescription.PosixUser != nil {
+			posixUser = &PosixUser{
+				Gid: *accessPointDescription.PosixUser.Gid,
+				Uid: *accessPointDescription.PosixUser.Gid,
+			}
+		} else {
+			posixUser = nil
+		}
+
 		accessPoint := &AccessPoint{
 			AccessPointId: *accessPointDescription.AccessPointId,
 			FileSystemId:  *accessPointDescription.FileSystemId,
-			PosixUser: &PosixUser{
-				Gid: *accessPointDescription.PosixUser.Gid,
-				Uid: *accessPointDescription.PosixUser.Gid,
-			},
+			PosixUser:     posixUser,
 		}
 		accessPoints = append(accessPoints, accessPoint)
 	}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

This is a fix for the bug reported in issue #1164 

**What is this PR about? / Why do we need it?**

A simple bugfix 

**What testing is done?** 

All unit test passed.