### PR TITLE
Allow controller SA to describe Secrets - fixes cross account dynamic provisioning

### DIFF
--- a/charts/aws-efs-csi-driver/templates/controller-serviceaccount.yaml
+++ b/charts/aws-efs-csi-driver/templates/controller-serviceaccount.yaml
@@ -40,12 +40,19 @@ rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["get", "watch", "list", "delete", "update", "create"]
-  # - apiGroups: [ "" ]
-  #   resources: [ "secrets" ]
-  #   verbs: [ "get", "watch", "list" ]
-
 ---
-
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: efs-csi-external-provisioner-role-describe-secrets
+  labels:
+    app.kubernetes.io/name: {{ include "aws-efs-csi-driver.name" . }}
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "secrets" ]
+    resourceNames: ["x-account"]
+    verbs: [ "get", "watch", "list" ]
+---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -59,4 +66,21 @@ subjects:
 roleRef:
   kind: ClusterRole
   name: efs-csi-external-provisioner-role
+  apiGroup: rbac.authorization.k8s.io
+---
+# We use a RoleBinding to restrict Secret access to the namespace that the 
+# RoleBinding is created in (typically kube-system)
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: efs-csi-provisioner-binding-describe-secrets
+  labels:
+    app.kubernetes.io/name: {{ include "aws-efs-csi-driver.name" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.controller.serviceAccount.name }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: efs-csi-external-provisioner-role-describe-secrets
   apiGroup: rbac.authorization.k8s.io

--- a/deploy/kubernetes/base/controller-serviceaccount.yaml
+++ b/deploy/kubernetes/base/controller-serviceaccount.yaml
@@ -36,9 +36,19 @@ rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["get", "watch", "list", "delete", "update", "create"]
-  # - apiGroups: [ "" ]
-  #   resources: [ "secrets" ]
-  #   verbs: [ "get", "watch", "list" ]
+---
+# Source: aws-efs-csi-driver/templates/controller-serviceaccount.yaml
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: efs-csi-external-provisioner-role-describe-secrets
+  labels:
+    app.kubernetes.io/name: aws-efs-csi-driver
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "secrets" ]
+    resourceNames: ["x-account"]
+    verbs: [ "get", "watch", "list" ]
 ---
 # Source: aws-efs-csi-driver/templates/controller-serviceaccount.yaml
 kind: ClusterRoleBinding
@@ -54,4 +64,21 @@ subjects:
 roleRef:
   kind: ClusterRole
   name: efs-csi-external-provisioner-role
+  apiGroup: rbac.authorization.k8s.io
+---
+# We use a RoleBinding to restrict Secret access to the namespace that the 
+# RoleBinding is created in (typically kube-system)
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: efs-csi-provisioner-binding-describe-secrets
+  labels:
+    app.kubernetes.io/name: aws-efs-csi-driver
+subjects:
+  - kind: ServiceAccount
+    name: efs-csi-controller-sa
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: efs-csi-external-provisioner-role-describe-secrets
   apiGroup: rbac.authorization.k8s.io

--- a/examples/kubernetes/cross_account_mount/iam-policy-examples/describe-mount-target-example.json
+++ b/examples/kubernetes/cross_account_mount/iam-policy-examples/describe-mount-target-example.json
@@ -1,24 +1,62 @@
 {
   "Version": "2012-10-17",
   "Statement": [
-    {
-      "Sid" : "Stmt1DescribeMountTargets",
-      "Effect": "Allow",
-      "Action": [
-        "elasticfilesystem:DescribeFileSystems",
-        "elasticfilesystem:DescribeMountTargets",
-        "elasticfilesystem:CreateAccessPoint"
-      ],
-      "Resource": "arn:aws:elasticfilesystem:us-west-2:123456789012:file-system/file-system-ID"
-    },
-    {
-      "Sid" : "Stmt2AdditionalEC2PermissionsToDescribeMountTarget",
-      "Effect": "Allow",
-      "Action": [
-        "ec2:DescribeSubnets",
-        "ec2:DescribeNetworkInterfaces"
-      ],
-      "Resource": "*"
-    }
+      {
+          "Sid": "AllowDescribe",
+          "Effect": "Allow",
+          "Action": [
+              "elasticfilesystem:DescribeAccessPoints",
+              "elasticfilesystem:DescribeFileSystems",
+              "elasticfilesystem:DescribeMountTargets",
+              "ec2:DescribeAvailabilityZones"
+          ],
+          "Resource": "*"
+      },
+      {
+          "Sid": "AllowCreateAccessPoint",
+          "Effect": "Allow",
+          "Action": [
+              "elasticfilesystem:CreateAccessPoint"
+          ],
+          "Resource": "*",
+          "Condition": {
+              "Null": {
+                  "aws:RequestTag/efs.csi.aws.com/cluster": "false"
+              },
+              "ForAllValues:StringEquals": {
+                  "aws:TagKeys": "efs.csi.aws.com/cluster"
+              }
+          }
+      },
+      {
+          "Sid": "AllowTagNewAccessPoints",
+          "Effect": "Allow",
+          "Action": [
+              "elasticfilesystem:TagResource"
+          ],
+          "Resource": "*",
+          "Condition": {
+              "StringEquals": {
+                  "elasticfilesystem:CreateAction": "CreateAccessPoint"
+              },
+              "Null": {
+                  "aws:RequestTag/efs.csi.aws.com/cluster": "false"
+              },
+              "ForAllValues:StringEquals": {
+                  "aws:TagKeys": "efs.csi.aws.com/cluster"
+              }
+          }
+      },
+      {
+          "Sid": "AllowDeleteAccessPoint",
+          "Effect": "Allow",
+          "Action": "elasticfilesystem:DeleteAccessPoint",
+          "Resource": "*",
+          "Condition": {
+              "Null": {
+                  "aws:ResourceTag/efs.csi.aws.com/cluster": "false"
+              }
+          }
+      }
   ]
 }


### PR DESCRIPTION
For cross account provisioning, the controller pods need to be able to describe K8s Secrets in the kube-system namespace.

Additionally, I modified the IAM Role used in our cross-account mount example. Users should use the managed AmazonEFSCSIDriverPolicy, which I've copied into describe-mount-target-example.json to be compatible with existing documentation links. Eventually, we will update the documentation to point at the managed policy instead of this file.

**Why did I change that IAM Policy?**
The describe-mount-target IAM Role wasn't working when following this blog post:
https://aws.amazon.com/blogs/storage/mount-amazon-efs-file-systems-cross-account-from-amazon-eks/

That's because it was missing two key permissions:
`elasticfilesystem:TagResource` and `elasticfilesystem:DescribeAccessPoints`

**Testing**:
I performed a Helm installation and a kustomize installation of the driver. For each, I then performed a cross-account mount and ensured it was successful.

