### PR TITLE
[Fix] Allow to add multiple IPs per filesystem ID

### DIFF
--- a/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
+++ b/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
@@ -25,12 +25,15 @@ spec:
       annotations: {{ toYaml .Values.node.podAnnotations | nindent 8 }}
       {{- end }}
     spec:
-    {{- with .Values.node.hostAliases }}
+    {{- if .Values.node.hostAliases }}
       hostAliases:
-      {{- range $k, $v := . }}
-        - ip: {{ $v.ip }}
+      {{- range .Values.node.hostAliases }}
+        {{- $alias := . }} 
+        {{- range $alias.ips }}
+        - ip: {{ . }}
           hostnames:
-            - {{ $k }}.efs.{{ $v.region }}.amazonaws.com
+            - {{ $alias.fsid }}.efs.{{ $alias.region }}.amazonaws.com
+          {{- end }}
       {{- end }}
     {{- end }}
     {{- if .Values.imagePullSecrets }}

--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -108,16 +108,19 @@ node:
   volMetricsOptIn: false
   volMetricsRefreshPeriod: 240
   volMetricsFsRateLimit: 5
-  hostAliases:
-    {}
+  hostAliases: []
     # For cross VPC EFS, you need to poison or overwrite the DNS for the efs volume as per
     # https://docs.aws.amazon.com/efs/latest/ug/efs-different-vpc.html#wt6-efs-utils-step3
     # implementing the suggested solution found here:
     # https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/240#issuecomment-676849346
-    # EFS Vol ID, IP, Region
-    # "fs-01234567":
-    #   ip: 10.10.2.2
-    #   region: us-east-2
+    # https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/1141
+    # Allows to set multiple IPs for the same file system ID
+    # - fsid: fs-01234567
+    #   region: eu-west-1
+    #   ips: 
+    #     - 10.10.10.1
+    #     - 10.10.10.2
+    #     - 10.10.10.31
   dnsPolicy: ClusterFirst
   dnsConfig:
     {}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
This should solves Issue: [1141](https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/1141)

**What is this PR about? / Why do we need it?**
Currently de `node-daemonset.yaml` loops over a map of host aliases where filesystemID is the key
```
    {{- with .Values.node.hostAliases }}
      hostAliases:
      {{- range $k, $v := . }}
        - ip: {{ $v.ip }}
          hostnames:
            - {{ $k }}.efs.{{ $v.region }}.amazonaws.com
      {{- end }}
    {{- end }}
```
```
node:
  # Number for the log level verbosity
  logLevel: 2
  volMetricsOptIn: false
  volMetricsRefreshPeriod: 240
  volMetricsFsRateLimit: 5
  hostAliases:
    {}
    # For cross VPC EFS, you need to poison or overwrite the DNS for the efs volume as per
    # https://docs.aws.amazon.com/efs/latest/ug/efs-different-vpc.html#wt6-efs-utils-step3
    # implementing the suggested solution found here:
    # https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/240#issuecomment-676849346
    # EFS Vol ID, IP, Region
    # "fs-01234567":
    #   ip: 10.10.2.2
    #   region: us-east-2
```
This caused that if you add the same filesystem ID that have multiple IPs per AZ as mentioned in the issue that only one entry gets added as you can't have a map with multiple entries with the same key.

This should fix  this and allow multiple host aliases where each filesystem can have multiple IPs per AZ
**What testing is done?** 
Installing the helm chart manually on a EKS cluster.

This is part of a same value file
```
node:
  # Number for the log level verbosity
  logLevel: 2
  volMetricsOptIn: false
  volMetricsRefreshPeriod: 240
  volMetricsFsRateLimit: 5
  hostAliases:
    # For cross VPC EFS, you need to poison or overwrite the DNS for the efs volume as per
    # https://docs.aws.amazon.com/efs/latest/ug/efs-different-vpc.html#wt6-efs-utils-step3
    # implementing the suggested solution found here:
    # https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/240#issuecomment-676849346
    # EFS Vol ID, IP, Region
    # https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/1141
    - fsid: fs-01234567
      region: eu-west-1
      ips: 
        - 10.10.10.1
        - 10.10.10.2
        - 10.10.10.3
```
This is the resulting daemonset

```
      dnsPolicy: ClusterFirst
      hostAliases:
      - hostnames:
        - fs-01234567.efs.eu-west-1.amazonaws.com
        ip: 10.10.10.1
      - hostnames:
        - fs-01234567.efs.eu-west-1.amazonaws.com
        ip: 10.10.10.2
      - hostnames:
        - fs-01234567.efs.eu-west-1.amazonaws.com
        ip: 10.10.10.3
```


