### PR TITLE
Added Fargate support in the EFS CSI Controller

### DIFF
--- a/pkg/cloud/k8s_metadata.go
+++ b/pkg/cloud/k8s_metadata.go
@@ -44,7 +44,7 @@ func (k kubernetesApiMetadataProvider) getMetadata() (MetadataService, error) {
 		return nil, fmt.Errorf("node providerID empty, cannot parse")
 	}
 
-	re := regexp.MustCompile("i-[a-z0-9]+$")
+	re := regexp.MustCompile("i-[a-z0-9]+$|[a-z0-9]{32}")
 	instanceID := re.FindString(providerId)
 	if instanceID == "" {
 		return nil, fmt.Errorf("did not find aws instance ID in node providerID string")

--- a/pkg/cloud/k8s_metadata_test.go
+++ b/pkg/cloud/k8s_metadata_test.go
@@ -78,6 +78,20 @@ func TestInstanceIdParsedFromProviderIdCorrectly(t *testing.T) {
 	}
 }
 
+func TestTaskIdParsedFromProviderIdCorrectly(t *testing.T) {
+	clientSet := setupKubernetesClient(t, nodeName, createFargateNode())
+	k8sMp := kubernetesApiMetadataProvider{api: clientSet}
+
+	metadata, err := k8sMp.getMetadata()
+
+	if err != nil {
+		t.Fatalf("Error occurred when parsing instance ID, %v", err)
+	}
+	if metadata.GetInstanceID() != taskId {
+		t.Fatalf("Instance ID not extracted correctly, expected %s, got %s", taskId, metadata.GetInstanceID())
+	}
+}
+
 func TestRegionAndZoneExtractedCorrectlyFromLabels(t *testing.T) {
 	clientSet := setupKubernetesClient(t, nodeName, createDefaultNode())
 	k8sMp := kubernetesApiMetadataProvider{api: clientSet}
@@ -122,4 +136,8 @@ func createNode(nodeName string, nodeRegion string, nodeZone string, providerId 
 
 func createDefaultNode() *v1.Node {
 	return createNode(nodeName, nodeRegion, nodeZone, fmt.Sprintf("aws:///%s/%s", nodeZone, instanceId))
+}
+
+func createFargateNode() *v1.Node {
+	return createNode(nodeName, nodeRegion, nodeZone, fmt.Sprintf("aws:///%s/1234567890-%s/%s", nodeZone, taskId, nodeName))
 }


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
bug fix

**What is this PR about? / Why do we need it?**
Current controller can use Kubernetes metadata to get node's instance ID from node's ProviderID. However, on Fargate, the ProviderID of Fargate node has different pattern than an EC2 instance ID. I am adding a fix that will pull the task ID from Fargate node ProviderID and allow CSI Controller to run as Fargate pod. This PR will fix kubernetes-sigs/aws-efs-csi-driver#1100

**What testing is done?** 
- Unit tests added
- Manual testing in Fargate environment