### PR TITLE
fix bottlerocket compatibility

### DIFF
--- a/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
+++ b/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
@@ -133,6 +133,8 @@ spec:
               mountPath: /csi
             - name: registration-dir
               mountPath: /registration
+            - name: probe-dir
+              mountPath: /var/lib/kubelet/plugins/efs.csi.aws.com/
           {{- with .Values.sidecars.nodeDriverRegistrar.resources }}
           resources: {{ toYaml . | nindent 12 }}
           {{- end }}
@@ -182,3 +184,5 @@ spec:
           hostPath:
             path: /etc/amazon/efs
             type: DirectoryOrCreate
+        - emptyDir: {}
+          name: probe-dir


### PR DESCRIPTION
bottlerocket nodes have a r/o file system:

```
[pod/efs-csi-node-cxcfc/csi-driver-registrar] E0111 23:11:21.812117       1 main.go:107] "Failed to create registration probe file" err="mkdir /var/lib/kubelet/plugins/efs.csi.aws.com: read-only file system" registrationProbePath="/var/lib/kubelet/plugins/efs.csi.aws.com/registration"
```

with this change:

```
[pod/efs-csi-node-kg9dt/csi-driver-registrar] I0111 23:14:01.377424       1 main.go:109] "Kubelet registration probe created" path="/var/lib/kubelet/plugins/efs.csi.aws.com/registration"
```

**Is this a bug fix or adding new feature?**

bug fix

**What is this PR about? / Why do we need it?**

bug fix for bottlerocket node compatibility

**What testing is done?** 

verified deployment on bottlerocket
