### PR TITLE
Fix check for gid being less than 0

### DIFF
--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -183,7 +183,7 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 		if err != nil {
 			return nil, status.Errorf(codes.InvalidArgument, "Failed to parse invalid %v: %v", Gid, err)
 		}
-		if uid < 0 {
+		if gid < 0 {
 			return nil, status.Errorf(codes.InvalidArgument, "%v must be greater or equal than 0", Gid)
 		}
 	}


### PR DESCRIPTION
We were checking the uid instead of the gid when we check the configured value against 0

**Is this a bug fix or adding new feature?**
Bug fix

**What is this PR about? / Why do we need it?**
Breaks the ability to specify just a gid without specifying a uid

**What testing is done?** 
