### PR TITLE
make gid allocator work with cross account feature

### DIFF
--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -254,7 +254,7 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 
 	var allocatedGid int64
 	if uid == -1 || gid == -1 {
-		allocatedGid, err = d.gidAllocator.getNextGid(ctx, accessPointsOptions.FileSystemId, gidMin, gidMax)
+		allocatedGid, err = d.gidAllocator.getNextGid(ctx, localCloud, accessPointsOptions.FileSystemId, gidMin, gidMax)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/driver/controller_test.go
+++ b/pkg/driver/controller_test.go
@@ -49,7 +49,7 @@ func TestCreateVolume(t *testing.T) {
 				driver := &Driver{
 					endpoint:     endpoint,
 					cloud:        mockCloud,
-					gidAllocator: NewGidAllocator(mockCloud),
+					gidAllocator: NewGidAllocator(),
 				}
 
 				req := &csi.CreateVolumeRequest{
@@ -114,7 +114,7 @@ func TestCreateVolume(t *testing.T) {
 				driver := &Driver{
 					endpoint:     endpoint,
 					cloud:        mockCloud,
-					gidAllocator: NewGidAllocator(mockCloud),
+					gidAllocator: NewGidAllocator(),
 				}
 
 				req := &csi.CreateVolumeRequest{
@@ -181,7 +181,7 @@ func TestCreateVolume(t *testing.T) {
 				driver := &Driver{
 					endpoint:     endpoint,
 					cloud:        mockCloud,
-					gidAllocator: NewGidAllocator(mockCloud),
+					gidAllocator: NewGidAllocator(),
 				}
 
 				req := &csi.CreateVolumeRequest{
@@ -267,7 +267,7 @@ func TestCreateVolume(t *testing.T) {
 				driver := &Driver{
 					endpoint:     endpoint,
 					cloud:        mockCloud,
-					gidAllocator: NewGidAllocator(mockCloud),
+					gidAllocator: NewGidAllocator(),
 				}
 
 				req := &csi.CreateVolumeRequest{
@@ -402,7 +402,7 @@ func TestCreateVolume(t *testing.T) {
 				driver := &Driver{
 					endpoint:     endpoint,
 					cloud:        mockCloud,
-					gidAllocator: NewGidAllocator(mockCloud),
+					gidAllocator: NewGidAllocator(),
 				}
 
 				req := &csi.CreateVolumeRequest{
@@ -497,7 +497,7 @@ func TestCreateVolume(t *testing.T) {
 				driver := &Driver{
 					endpoint:     endpoint,
 					cloud:        mockCloud,
-					gidAllocator: NewGidAllocator(mockCloud),
+					gidAllocator: NewGidAllocator(),
 					tags:         parseTagsFromStr(""),
 				}
 
@@ -561,7 +561,7 @@ func TestCreateVolume(t *testing.T) {
 				driver := &Driver{
 					endpoint:     endpoint,
 					cloud:        mockCloud,
-					gidAllocator: NewGidAllocator(mockCloud),
+					gidAllocator: NewGidAllocator(),
 				}
 
 				req := &csi.CreateVolumeRequest{
@@ -621,7 +621,7 @@ func TestCreateVolume(t *testing.T) {
 				driver := &Driver{
 					endpoint:     endpoint,
 					cloud:        mockCloud,
-					gidAllocator: NewGidAllocator(mockCloud),
+					gidAllocator: NewGidAllocator(),
 					tags:         parseTagsFromStr("cluster:efs"),
 				}
 
@@ -684,7 +684,7 @@ func TestCreateVolume(t *testing.T) {
 				driver := &Driver{
 					endpoint:     endpoint,
 					cloud:        mockCloud,
-					gidAllocator: NewGidAllocator(mockCloud),
+					gidAllocator: NewGidAllocator(),
 					tags:         parseTagsFromStr("cluster-efs"),
 				}
 
@@ -747,7 +747,7 @@ func TestCreateVolume(t *testing.T) {
 				driver := &Driver{
 					endpoint:     endpoint,
 					cloud:        mockCloud,
-					gidAllocator: NewGidAllocator(mockCloud),
+					gidAllocator: NewGidAllocator(),
 					tags:         parseTagsFromStr(""),
 				}
 				pvcNameVal := "test-pvc"
@@ -816,7 +816,7 @@ func TestCreateVolume(t *testing.T) {
 				driver := &Driver{
 					endpoint:     endpoint,
 					cloud:        mockCloud,
-					gidAllocator: NewGidAllocator(mockCloud),
+					gidAllocator: NewGidAllocator(),
 					tags:         parseTagsFromStr(""),
 				}
 
@@ -890,7 +890,7 @@ func TestCreateVolume(t *testing.T) {
 				driver := &Driver{
 					endpoint:     endpoint,
 					cloud:        mockCloud,
-					gidAllocator: NewGidAllocator(mockCloud),
+					gidAllocator: NewGidAllocator(),
 					tags:         parseTagsFromStr(""),
 				}
 
@@ -962,7 +962,7 @@ func TestCreateVolume(t *testing.T) {
 				driver := &Driver{
 					endpoint:     endpoint,
 					cloud:        mockCloud,
-					gidAllocator: NewGidAllocator(mockCloud),
+					gidAllocator: NewGidAllocator(),
 					tags:         parseTagsFromStr(""),
 				}
 
@@ -1037,7 +1037,7 @@ func TestCreateVolume(t *testing.T) {
 				driver := &Driver{
 					endpoint:     endpoint,
 					cloud:        mockCloud,
-					gidAllocator: NewGidAllocator(mockCloud),
+					gidAllocator: NewGidAllocator(),
 					tags:         parseTagsFromStr(""),
 				}
 
@@ -1113,7 +1113,7 @@ func TestCreateVolume(t *testing.T) {
 				driver := &Driver{
 					endpoint:     endpoint,
 					cloud:        mockCloud,
-					gidAllocator: NewGidAllocator(mockCloud),
+					gidAllocator: NewGidAllocator(),
 					tags:         parseTagsFromStr(""),
 				}
 
@@ -1186,7 +1186,7 @@ func TestCreateVolume(t *testing.T) {
 				driver := &Driver{
 					endpoint:     endpoint,
 					cloud:        mockCloud,
-					gidAllocator: NewGidAllocator(mockCloud),
+					gidAllocator: NewGidAllocator(),
 					tags:         parseTagsFromStr(""),
 				}
 
@@ -1255,7 +1255,7 @@ func TestCreateVolume(t *testing.T) {
 				driver := &Driver{
 					endpoint:     endpoint,
 					cloud:        mockCloud,
-					gidAllocator: NewGidAllocator(mockCloud),
+					gidAllocator: NewGidAllocator(),
 					tags:         parseTagsFromStr(""),
 				}
 
@@ -1325,7 +1325,7 @@ func TestCreateVolume(t *testing.T) {
 				driver := &Driver{
 					endpoint:     endpoint,
 					cloud:        mockCloud,
-					gidAllocator: NewGidAllocator(mockCloud),
+					gidAllocator: NewGidAllocator(),
 					tags:         parseTagsFromStr(""),
 				}
 
@@ -1397,7 +1397,7 @@ func TestCreateVolume(t *testing.T) {
 				driver := &Driver{
 					endpoint:     endpoint,
 					cloud:        mockCloud,
-					gidAllocator: NewGidAllocator(mockCloud),
+					gidAllocator: NewGidAllocator(),
 				}
 
 				req := &csi.CreateVolumeRequest{
@@ -1425,7 +1425,7 @@ func TestCreateVolume(t *testing.T) {
 				driver := &Driver{
 					endpoint:     endpoint,
 					cloud:        mockCloud,
-					gidAllocator: NewGidAllocator(mockCloud),
+					gidAllocator: NewGidAllocator(),
 				}
 
 				req := &csi.CreateVolumeRequest{
@@ -1454,7 +1454,7 @@ func TestCreateVolume(t *testing.T) {
 				driver := &Driver{
 					endpoint:     endpoint,
 					cloud:        mockCloud,
-					gidAllocator: NewGidAllocator(mockCloud),
+					gidAllocator: NewGidAllocator(),
 				}
 
 				req := &csi.CreateVolumeRequest{
@@ -1486,7 +1486,7 @@ func TestCreateVolume(t *testing.T) {
 				driver := &Driver{
 					endpoint:     endpoint,
 					cloud:        mockCloud,
-					gidAllocator: NewGidAllocator(mockCloud),
+					gidAllocator: NewGidAllocator(),
 				}
 
 				req := &csi.CreateVolumeRequest{
@@ -1528,7 +1528,7 @@ func TestCreateVolume(t *testing.T) {
 				driver := &Driver{
 					endpoint:     endpoint,
 					cloud:        mockCloud,
-					gidAllocator: NewGidAllocator(mockCloud),
+					gidAllocator: NewGidAllocator(),
 					tags:         parseTagsFromStr(""),
 				}
 
@@ -1576,7 +1576,7 @@ func TestCreateVolume(t *testing.T) {
 				driver := &Driver{
 					endpoint:     endpoint,
 					cloud:        mockCloud,
-					gidAllocator: NewGidAllocator(mockCloud),
+					gidAllocator: NewGidAllocator(),
 				}
 
 				req := &csi.CreateVolumeRequest{
@@ -1618,7 +1618,7 @@ func TestCreateVolume(t *testing.T) {
 				driver := &Driver{
 					endpoint:     endpoint,
 					cloud:        mockCloud,
-					gidAllocator: NewGidAllocator(mockCloud),
+					gidAllocator: NewGidAllocator(),
 				}
 
 				req := &csi.CreateVolumeRequest{
@@ -1653,7 +1653,7 @@ func TestCreateVolume(t *testing.T) {
 				driver := &Driver{
 					endpoint:     endpoint,
 					cloud:        mockCloud,
-					gidAllocator: NewGidAllocator(mockCloud),
+					gidAllocator: NewGidAllocator(),
 				}
 
 				req := &csi.CreateVolumeRequest{
@@ -1687,7 +1687,7 @@ func TestCreateVolume(t *testing.T) {
 				driver := &Driver{
 					endpoint:     endpoint,
 					cloud:        mockCloud,
-					gidAllocator: NewGidAllocator(mockCloud),
+					gidAllocator: NewGidAllocator(),
 				}
 
 				req := &csi.CreateVolumeRequest{
@@ -1721,7 +1721,7 @@ func TestCreateVolume(t *testing.T) {
 				driver := &Driver{
 					endpoint:     endpoint,
 					cloud:        mockCloud,
-					gidAllocator: NewGidAllocator(mockCloud),
+					gidAllocator: NewGidAllocator(),
 				}
 
 				req := &csi.CreateVolumeRequest{
@@ -1756,7 +1756,7 @@ func TestCreateVolume(t *testing.T) {
 				driver := &Driver{
 					endpoint:     endpoint,
 					cloud:        mockCloud,
-					gidAllocator: NewGidAllocator(mockCloud),
+					gidAllocator: NewGidAllocator(),
 				}
 
 				req := &csi.CreateVolumeRequest{
@@ -1792,7 +1792,7 @@ func TestCreateVolume(t *testing.T) {
 				driver := &Driver{
 					endpoint:     endpoint,
 					cloud:        mockCloud,
-					gidAllocator: NewGidAllocator(mockCloud),
+					gidAllocator: NewGidAllocator(),
 				}
 
 				req := &csi.CreateVolumeRequest{
@@ -1828,7 +1828,7 @@ func TestCreateVolume(t *testing.T) {
 				driver := &Driver{
 					endpoint:     endpoint,
 					cloud:        mockCloud,
-					gidAllocator: NewGidAllocator(mockCloud),
+					gidAllocator: NewGidAllocator(),
 				}
 
 				req := &csi.CreateVolumeRequest{
@@ -1864,7 +1864,7 @@ func TestCreateVolume(t *testing.T) {
 				driver := &Driver{
 					endpoint:     endpoint,
 					cloud:        mockCloud,
-					gidAllocator: NewGidAllocator(mockCloud),
+					gidAllocator: NewGidAllocator(),
 				}
 
 				req := &csi.CreateVolumeRequest{
@@ -1900,7 +1900,7 @@ func TestCreateVolume(t *testing.T) {
 				driver := &Driver{
 					endpoint:     endpoint,
 					cloud:        mockCloud,
-					gidAllocator: NewGidAllocator(mockCloud),
+					gidAllocator: NewGidAllocator(),
 				}
 
 				req := &csi.CreateVolumeRequest{
@@ -1936,7 +1936,7 @@ func TestCreateVolume(t *testing.T) {
 				driver := &Driver{
 					endpoint:     endpoint,
 					cloud:        mockCloud,
-					gidAllocator: NewGidAllocator(mockCloud),
+					gidAllocator: NewGidAllocator(),
 				}
 
 				req := &csi.CreateVolumeRequest{
@@ -1972,7 +1972,7 @@ func TestCreateVolume(t *testing.T) {
 				driver := &Driver{
 					endpoint:     endpoint,
 					cloud:        mockCloud,
-					gidAllocator: NewGidAllocator(mockCloud),
+					gidAllocator: NewGidAllocator(),
 				}
 
 				req := &csi.CreateVolumeRequest{
@@ -2009,7 +2009,7 @@ func TestCreateVolume(t *testing.T) {
 				driver := &Driver{
 					endpoint:     endpoint,
 					cloud:        mockCloud,
-					gidAllocator: NewGidAllocator(mockCloud),
+					gidAllocator: NewGidAllocator(),
 				}
 
 				req := &csi.CreateVolumeRequest{
@@ -2046,7 +2046,7 @@ func TestCreateVolume(t *testing.T) {
 				driver := &Driver{
 					endpoint:     endpoint,
 					cloud:        mockCloud,
-					gidAllocator: NewGidAllocator(mockCloud),
+					gidAllocator: NewGidAllocator(),
 				}
 
 				req := &csi.CreateVolumeRequest{
@@ -2082,7 +2082,7 @@ func TestCreateVolume(t *testing.T) {
 				driver := &Driver{
 					endpoint:     endpoint,
 					cloud:        mockCloud,
-					gidAllocator: NewGidAllocator(mockCloud),
+					gidAllocator: NewGidAllocator(),
 				}
 
 				req := &csi.CreateVolumeRequest{
@@ -2118,7 +2118,7 @@ func TestCreateVolume(t *testing.T) {
 				driver := &Driver{
 					endpoint:     endpoint,
 					cloud:        mockCloud,
-					gidAllocator: NewGidAllocator(mockCloud),
+					gidAllocator: NewGidAllocator(),
 				}
 
 				req := &csi.CreateVolumeRequest{
@@ -2156,7 +2156,7 @@ func TestCreateVolume(t *testing.T) {
 				driver := &Driver{
 					endpoint:     endpoint,
 					cloud:        mockCloud,
-					gidAllocator: NewGidAllocator(mockCloud),
+					gidAllocator: NewGidAllocator(),
 				}
 
 				req := &csi.CreateVolumeRequest{
@@ -2194,7 +2194,7 @@ func TestCreateVolume(t *testing.T) {
 				driver := &Driver{
 					endpoint:     endpoint,
 					cloud:        mockCloud,
-					gidAllocator: NewGidAllocator(mockCloud),
+					gidAllocator: NewGidAllocator(),
 				}
 
 				req := &csi.CreateVolumeRequest{
@@ -2232,7 +2232,7 @@ func TestCreateVolume(t *testing.T) {
 				driver := &Driver{
 					endpoint:     endpoint,
 					cloud:        mockCloud,
-					gidAllocator: NewGidAllocator(mockCloud),
+					gidAllocator: NewGidAllocator(),
 				}
 
 				req := &csi.CreateVolumeRequest{
@@ -2275,7 +2275,7 @@ func TestCreateVolume(t *testing.T) {
 				driver := &Driver{
 					endpoint:     endpoint,
 					cloud:        mockCloud,
-					gidAllocator: NewGidAllocator(mockCloud),
+					gidAllocator: NewGidAllocator(),
 				}
 
 				req := &csi.CreateVolumeRequest{
@@ -2318,7 +2318,7 @@ func TestCreateVolume(t *testing.T) {
 				driver := &Driver{
 					endpoint:     endpoint,
 					cloud:        mockCloud,
-					gidAllocator: NewGidAllocator(mockCloud),
+					gidAllocator: NewGidAllocator(),
 				}
 
 				req := &csi.CreateVolumeRequest{
@@ -2381,7 +2381,7 @@ func TestCreateVolume(t *testing.T) {
 				driver := &Driver{
 					endpoint:     endpoint,
 					cloud:        mockCloud,
-					gidAllocator: NewGidAllocator(mockCloud),
+					gidAllocator: NewGidAllocator(),
 					tags:         parseTagsFromStr(""),
 				}
 
@@ -2429,7 +2429,7 @@ func TestCreateVolume(t *testing.T) {
 				driver := &Driver{
 					endpoint:     endpoint,
 					cloud:        mockCloud,
-					gidAllocator: NewGidAllocator(mockCloud),
+					gidAllocator: NewGidAllocator(),
 				}
 
 				req := &csi.CreateVolumeRequest{
@@ -2478,7 +2478,7 @@ func TestCreateVolume(t *testing.T) {
 				driver := &Driver{
 					endpoint:     endpoint,
 					cloud:        mockCloud,
-					gidAllocator: NewGidAllocator(mockCloud),
+					gidAllocator: NewGidAllocator(),
 				}
 
 				req := &csi.CreateVolumeRequest{
@@ -2527,7 +2527,7 @@ func TestCreateVolume(t *testing.T) {
 				driver := &Driver{
 					endpoint:     endpoint,
 					cloud:        mockCloud,
-					gidAllocator: NewGidAllocator(mockCloud),
+					gidAllocator: NewGidAllocator(),
 				}
 
 				req := &csi.CreateVolumeRequest{
@@ -2593,7 +2593,7 @@ func TestDeleteVolume(t *testing.T) {
 				driver := &Driver{
 					endpoint:     endpoint,
 					cloud:        mockCloud,
-					gidAllocator: NewGidAllocator(mockCloud),
+					gidAllocator: NewGidAllocator(),
 				}
 
 				req := &csi.DeleteVolumeRequest{
@@ -2620,7 +2620,7 @@ func TestDeleteVolume(t *testing.T) {
 					endpoint:                 endpoint,
 					cloud:                    mockCloud,
 					mounter:                  mockMounter,
-					gidAllocator:             NewGidAllocator(mockCloud),
+					gidAllocator:             NewGidAllocator(),
 					deleteAccessPointRootDir: true,
 				}
 
@@ -2659,7 +2659,7 @@ func TestDeleteVolume(t *testing.T) {
 					endpoint:                 endpoint,
 					cloud:                    mockCloud,
 					mounter:                  mockMounter,
-					gidAllocator:             NewGidAllocator(mockCloud),
+					gidAllocator:             NewGidAllocator(),
 					deleteAccessPointRootDir: true,
 				}
 
@@ -2687,7 +2687,7 @@ func TestDeleteVolume(t *testing.T) {
 					endpoint:                 endpoint,
 					cloud:                    mockCloud,
 					mounter:                  mockMounter,
-					gidAllocator:             NewGidAllocator(mockCloud),
+					gidAllocator:             NewGidAllocator(),
 					deleteAccessPointRootDir: true,
 				}
 
@@ -2715,7 +2715,7 @@ func TestDeleteVolume(t *testing.T) {
 					endpoint:                 endpoint,
 					cloud:                    mockCloud,
 					mounter:                  mockMounter,
-					gidAllocator:             NewGidAllocator(mockCloud),
+					gidAllocator:             NewGidAllocator(),
 					deleteAccessPointRootDir: true,
 				}
 
@@ -2743,7 +2743,7 @@ func TestDeleteVolume(t *testing.T) {
 					endpoint:                 endpoint,
 					cloud:                    mockCloud,
 					mounter:                  mockMounter,
-					gidAllocator:             NewGidAllocator(mockCloud),
+					gidAllocator:             NewGidAllocator(),
 					deleteAccessPointRootDir: true,
 				}
 
@@ -2779,7 +2779,7 @@ func TestDeleteVolume(t *testing.T) {
 					endpoint:                 endpoint,
 					cloud:                    mockCloud,
 					mounter:                  mockMounter,
-					gidAllocator:             NewGidAllocator(mockCloud),
+					gidAllocator:             NewGidAllocator(),
 					deleteAccessPointRootDir: true,
 				}
 
@@ -2816,7 +2816,7 @@ func TestDeleteVolume(t *testing.T) {
 					endpoint:                 endpoint,
 					cloud:                    mockCloud,
 					mounter:                  mockMounter,
-					gidAllocator:             NewGidAllocator(mockCloud),
+					gidAllocator:             NewGidAllocator(),
 					deleteAccessPointRootDir: true,
 				}
 
@@ -2852,7 +2852,7 @@ func TestDeleteVolume(t *testing.T) {
 				driver := &Driver{
 					endpoint:     endpoint,
 					cloud:        mockCloud,
-					gidAllocator: NewGidAllocator(mockCloud),
+					gidAllocator: NewGidAllocator(),
 				}
 
 				req := &csi.DeleteVolumeRequest{
@@ -2877,7 +2877,7 @@ func TestDeleteVolume(t *testing.T) {
 				driver := &Driver{
 					endpoint:     endpoint,
 					cloud:        mockCloud,
-					gidAllocator: NewGidAllocator(mockCloud),
+					gidAllocator: NewGidAllocator(),
 				}
 
 				req := &csi.DeleteVolumeRequest{
@@ -2902,7 +2902,7 @@ func TestDeleteVolume(t *testing.T) {
 				driver := &Driver{
 					endpoint:     endpoint,
 					cloud:        mockCloud,
-					gidAllocator: NewGidAllocator(mockCloud),
+					gidAllocator: NewGidAllocator(),
 				}
 
 				req := &csi.DeleteVolumeRequest{
@@ -2927,7 +2927,7 @@ func TestDeleteVolume(t *testing.T) {
 				driver := &Driver{
 					endpoint:     endpoint,
 					cloud:        mockCloud,
-					gidAllocator: NewGidAllocator(mockCloud),
+					gidAllocator: NewGidAllocator(),
 				}
 
 				req := &csi.DeleteVolumeRequest{
@@ -2951,7 +2951,7 @@ func TestDeleteVolume(t *testing.T) {
 				driver := &Driver{
 					endpoint:     endpoint,
 					cloud:        mockCloud,
-					gidAllocator: NewGidAllocator(mockCloud),
+					gidAllocator: NewGidAllocator(),
 					tags:         parseTagsFromStr(""),
 				}
 

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -69,7 +69,7 @@ func NewDriver(endpoint, efsUtilsCfgPath, efsUtilsStaticFilesPath, tags string, 
 		volMetricsOptIn:          volMetricsOptIn,
 		volMetricsRefreshPeriod:  volMetricsRefreshPeriod,
 		volMetricsFsRateLimit:    volMetricsFsRateLimit,
-		gidAllocator:             NewGidAllocator(cloud),
+		gidAllocator:             NewGidAllocator(),
 		deleteAccessPointRootDir: deleteAccessPointRootDir,
 		tags:                     parseTagsFromStr(strings.TrimSpace(tags)),
 	}

--- a/pkg/driver/gid_allocator.go
+++ b/pkg/driver/gid_allocator.go
@@ -20,26 +20,24 @@ type FilesystemID struct {
 }
 
 type GidAllocator struct {
-	cloud      cloud.Cloud
 	fsIdGidMap map[string]*FilesystemID
 	mu         sync.Mutex
 }
 
-func NewGidAllocator(cloud cloud.Cloud) GidAllocator {
+func NewGidAllocator() GidAllocator {
 	return GidAllocator{
-		cloud:      cloud,
 		fsIdGidMap: make(map[string]*FilesystemID),
 	}
 }
 
 // Retrieves the next available GID
-func (g *GidAllocator) getNextGid(ctx context.Context, fsId string, gidMin, gidMax int) (int64, error) {
+func (g *GidAllocator) getNextGid(ctx context.Context, localCloud cloud.Cloud, fsId string, gidMin, gidMax int) (int64, error) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 
 	klog.V(5).Infof("Recieved getNextGid for fsId: %v, min: %v, max: %v", fsId, gidMin, gidMax)
 
-	usedGids, err := g.getUsedGids(ctx, fsId)
+	usedGids, err := g.getUsedGids(ctx, localCloud, fsId)
 	if err != nil {
 		return 0, status.Errorf(codes.Internal, "Failed to discover used GIDs for filesystem: %v: %v ", fsId, err)
 	}
@@ -61,9 +59,9 @@ func (g *GidAllocator) removeFsId(fsId string) {
 	delete(g.fsIdGidMap, fsId)
 }
 
-func (g *GidAllocator) getUsedGids(ctx context.Context, fsId string) (gids []int64, err error) {
+func (g *GidAllocator) getUsedGids(ctx context.Context, localCloud cloud.Cloud, fsId string) (gids []int64, err error) {
 	gids = []int64{}
-	accessPoints, err := g.cloud.ListAccessPoints(ctx, fsId)
+	accessPoints, err := localCloud.ListAccessPoints(ctx, fsId)
 	if err != nil {
 		err = fmt.Errorf("failed to list access points: %v", err)
 		return

--- a/pkg/driver/sanity_test.go
+++ b/pkg/driver/sanity_test.go
@@ -79,7 +79,7 @@ func TestSanityEFSCSI(t *testing.T) {
 		nodeCaps:        nodeCaps,
 		volMetricsOptIn: true,
 		volStatter:      NewVolStatter(),
-		gidAllocator:    NewGidAllocator(mockCloud),
+		gidAllocator:    NewGidAllocator(),
 	}
 	defer func() {
 		if r := recover(); r != nil {


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

Bug.

**What is this PR about? / Why do we need it?**

Cross account feature is broken.  GID allocator must use `localCloud` created during `CreateVolume` which takes cross account feature into account. Without this change the driver attempts to list/describe access points and fails:

```
  Warning  ProvisioningFailed  29m (x6 over 47m)  efs.csi.aws.com_ip-10-0-30-56_e49a0a8c-a449-4a7c-bee5-9113112cd270  (combined from similar events): failed to provision volume with StorageClass "efs-crossaccount-sc": rpc error: code = Internal desc = Failed to discover used GIDs for filesystem: fs-04cbcb7d2b03a38a4: failed to list access points: FileSystemNotFound: File system 'fs-04cbcb7d2b03a38a4' does not exist.
{
  RespMetadata: {
    StatusCode: 404,
    RequestID: "1474ec74-cd0c-4a4d-b363-f792418b7e35"
  },
  ErrorCode: "FileSystemNotFound",
  Message_: "File system 'fs-04cbcb7d2b03a38a4' does not exist."
}
```

**What testing is done?** 

Unit tests + manual testing including cross account configuration described here: https://github.com/kubernetes-sigs/aws-efs-csi-driver/blob/1203d4163e777b421617288fb5769203d3239d33/examples/kubernetes/cross_account_mount/README.md
