### PR TITLE
feature: add support to include the custom labels to the hlm chart ht…

### DIFF
--- a/charts/aws-efs-csi-driver/templates/_helpers.tpl
+++ b/charts/aws-efs-csi-driver/templates/_helpers.tpl
@@ -42,6 +42,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.customLabels }}
+{{ toYaml .Values.customLabels }}
+{{- end }}
 {{- end -}}
 
 {{/*

--- a/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
+++ b/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
@@ -9,6 +9,7 @@ metadata:
     {{- with .Values.controller.additionalLabels }}
     {{ toYaml . | nindent 4 }}
     {{- end }}
+    {{- include "aws-efs-csi-driver.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
@@ -16,6 +17,7 @@ spec:
       app: efs-csi-controller
       app.kubernetes.io/name: {{ include "aws-efs-csi-driver.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- include "aws-efs-csi-driver.labels" . | nindent 6 }}
   {{- with .Values.controller.updateStrategy }}
   strategy:
     {{ toYaml . | nindent 4 }}
@@ -29,6 +31,7 @@ spec:
         {{- with .Values.controller.podLabels }}
         {{ toYaml . | nindent 8 }}
         {{- end }}
+        {{- include "aws-efs-csi-driver.labels" . | nindent 8 }}
       {{- with .Values.controller.podAnnotations }}
       annotations: {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/aws-efs-csi-driver/templates/controller-serviceaccount.yaml
+++ b/charts/aws-efs-csi-driver/templates/controller-serviceaccount.yaml
@@ -4,7 +4,7 @@ kind: ServiceAccount
 metadata:
   name: {{ .Values.controller.serviceAccount.name }}
   labels:
-    app.kubernetes.io/name: {{ include "aws-efs-csi-driver.name" . }}
+    {{- include "aws-efs-csi-driver.labels" . | nindent 4 }}
   {{- with .Values.controller.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
@@ -17,7 +17,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: efs-csi-external-provisioner-role
   labels:
-    app.kubernetes.io/name: {{ include "aws-efs-csi-driver.name" . }}
+    {{- include "aws-efs-csi-driver.labels" . | nindent 4 }}
 rules:
   - apiGroups: [""]
     resources: ["persistentvolumes"]
@@ -58,7 +58,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: efs-csi-provisioner-binding
   labels:
-    app.kubernetes.io/name: {{ include "aws-efs-csi-driver.name" . }}
+    {{- include "aws-efs-csi-driver.labels" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
     name: {{ .Values.controller.serviceAccount.name }}

--- a/charts/aws-efs-csi-driver/templates/csidriver.yaml
+++ b/charts/aws-efs-csi-driver/templates/csidriver.yaml
@@ -2,6 +2,8 @@ apiVersion: {{ ternary "storage.k8s.io/v1" "storage.k8s.io/v1beta1" (semverCompa
 kind: CSIDriver
 metadata:
   name: efs.csi.aws.com
+  labels:
+    {{- include "aws-efs-csi-driver.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": pre-install, pre-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
+++ b/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
@@ -4,13 +4,12 @@ apiVersion: apps/v1
 metadata:
   name: efs-csi-node
   labels:
-    app.kubernetes.io/name: {{ include "aws-efs-csi-driver.name" . }}
+    {{- include "aws-efs-csi-driver.labels" . | nindent 4 }}
 spec:
   selector:
     matchLabels:
       app: efs-csi-node
-      app.kubernetes.io/name: {{ include "aws-efs-csi-driver.name" . }}
-      app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- include "aws-efs-csi-driver.labels" . | nindent 6 }}
   {{- with .Values.node.updateStrategy }}
   updateStrategy:
     {{ toYaml . | nindent 4 }}
@@ -19,8 +18,7 @@ spec:
     metadata:
       labels:
         app: efs-csi-node
-        app.kubernetes.io/name: {{ include "aws-efs-csi-driver.name" . }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- include "aws-efs-csi-driver.labels" . | nindent 8 }}
       {{- if .Values.node.podAnnotations }}
       annotations: {{ toYaml .Values.node.podAnnotations | nindent 8 }}
       {{- end }}

--- a/charts/aws-efs-csi-driver/templates/node-serviceaccount.yaml
+++ b/charts/aws-efs-csi-driver/templates/node-serviceaccount.yaml
@@ -4,7 +4,7 @@ kind: ServiceAccount
 metadata:
   name: {{ .Values.node.serviceAccount.name }}
   labels:
-    app.kubernetes.io/name: {{ include "aws-efs-csi-driver.name" . }}
+    {{- include "aws-efs-csi-driver.labels" . | nindent 4 }}
   {{- with .Values.node.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
@@ -16,7 +16,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: efs-csi-node-role
   labels:
-    app.kubernetes.io/name: {{ include "aws-efs-csi-driver.name" . }}
+    {{- include "aws-efs-csi-driver.labels" . | nindent 4 }}
 rules:
   - apiGroups: [""]
     resources: ["nodes"]
@@ -27,7 +27,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: efs-csi-node-binding
   labels:
-    app.kubernetes.io/name: {{ include "aws-efs-csi-driver.name" . }}
+    {{- include "aws-efs-csi-driver.labels" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
     name: {{ .Values.node.serviceAccount.name }}

--- a/charts/aws-efs-csi-driver/templates/storageclass.yaml
+++ b/charts/aws-efs-csi-driver/templates/storageclass.yaml
@@ -3,6 +3,8 @@ kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
   name: {{ .name }}
+  labels:
+    {{- include "aws-efs-csi-driver.labels" . | nindent 4 }}
   {{- with .annotations }}
   annotations:
   {{ toYaml . | indent 4 }}

--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -14,6 +14,11 @@ image:
   tag: "v1.7.5"
   pullPolicy: IfNotPresent
 
+# -- Custom labels to add into metadata
+customLabels:
+  {}
+# k8s-app: aws-efs-csi-driver
+
 sidecars:
   livenessProbe:
     image:


### PR DESCRIPTION
…tps://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/1240

**Is this a bug fix or adding new feature?**
This is a feature.

**What is this PR about? / Why do we need it?**
This PR is to add the feature request mentioned here: https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/1240

**What testing is done?** 
Local testing for labels: when the following custom labels are passed from values.yaml:
customLabels:
  foo: "bar"
  k8sApp: "aws-ebs-csi-driver"
  dept: "111"
  team: "team-distro"

<img width="478" alt="image" src="https://github.com/kubernetes-sigs/aws-efs-csi-driver/assets/12025474/31336217-fffd-4d8e-a435-3f93faf65da7">
