### PR TITLE
fix(helm): allow controller to run in hostNetwork

### DIFF
--- a/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
+++ b/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
@@ -27,6 +27,7 @@ spec:
       annotations: {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      hostNetwork: {{ .Values.controller.hostNetwork }}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- range .Values.imagePullSecrets }}

--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -96,7 +96,7 @@ controller:
     runAsUser: 0
     runAsGroup: 0
     fsGroup: 0
-
+  hostNetwork: false 
 
 ## Node daemonset variables
 


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

**What is this PR about? / Why do we need it?**
Partially reverts 
- https://github.com/kubernetes-sigs/aws-efs-csi-driver/pull/910 

Allows hostNetwork to optionally be enabled on the helm chart. 

**What testing is done?** 
When upgrading the efs-csi-driver from helm chart version 2.3.6 to 2.4.5 we noticed certain instabilities in our environment that we suppose are due to the controller no longer running in hostNetwork. Thus we would like to thave the option to enable this again. 