### PR TITLE
Bump the side-cars to the latest to mitigate the CVEs

### DIFF
--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -18,7 +18,7 @@ sidecars:
   livenessProbe:
     image:
       repository: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe
-      tag: v2.10.0-eks-1-28-4
+      tag: v2.11.0-eks-1-29-2
       pullPolicy: IfNotPresent
     resources: {}
     securityContext:
@@ -27,7 +27,7 @@ sidecars:
   nodeDriverRegistrar:
     image:
       repository: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar
-      tag: v2.8.0-eks-1-28-4
+      tag: v2.9.3-eks-1-29-2
       pullPolicy: IfNotPresent
     resources: {}
     securityContext:
@@ -36,7 +36,7 @@ sidecars:
   csiProvisioner:
     image:
       repository: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner
-      tag: v3.5.0-eks-1-28-4
+      tag: v3.6.3-eks-1-29-2
       pullPolicy: IfNotPresent
     resources: {}
     securityContext:

--- a/deploy/kubernetes/base/controller-deployment.yaml
+++ b/deploy/kubernetes/base/controller-deployment.yaml
@@ -67,7 +67,7 @@ spec:
             periodSeconds: 10
             failureThreshold: 5
         - name: csi-provisioner
-          image: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner:v3.5.0-eks-1-28-4
+          image: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner:v3.6.3-eks-1-29-2
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)
@@ -85,7 +85,7 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
         - name: liveness-probe
-          image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.10.0-eks-1-28-4
+          image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.11.0-eks-1-29-2
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=/csi/csi.sock

--- a/deploy/kubernetes/base/node-daemonset.yaml
+++ b/deploy/kubernetes/base/node-daemonset.yaml
@@ -89,7 +89,7 @@ spec:
             periodSeconds: 2
             failureThreshold: 5
         - name: csi-driver-registrar
-          image: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar:v2.8.0-eks-1-28-4
+          image: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar:v2.9.3-eks-1-29-2
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)
@@ -113,7 +113,7 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
         - name: liveness-probe
-          image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.10.0-eks-1-28-4
+          image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.11.0-eks-1-29-2
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=/csi/csi.sock

--- a/deploy/kubernetes/overlays/stable/ecr/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/ecr/kustomization.yaml
@@ -8,10 +8,10 @@ images:
     newTag: v1.7.3
   - name: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe
     newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/livenessprobe
-    newTag: v2.10.0-eks-1-28-4
+    newTag: v2.11.0-eks-1-29-2
   - name: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar
     newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-node-driver-registrar
-    newTag: v2.8.0-eks-1-28-4
+    newTag: v2.9.3-eks-1-29-2
   - name: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner
     newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-provisioner
-    newTag: v3.5.0-eks-1-28-4
+    newTag: v3.6.3-eks-1-29-2

--- a/deploy/kubernetes/overlays/stable/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/kustomization.yaml
@@ -6,8 +6,8 @@ images:
   - name: amazon/aws-efs-csi-driver
     newTag: v1.7.3
   - name: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe
-    newTag: v2.10.0-eks-1-28-4
+    newTag: v2.11.0-eks-1-29-2
   - name: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar
-    newTag: v2.8.0-eks-1-28-4
+    newTag: v2.9.3-eks-1-29-2
   - name: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner
-    newTag: v3.5.0-eks-1-28-4
+    newTag: v3.6.3-eks-1-29-2


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

**What is this PR about? / Why do we need it?**
Bump the side-cars to the latest to mitigate the CVEs


**What testing is done?** 

```
mskanth@bcd07411789d ~ % trivy image public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.11.0-eks-1-29-2
2024-01-18T20:17:43.560-0500	INFO	Vulnerability scanning is enabled
2024-01-18T20:17:43.560-0500	INFO	Secret scanning is enabled
2024-01-18T20:17:43.560-0500	INFO	If your scanning is slow, please try '--security-checks vuln' to disable secret scanning
2024-01-18T20:17:43.560-0500	INFO	Please see also https://aquasecurity.github.io/trivy/v0.35/docs/secret/scanning/#recommendation for faster secret detection
2024-01-18T20:17:52.436-0500	INFO	Detected OS: amazon
2024-01-18T20:17:52.436-0500	INFO	Detecting Amazon Linux vulnerabilities...
2024-01-18T20:17:52.437-0500	INFO	Number of language-specific files: 1
2024-01-18T20:17:52.437-0500	INFO	Detecting gobinary vulnerabilities...

public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.11.0-eks-1-29-2 (amazon 2 (Karoo))

Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)

mskanth@bcd07411789d ~ % trivy image public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar:v2.9.3-eks-1-29-2
2024-01-18T20:26:46.164-0500	INFO	Vulnerability scanning is enabled
2024-01-18T20:26:46.164-0500	INFO	Secret scanning is enabled
2024-01-18T20:26:46.164-0500	INFO	If your scanning is slow, please try '--security-checks vuln' to disable secret scanning
2024-01-18T20:26:46.164-0500	INFO	Please see also https://aquasecurity.github.io/trivy/v0.35/docs/secret/scanning/#recommendation for faster secret detection
2024-01-18T20:26:53.760-0500	INFO	Detected OS: amazon
2024-01-18T20:26:53.760-0500	INFO	Detecting Amazon Linux vulnerabilities...
2024-01-18T20:26:53.760-0500	INFO	Number of language-specific files: 1
2024-01-18T20:26:53.760-0500	INFO	Detecting gobinary vulnerabilities...

public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar:v2.9.3-eks-1-29-2 (amazon 2 (Karoo))

Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)

mskanth@bcd07411789d ~ % trivy image public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner:v3.6.3-eks-1-29-2 
2024-01-18T20:27:10.092-0500	INFO	Vulnerability scanning is enabled
2024-01-18T20:27:10.092-0500	INFO	Secret scanning is enabled
2024-01-18T20:27:10.092-0500	INFO	If your scanning is slow, please try '--security-checks vuln' to disable secret scanning
2024-01-18T20:27:10.092-0500	INFO	Please see also https://aquasecurity.github.io/trivy/v0.35/docs/secret/scanning/#recommendation for faster secret detection
2024-01-18T20:27:33.932-0500	INFO	Detected OS: amazon
2024-01-18T20:27:33.932-0500	INFO	Detecting Amazon Linux vulnerabilities...
2024-01-18T20:27:33.932-0500	INFO	Number of language-specific files: 1
2024-01-18T20:27:33.932-0500	INFO	Detecting gobinary vulnerabilities...

public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner:v3.6.3-eks-1-29-2 (amazon 2 (Karoo))

Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)
```
Tested both on the public registry and private registry images