### PR TITLE
fix the storage class example in helm values

### DIFF
--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -183,6 +183,6 @@ storageClasses: []
 #     gidRangeEnd: "2000"
 #     basePath: "/dynamic_provisioning"
 #     subPathPattern: "/subPath"
-#     ensureUniqueDirectory: true
+#     ensureUniqueDirectory: "true"
 #   reclaimPolicy: Delete
 #   volumeBindingMode: Immediate


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Docs / Example

**What is this PR about? / Why do we need it?**
Corrects the example of a storage class in helm values file in order to avoid:
```
json: cannot unmarshal bool into Go struct field StorageClass.parameters of type string
```
if someone uses the `ensureUniqueDirectory: true` from the example.

**What testing is done?**
Helm chart install with the example storage class.
