### PR TITLE
Templatizing priotityClassName, hostNetwork, and additionalLabels in node-daemonset.yaml

### DIFF
--- a/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
+++ b/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
@@ -21,9 +21,9 @@ spec:
         app: efs-csi-node
         app.kubernetes.io/name: {{ include "aws-efs-csi-driver.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
-        {{- with .Values.global.podLabels}}
-        {{- toYaml . | nindent 8 }}
-        {{- end}}
+        {{- with .Values.node.podLabels }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
       {{- if .Values.node.podAnnotations }}
       annotations: {{ toYaml .Values.node.podAnnotations | nindent 8 }}
       {{- end }}
@@ -50,13 +50,13 @@ spec:
       {{- with .Values.node.affinity }}
       affinity: {{- toYaml . | nindent 8 }}
       {{- end }}
-      hostNetwork: {{ .Values.node.hostNetwork}}
+      hostNetwork: {{ .Values.node.hostNetwork }}
       dnsPolicy: {{ .Values.node.dnsPolicy }}
       {{- with .Values.node.dnsConfig }}
       dnsConfig: {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ .Values.node.serviceAccount.name }}
-      priorityClassName: {{ .Values.priorityClassName | default "system-node-critical"}}
+      priorityClassName: {{ .Values.node.priorityClassName}}
       {{- with .Values.node.tolerations }}
       tolerations: {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
+++ b/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
@@ -21,6 +21,9 @@ spec:
         app: efs-csi-node
         app.kubernetes.io/name: {{ include "aws-efs-csi-driver.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- with .Values.global.podLabels}}
+        {{- toYaml . | nindent 8 }}
+        {{- end}}
       {{- if .Values.node.podAnnotations }}
       annotations: {{ toYaml .Values.node.podAnnotations | nindent 8 }}
       {{- end }}
@@ -47,13 +50,13 @@ spec:
       {{- with .Values.node.affinity }}
       affinity: {{- toYaml . | nindent 8 }}
       {{- end }}
-      hostNetwork: true
+      hostNetwork: {{ .Values.node.hostNetwork}}
       dnsPolicy: {{ .Values.node.dnsPolicy }}
       {{- with .Values.node.dnsConfig }}
       dnsConfig: {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ .Values.node.serviceAccount.name }}
-      priorityClassName: system-node-critical
+      priorityClassName: {{ .Values.priorityClassName | default "system-node-critical"}}
       {{- with .Values.node.tolerations }}
       tolerations: {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -130,6 +130,8 @@ node:
     # "fs-01234567":
     #   ip: 10.10.2.2
     #   region: us-east-2
+  hostNetwork: true
+  priorityClassName: system-node-critical
   dnsPolicy: ClusterFirst
   dnsConfig:
     {}
@@ -138,6 +140,7 @@ node:
     # dnsConfig:
     #   nameservers:
     #     - 169.254.169.253
+  podLabels: {}
   podAnnotations: {}
   resources:
     {}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
This is adding some new features to the aws-efs-csi-driver helm charts

**What is this PR about? / Why do we need it?**
The PR is about adding changes to the aes-efs-csi-driver helm chart. 
- In `node-daemonset.yaml`
  - templatize priorityClassName
  - templatize hostNetwork
  - add additional labels to node-daemonset.yaml

**What testing is done?** 
yes 
