### PR TITLE
Revert "Templatizing priotityClassName, hostNetwork, and additionalLabels in node-daemonset.yaml"

### DIFF
--- a/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
+++ b/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
@@ -21,9 +21,6 @@ spec:
         app: efs-csi-node
         app.kubernetes.io/name: {{ include "aws-efs-csi-driver.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
-        {{- with .Values.node.podLabels }}
-        {{ toYaml . | nindent 8 }}
-        {{- end }}
       {{- if .Values.node.podAnnotations }}
       annotations: {{ toYaml .Values.node.podAnnotations | nindent 8 }}
       {{- end }}
@@ -50,13 +47,13 @@ spec:
       {{- with .Values.node.affinity }}
       affinity: {{- toYaml . | nindent 8 }}
       {{- end }}
-      hostNetwork: {{ .Values.node.hostNetwork }}
+      hostNetwork: true
       dnsPolicy: {{ .Values.node.dnsPolicy }}
       {{- with .Values.node.dnsConfig }}
       dnsConfig: {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ .Values.node.serviceAccount.name }}
-      priorityClassName: {{ .Values.node.priorityClassName}}
+      priorityClassName: system-node-critical
       {{- with .Values.node.tolerations }}
       tolerations: {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -130,8 +130,6 @@ node:
     # "fs-01234567":
     #   ip: 10.10.2.2
     #   region: us-east-2
-  hostNetwork: true
-  priorityClassName: system-node-critical
   dnsPolicy: ClusterFirst
   dnsConfig:
     {}
@@ -140,7 +138,6 @@ node:
     # dnsConfig:
     #   nameservers:
     #     - 169.254.169.253
-  podLabels: {}
   podAnnotations: {}
   resources:
     {}


### PR DESCRIPTION
Reverts kubernetes-sigs/aws-efs-csi-driver#1281

Setting hostNetwork=False on the Node Daemonset will cause mounts to hang at upgrade time. See this Github issue:
https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/1270.