### PR TITLE
Adding APA and FFZ regions to watchdog config template

### DIFF
--- a/pkg/driver/efs_watch_dog.go
+++ b/pkg/driver/efs_watch_dog.go
@@ -85,9 +85,16 @@ dns_name_suffix = amazonaws.com.cn
 [mount.cn-northwest-1]
 dns_name_suffix = amazonaws.com.cn
 
+[mount.us-iso-west-1]
+dns_name_suffix = c2s.ic.gov
+stunnel_cafile = /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
 
 [mount.us-iso-east-1]
 dns_name_suffix = c2s.ic.gov
+stunnel_cafile = /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+
+[mount.us-isob-west-1]
+dns_name_suffix = sc2s.sgov.gov
 stunnel_cafile = /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
 
 [mount.us-isob-east-1]

--- a/pkg/driver/efs_watch_dog_test.go
+++ b/pkg/driver/efs_watch_dog_test.go
@@ -75,9 +75,16 @@ dns_name_suffix = amazonaws.com.cn
 [mount.cn-northwest-1]
 dns_name_suffix = amazonaws.com.cn
 
+[mount.us-iso-west-1]
+dns_name_suffix = c2s.ic.gov
+stunnel_cafile = /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
 
 [mount.us-iso-east-1]
 dns_name_suffix = c2s.ic.gov
+stunnel_cafile = /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+
+[mount.us-isob-west-1]
+dns_name_suffix = sc2s.sgov.gov
 stunnel_cafile = /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
 
 [mount.us-isob-east-1]


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Sort of both. It's a bug because it's preventing the driver from working in new ADC regions but it will enable the driver in the regions so it's kind of a feature too.

**What is this PR about? / Why do we need it?**
This is to enable the driver to run in two new dedicated regions.

**What testing is done?** 
Changes were manually tested in dedicated regions and fixed the issue.
