### PR TITLE
Disable efs-utils version check

### DIFF
--- a/pkg/driver/efs_watch_dog.go
+++ b/pkg/driver/efs_watch_dog.go
@@ -115,6 +115,8 @@ stunnel_health_check_enabled = true
 stunnel_health_check_interval_min = 5
 stunnel_health_check_command_timeout_sec = 30
 
+enable_version_check = false
+
 [client-info] 
 source={{.EfsClientSource}}
 

--- a/pkg/driver/efs_watch_dog_test.go
+++ b/pkg/driver/efs_watch_dog_test.go
@@ -105,6 +105,8 @@ stunnel_health_check_enabled = true
 stunnel_health_check_interval_min = 5
 stunnel_health_check_command_timeout_sec = 30
 
+enable_version_check = false
+
 [client-info] 
 source=k8s
 


### PR DESCRIPTION
A "version check" feature was introduced into v1.35.1 of efs-utils. This check runs once an hour and may result in the watchdog process making API calls to Github. This commit disables this feature.

We are disabling this feature because it doesn't provide any useful functionality to users of the CSI driver, and it results in unexpected API requests to Github.

**What testing is done?** 

I deployed the csi driver and asserted that the version check wasn't executing. I checked the [version check file](https://github.com/aws/efs-utils/blob/master/src/watchdog/__init__.py#L379) and watchdog logs to assert the version check wasn't occurring.

```
bash-4.2# cat /var/log/amazon/efs/mount-watchdog.log
2024-02-15 20:23:43 UTC - INFO - amazon-efs-mount-watchdog, version 1.35.1, is enabled and started
bash-4.2# ls /var/run/efs/ | grep version
bash-4.2#
bash-4.2# cat /etc/amazon/efs/efs-utils.conf | grep enable_version_check
enable_version_check = false


```