### PR TITLE
allocate GIDs in increasing order

### DIFF
--- a/pkg/driver/gid_allocator.go
+++ b/pkg/driver/gid_allocator.go
@@ -94,7 +94,7 @@ func getNextUnusedGid(usedGids []int64, gidMin, gidMax int) (nextGid int, err er
 
 	var lookup func(usedGids []int64)
 	lookup = func(usedGids []int64) {
-		for gid := gidMax; gid > gidMin; gid-- {
+		for gid := gidMin; gid <= gidMax; gid++ {
 			if !slices.Contains(usedGids, int64(gid)) {
 				nextGid = gid
 				return


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

This is a bug fix/followup for: https://github.com/kubernetes-sigs/aws-efs-csi-driver/pull/850

The patch fixes GID allocator and changes allocation to be in descending order. While this would probably not cause any issues it makes sense to stick to he the original GID allocation which used ascending order.

**What is this PR about? / Why do we need it?**

Existing clusters would start allocating GIDs from highest to lowest which is reversed to what was used before. The range is determined by `gidRangeStart` and `gidRangeEnd` parameters of a storage class. This does not pose any risk, however there is no reason to change the ordering (it was changed by mistake).

**What testing is done?** 

Unit tests + manual verification.

StorageClass used:
```
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: efs-sc1
parameters:
  basePath: /dynamic_provisioning
  directoryPerms: "700"
  fileSystemId: fs-07fe814e87e98c836
  gidRangeEnd: "1005"
  gidRangeStart: "1000"
  provisioningMode: efs-ap
provisioner: efs.csi.aws.com
reclaimPolicy: Delete 
```

GID allocation is ascending with this patch:
```
fsap-07e068fedfe932c08  /dynamic_provisioning/pvc-7398fc4f-fe53-4f6c-ae59-00df2e96bb4a  1000 : 1000     1000 : 1000 (700)        Available
fsap-009d4d170cef6de9c  /dynamic_provisioning/pvc-0a7e9a7b-8fa1-4257-98bc-bec726a53429  1001 : 1001     1001 : 1001 (700)        Available
fsap-0efb1789cd7ad03a4  /dynamic_provisioning/pvc-91799faa-b1eb-47ff-93f5-6bcb97497a88  1002 : 1002     1002 : 1002 (700)        Available
fsap-04c5f99364e5460ce  /dynamic_provisioning/pvc-dd526a47-4418-43d0-9eb9-cf3cfd0c5792  1003 : 1003     1003 : 1003 (700)        Available
fsap-0e4d38626a6a62b5a  /dynamic_provisioning/pvc-b4f802c4-c750-4dc7-842b-6fc5995850b5  1004 : 1004     1004 : 1004 (700)        Available
fsap-07768681aa37cce5b  /dynamic_provisioning/pvc-80e74fe6-2121-47a2-aa1b-a7feaf2990df  1005 : 1005     1005 : 1005 (700)        Available 
```