### PR TITLE
Fixed Posixuser nil pointer dereference issue

### DIFF
--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -309,14 +309,20 @@ func (c *cloud) ListAccessPoints(ctx context.Context, fileSystemId string) (acce
 		return
 	}
 
+	var posixUser *PosixUser
 	for _, accessPointDescription := range res.AccessPoints {
+		if accessPointDescription.PosixUser != nil {
+			posixUser = &PosixUser{
+				Gid: *accessPointDescription.PosixUser.Gid,
+				Uid: *accessPointDescription.PosixUser.Gid,
+			}
+		} else {
+			posixUser = nil
+		}
 		accessPoint := &AccessPoint{
 			AccessPointId: *accessPointDescription.AccessPointId,
 			FileSystemId:  *accessPointDescription.FileSystemId,
-			PosixUser: &PosixUser{
-				Gid: *accessPointDescription.PosixUser.Gid,
-				Uid: *accessPointDescription.PosixUser.Gid,
-			},
+			PosixUser:     posixUser,
 		}
 		accessPoints = append(accessPoints, accessPoint)
 	}

--- a/pkg/driver/gid_allocator.go
+++ b/pkg/driver/gid_allocator.go
@@ -76,11 +76,9 @@ func (g *GidAllocator) getUsedGids(ctx context.Context, fsId string) (gids []int
 		if ap == nil {
 			continue
 		}
-		if ap != nil && ap.PosixUser == nil {
-			err = fmt.Errorf("failed to discover used GID because PosixUser is nil for AccessPoint: %s", ap.AccessPointId)
-			return
+		if ap.PosixUser != nil {
+			gids = append(gids, ap.PosixUser.Gid)
 		}
-		gids = append(gids, ap.PosixUser.Gid)
 	}
 	klog.V(5).Infof("Discovered used GIDs: %+v for FS ID: %v", gids, fsId)
 	return


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
This is a Bug fix

**What is this PR about? / Why do we need it?**
When access point is created without PosixUser , efs-csi-driver failed with nil pointer issue while parsing. Added a nil pointer check to fix this issue.

**What testing is done?** 
Manual testing and also added a unit test case around this scenario.