### PR TITLE
GIDs are not allocated correctly above certain volume threshold

### DIFF
--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -38,6 +38,7 @@ const (
 	AccessDeniedException    = "AccessDeniedException"
 	AccessPointAlreadyExists = "AccessPointAlreadyExists"
 	PvcNameTagKey            = "pvcName"
+	AccessPointPerFsLimit    = 1000
 )
 
 var (
@@ -266,7 +267,7 @@ func (c *cloud) findAccessPointByClientToken(ctx context.Context, clientToken st
 	klog.V(2).Infof("ClientToken to find AP : %s", clientToken)
 	describeAPInput := &efs.DescribeAccessPointsInput{
 		FileSystemId: &accessPointOpts.FileSystemId,
-		MaxResults:   aws.Int64(1000),
+		MaxResults:   aws.Int64(AccessPointPerFsLimit),
 	}
 	res, err := c.efs.DescribeAccessPointsWithContext(ctx, describeAPInput)
 	if err != nil {
@@ -296,6 +297,7 @@ func (c *cloud) findAccessPointByClientToken(ctx context.Context, clientToken st
 func (c *cloud) ListAccessPoints(ctx context.Context, fileSystemId string) (accessPoints []*AccessPoint, err error) {
 	describeAPInput := &efs.DescribeAccessPointsInput{
 		FileSystemId: &fileSystemId,
+		MaxResults:   aws.Int64(AccessPointPerFsLimit),
 	}
 	res, err := c.efs.DescribeAccessPointsWithContext(ctx, describeAPInput)
 	if err != nil {

--- a/pkg/driver/controller_test.go
+++ b/pkg/driver/controller_test.go
@@ -215,8 +215,8 @@ func TestCreateVolume(t *testing.T) {
 						AccessPointId: apId,
 						FileSystemId:  fsId,
 						PosixUser: &cloud.PosixUser{
-							Gid: 1003,
-							Uid: 1003,
+							Gid: 1001,
+							Uid: 1001,
 						},
 					},
 					{
@@ -229,7 +229,7 @@ func TestCreateVolume(t *testing.T) {
 					},
 				}
 
-				var expectedGid int64 = 1001 //1003 and 1002 are taken, next available is 1001
+				var expectedGid int64 = 1003 //1001 and 1002 are taken, next available is 1003
 				mockCloud.EXPECT().DescribeFileSystem(gomock.Eq(ctx), gomock.Any()).Return(fileSystem, nil)
 				mockCloud.EXPECT().ListAccessPoints(gomock.Eq(ctx), gomock.Any()).Return(accessPoints, nil)
 				mockCloud.EXPECT().CreateAccessPoint(gomock.Eq(ctx), gomock.Any(), gomock.Any(), false).Return(accessPoint, nil).
@@ -429,7 +429,7 @@ func TestCreateVolume(t *testing.T) {
 				}
 
 				accessPoints := []*cloud.AccessPoint{}
-				for i := 0; i < ACCESS_POINT_PER_FS_LIMIT; i++ {
+				for i := 0; i < cloud.AccessPointPerFsLimit; i++ {
 					gidMin, err := strconv.Atoi(req.Parameters[GidMin])
 					if err != nil {
 						t.Fatalf("Failed to convert GidMax Parameter to int.")
@@ -485,6 +485,69 @@ func TestCreateVolume(t *testing.T) {
 				if err == nil {
 					t.Fatalf("CreateVolume should have failed.")
 				}
+				mockCtl.Finish()
+			},
+		},
+		{
+			name: "Success: GID range exceeds EFS access point limit",
+			testFunc: func(t *testing.T) {
+				mockCtl := gomock.NewController(t)
+				mockCloud := mocks.NewMockCloud(mockCtl)
+
+				driver := &Driver{
+					endpoint:     endpoint,
+					cloud:        mockCloud,
+					gidAllocator: NewGidAllocator(),
+				}
+
+				req := &csi.CreateVolumeRequest{
+					Name: volumeName,
+					VolumeCapabilities: []*csi.VolumeCapability{
+						stdVolCap,
+					},
+					CapacityRange: &csi.CapacityRange{
+						RequiredBytes: capacityRange,
+					},
+					Parameters: map[string]string{
+						ProvisioningMode: "efs-ap",
+						FsId:             fsId,
+						DirectoryPerms:   "777",
+						BasePath:         "test",
+						GidMin:           "1000",
+						GidMax:           "1000000",
+					},
+				}
+
+				ctx := context.Background()
+				fileSystem := &cloud.FileSystem{
+					FileSystemId: fsId,
+				}
+
+				accessPoint := &cloud.AccessPoint{
+					AccessPointId: apId,
+					FileSystemId:  fsId,
+				}
+
+				expectedGid := 1000 // Allocator should pick lowest available GID
+				mockCloud.EXPECT().DescribeFileSystem(gomock.Eq(ctx), gomock.Any()).Return(fileSystem, nil)
+				mockCloud.EXPECT().ListAccessPoints(gomock.Eq(ctx), gomock.Any()).Return(nil, nil)
+				mockCloud.EXPECT().CreateAccessPoint(gomock.Eq(ctx), gomock.Any(), gomock.Any(), false).Return(accessPoint, nil).
+					Do(func(ctx context.Context, clientToken string, accessPointOpts *cloud.AccessPointOptions, reuseAccessPointName bool) {
+						if accessPointOpts.Uid != int64(expectedGid) {
+							t.Fatalf("Uid mismatched. Expected: %v, actual: %v", expectedGid, accessPointOpts.Uid)
+						}
+						if accessPointOpts.Gid != int64(expectedGid) {
+							t.Fatalf("Gid mismatched. Expected: %v, actual: %v", expectedGid, accessPointOpts.Gid)
+						}
+					})
+
+				var err error
+
+				_, err = driver.CreateVolume(ctx, req)
+				if err != nil {
+					t.Fatalf("CreateVolume failed unexpectedly: %v", err)
+				}
+
 				mockCtl.Finish()
 			},
 		},

--- a/pkg/driver/gid_allocator.go
+++ b/pkg/driver/gid_allocator.go
@@ -12,8 +12,6 @@ import (
 	"k8s.io/klog/v2"
 )
 
-var ACCESS_POINT_PER_FS_LIMIT int = 1000
-
 type FilesystemID struct {
 	gidMin int
 	gidMax int
@@ -85,9 +83,10 @@ func (g *GidAllocator) getUsedGids(ctx context.Context, localCloud cloud.Cloud, 
 func getNextUnusedGid(usedGids []int64, gidMin, gidMax int) (nextGid int, err error) {
 	requestedRange := gidMax - gidMin
 
-	if requestedRange > ACCESS_POINT_PER_FS_LIMIT {
-		klog.Warningf("Requested GID range (%v:%v) exceeds EFS Access Point limit (%v) per Filesystem. Driver will not allocate GIDs outside of this limit.", gidMin, gidMax, ACCESS_POINT_PER_FS_LIMIT)
-		gidMin = gidMax - ACCESS_POINT_PER_FS_LIMIT
+	if requestedRange > cloud.AccessPointPerFsLimit {
+		overrideGidMax := gidMin + cloud.AccessPointPerFsLimit
+		klog.Warningf("Requested GID range (%v:%v) exceeds EFS Access Point limit (%v) per Filesystem. Driver will use limited GID range (%v:%v)", gidMin, gidMax, cloud.AccessPointPerFsLimit, gidMin, overrideGidMax)
+		gidMax = overrideGidMax
 	}
 
 	var lookup func(usedGids []int64)
@@ -97,7 +96,7 @@ func getNextUnusedGid(usedGids []int64, gidMin, gidMax int) (nextGid int, err er
 				nextGid = gid
 				return
 			}
-			klog.V(5).Infof("Allocator found GID which is already in use: %v - trying next one.", nextGid)
+			klog.V(5).Infof("Allocator found GID which is already in use: %v, trying next one.", gid)
 		}
 		return
 	}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

Bug fix.

**What is this PR about? / Why do we need it?**

There are two smaller issues addressed in this PR:

- EFS client call `DescribeAccessPointsRequest` is limited to 100 results by default, so when more than 100 access points are created for a filesystem we don't get a full listing. Because of this allocator will assign GIDs that are already used which is incorrect.

- When GID range exceeds the current access point limit, allocator picks the upper range, but it makes more sense to use lower GIDs first starting from `gidRangeStart`/`gidMin`.

_Reproducer:_

1) Create StorageClass with GID range 10000-90000:

```
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: mysc
provisioner: efs.csi.aws.com
reclaimPolicy: Delete
volumeBindingMode: WaitForFirstConsumer
parameters:
  basePath: "/basePath"
  directoryPerms: "777"
  fileSystemId: fs-068b18a45f696ada6
  gidRangeStart: "10000"
  gidRangeEnd: "90000"
  provisioningMode: efs-ap
  subPathPattern: /subPath/${.PVC.name}/foo
allowVolumeExpansion: false
```

2) Create more than 100 volumes/access points, here we can observe that above 100 volumes the same GID was is getting reused. Also it started from 89000, but starting from 10000 makes more sense.

```
fsap-0357469ca94e8555c  /basePath/pvc-5ad04682-04e4-4946-8deb-e655b8afb104      89100 : 89100   89100 : 89100 (777)      Available
fsap-0cc2d107780c7b345  /basePath/pvc-b15acd33-9ffe-4d56-9dac-766ca2f3c894      89100 : 89100   89100 : 89100 (777)      Available
fsap-0b4590b20c00b0bcb  /basePath/pvc-da0aa6b8-ec6b-4822-a78f-63e3b0fb7cf6      89100 : 89100   89100 : 89100 (777)      Available
```

**What testing is done?** 

Unit tests + manual verification.