### PR TITLE
Updated the apiversion in storageclass.yaml

### DIFF
--- a/examples/kubernetes/static_provisioning/specs/storageclass.yaml
+++ b/examples/kubernetes/static_provisioning/specs/storageclass.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: efs-sc


### PR DESCRIPTION
The SC manifest contained a deprecated ApiVersion, updated the same.

**Is this a bug fix or adding new feature?**
Bug Fix

**What is this PR about? / Why do we need it?**
The sc manifest wouldn't work without updating the apiversion, so the efs-csi-driver check is useless without it.

**What testing is done?** 
I deployed the whole stack after updating the apiversion of the sc manifest and it worked absolutely fine.