### PR TITLE
Add EFS CSI Driver support for ADC regions

### DIFF
--- a/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
+++ b/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
@@ -72,6 +72,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: AWS_DEFAULT_REGION
+              value: AWS_REGION
+            - name: AWS_CA_BUNDLE
+              value: /etc/pki/tls/certs/ca-bundle.crt
             {{- if .Values.useFIPS }}
             - name: AWS_USE_FIPS_ENDPOINT
               value: "true"
@@ -79,6 +83,8 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
+            - name: ca-bundle
+              mountPath: /etc/pki/tls/certs/ca-bundle.crt
           ports:
             - name: healthz
               containerPort: {{ .Values.controller.healthPort }}
@@ -137,6 +143,10 @@ spec:
       volumes:
         - name: socket-dir
           emptyDir: {}
+        - name: ca-bundle
+          hostPath:
+            path: /etc/pki/tls/certs/ca-bundle.crt
+            type: File
       {{- with .Values.controller.affinity }}
       affinity: {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
+++ b/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
@@ -85,6 +85,10 @@ spec:
             - name: AWS_USE_FIPS_ENDPOINT
               value: "true"
             {{- end }}
+            - name: AWS_DEFAULT_REGION
+              value: AWS_REGION
+            - name: AWS_CA_BUNDLE
+              value: /etc/pki/tls/certs/ca-bundle.crt
           volumeMounts:
             - name: kubelet-dir
               mountPath: /var/lib/kubelet
@@ -97,6 +101,8 @@ spec:
               mountPath: /var/amazon/efs
             - name: efs-utils-config-legacy
               mountPath: /etc/amazon/efs-legacy
+            - name: ca-bundle
+              mountPath: /etc/pki/tls/certs/ca-bundle.crt
           ports:
             - name: healthz
               containerPort: {{ .Values.node.healthPort }}
@@ -182,3 +188,7 @@ spec:
           hostPath:
             path: /etc/amazon/efs
             type: DirectoryOrCreate
+        - name: ca-bundle
+          hostPath:
+            path: /etc/pki/tls/certs/ca-bundle.crt
+            type: File

--- a/deploy/kubernetes/base/controller-deployment.yaml
+++ b/deploy/kubernetes/base/controller-deployment.yaml
@@ -51,9 +51,15 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: AWS_DEFAULT_REGION
+              value: AWS_REGION
+            - name: AWS_CA_BUNDLE
+              value: /etc/pki/tls/certs/ca-bundle.crt
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
+            - name: ca-bundle
+              mountPath: /etc/pki/tls/certs/ca-bundle.crt
           ports:
             - name: healthz
               containerPort: 9909
@@ -99,3 +105,7 @@ spec:
       volumes:
         - name: socket-dir
           emptyDir: {}
+        - name: ca-bundle
+          hostPath:
+            path: /etc/pki/tls/certs/ca-bundle.crt
+            type: File

--- a/deploy/kubernetes/base/node-daemonset.yaml
+++ b/deploy/kubernetes/base/node-daemonset.yaml
@@ -64,6 +64,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: AWS_DEFAULT_REGION
+              value: AWS_REGION
+            - name: AWS_CA_BUNDLE
+              value: /etc/pki/tls/certs/ca-bundle.crt
           volumeMounts:
             - name: kubelet-dir
               mountPath: /var/lib/kubelet
@@ -76,6 +80,8 @@ spec:
               mountPath: /var/amazon/efs
             - name: efs-utils-config-legacy
               mountPath: /etc/amazon/efs-legacy
+            - name: ca-bundle
+              mountPath: /etc/pki/tls/certs/ca-bundle.crt
           ports:
             - name: healthz
               containerPort: 9809
@@ -150,3 +156,7 @@ spec:
           hostPath:
             path: /etc/amazon/efs
             type: DirectoryOrCreate
+        - name: ca-bundle
+          hostPath:
+            path: /etc/pki/tls/certs/ca-bundle.crt
+            type: File


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
New Feature

**What is this PR about? / Why do we need it?**
This PR introduces support for ADC regions in the EFS CSI Driver. For containers to effectively communicate with service endpoints in these ADC regions, it's essential to reference the region-specific Certificate Authority (CA) files. These necessary CA files are already present on the worker nodes. The modifications in this PR enable both the node daemonset and the controller ConfigMaps to utilize the CA file available on the worker node.

**What testing is done?** 
