### PR TITLE
Add static & dynamic provisioning options for using efs-utils crossac…

### DIFF
--- a/examples/kubernetes/cross_account_mount/README.md
+++ b/examples/kubernetes/cross_account_mount/README.md
@@ -1,7 +1,7 @@
 ## Dynamic Provisioning
 This example shows how to create a dynamically provisioned volume created through [EFS access points](https://docs.aws.amazon.com/efs/latest/ug/efs-access-points.html) and Persistent Volume Claim (PVC) and consume it from a pod.
 
-**Note**: this example requires Kubernetes v1.17+ and driver version >= 1.2.0.
+**Note**: this example requires Kubernetes v1.17+ and driver version >= 1.8.0.
 
 ### Edit [StorageClass](./specs/storageclass.yaml)
 
@@ -30,7 +30,7 @@ Lets say you have an EKS cluster in aws account `A` & you wish to mount your fil
 1. Perform [vpc-peering](https://docs.aws.amazon.com/vpc/latest/peering/working-with-vpc-peering.html) between EKS cluster `vpc` in aws account `A` and EFS `vpc` in another aws account `B`.
 2. Create an IAM role, say `EFSCrossAccountAccessRole` in Account `B` which has a [trust relationship](./iam-policy-examples/trust-relationship-example.json) with Account `A` and add an inline EFS policy with [permissions](./iam-policy-examples/describe-mount-target-example.json) to call `DescribeMountTargets`. This role will be used by CSI-Driver's Controller service running on EKS cluster in account `A` to determine the mount targets for your file system in account `B`. 
 3. In aws account `A`, attach an inline policy to IAM role of efs-csi-driver's controller service account with necessary [permissions](./iam-policy-examples/cross-account-assume-policy-example.json) to perform `sts assume role` on the IAM role created in step 2.  
-4. Create a kubernetes secret with `awsRoleArn` as the key and the role from step 2 as the value. For example, `kubectl create secret generic x-account --namespace=default --from-literal=awsRoleArn='arn:aws:iam::123456789012:role/EFSCrossAccountAccessRole'`.
+4. Create a kubernetes secret with `awsRoleArn` as the key and the role from step 2 as the value. For example, `kubectl create secret generic x-account --namespace=default --from-literal=awsRoleArn='arn:aws:iam::123456789012:role/EFSCrossAccountAccessRole'`. If you would like to ensure that your EFS Mount Target is in the same availability zone as your EKS Node, then ensure you have completed the [prerequisites for cross-account DNS resolution](https://github.com/aws/efs-utils?tab=readme-ov-file#crossaccount-option-prerequisites) and include the `crossaccount` key with value `true`. For example, `kubectl create secret generic x-account --namespace=kube-system --from-literal=awsRoleArn='arn:aws:iam::123456789012:role/EFSCrossAccountAccessRole' --from-literal=crossaccount='true'` instead.
 5. Create an IAM role for service accounts for EKS cluster in account `A` with required [permissions](./iam-policy-examples/node-deamonset-iam-policy-example.json) for EFS client mount. Alternatively, you can find this policy under AWS managed policy as `AmazonElasticFileSystemClientFullAccess`.  
 6. Attach the service account from step 5 to node daemonset.
 7. Create a [file system policy](https://docs.aws.amazon.com/efs/latest/ug/iam-access-control-nfs-efs.html#file-sys-policy-examples) for file system in account `B` which allows account `A` to perform mount on it.
@@ -58,3 +58,55 @@ Also you can verify that data is written onto EFS filesystem:
 >> kubectl exec -ti efs-app -- tail -f /data/out
 ```
 
+## Static Provisioning
+This example shows how to perform cross-account static provisioning.
+
+**Note**: this example requires Kubernetes v1.17+ and driver version >= 1.8.0.
+
+### Edit [PersistentVolume](./specs/pv.yaml) config file volumeAttributes
+
+```
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: efs-pv
+spec:
+  capacity:
+    storage: 5Gi
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: efs-sc
+  persistentVolumeReclaimPolicy: Retain
+  csi:
+    driver: efs.csi.aws.com
+    volumeHandle: [Filesystem ID]
+    volumeAttributes:
+      crossaccount: "true"
+```
+Replace [Filesystem ID] with the corresponding EFS filesystem ID.
+
+### Prerequisite setup
+Complete the [efs-utils crossaccount mount option setup](https://github.com/aws/efs-utils?tab=readme-ov-file#crossaccount-option-prerequisites).
+
+### Deploy the Example Application
+Create PV and persistent volume claim (PVC):
+```sh
+>> kubectl apply -f examples/kubernetes/cross_account_mount/specs/storageclass-static-prov.yaml
+>> kubectl apply -f examples/kubernetes/cross_account_mount/specs/pv.yaml
+>> kubectl apply -f examples/kubernetes/cross_account_mount/specs/claim.yaml
+>> kubectl apply -f examples/kubernetes/cross_account_mount/specs/pod-static-prov.yaml
+```
+
+### Check EFS filesystem is used
+After the objects are created, verify that pod is running:
+
+```sh
+>> kubectl get pods
+```
+
+Also you can verify that data is written onto EFS filesystem:
+
+```sh
+>> kubectl exec -ti efs-app -- tail -f /data/out.txt
+```

--- a/examples/kubernetes/cross_account_mount/specs/claim.yaml
+++ b/examples/kubernetes/cross_account_mount/specs/claim.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: efs-claim
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: efs-sc
+  resources:
+    requests:
+      storage: 5Gi

--- a/examples/kubernetes/cross_account_mount/specs/pod-static-prov.yaml
+++ b/examples/kubernetes/cross_account_mount/specs/pod-static-prov.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: efs-app
+spec:
+  containers:
+  - name: app
+    image: centos
+    command: ["/bin/sh"]
+    args: ["-c", "while true; do echo $(date -u) >> /data/out.txt; sleep 5; done"]
+    volumeMounts:
+    - name: persistent-storage
+      mountPath: /data
+  volumes:
+  - name: persistent-storage
+    persistentVolumeClaim:
+      claimName: efs-claim

--- a/examples/kubernetes/cross_account_mount/specs/pv.yaml
+++ b/examples/kubernetes/cross_account_mount/specs/pv.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: efs-pv
+spec:
+  capacity:
+    storage: 5Gi
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: efs-sc
+  persistentVolumeReclaimPolicy: Retain
+  csi:
+    driver: efs.csi.aws.com
+    volumeHandle: [Filesystem ID]
+    volumeAttributes:
+      crossaccount: "true"

--- a/examples/kubernetes/cross_account_mount/specs/storageclass-static-prov.yaml
+++ b/examples/kubernetes/cross_account_mount/specs/storageclass-static-prov.yaml
@@ -1,0 +1,5 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: efs-sc
+provisioner: efs.csi.aws.com

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -20,12 +20,13 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
-	"github.com/google/uuid"
 	"os"
 	"path"
 	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/google/uuid"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/kubernetes-sigs/aws-efs-csi-driver/pkg/cloud"
@@ -59,6 +60,7 @@ const (
 	Uid                   = "uid"
 	ReuseAccessPointKey   = "reuseAccessPoint"
 	PvcNameKey            = "csi.storage.k8s.io/pvc/name"
+	CrossAccount          = "crossaccount"
 )
 
 var (
@@ -117,15 +119,16 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 	}
 
 	var (
-		azName           string
-		basePath         string
-		gid              int64
-		gidMin           int64
-		gidMax           int64
-		localCloud       cloud.Cloud
-		provisioningMode string
-		roleArn          string
-		uid              int64
+		azName                 string
+		basePath               string
+		gid                    int64
+		gidMin                 int64
+		gidMax                 int64
+		localCloud             cloud.Cloud
+		provisioningMode       string
+		roleArn                string
+		uid                    int64
+		crossAccountDNSEnabled bool
 	)
 
 	//Parse parameters
@@ -236,7 +239,7 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 		azName = value
 	}
 
-	localCloud, roleArn, err = getCloud(req.GetSecrets(), d)
+	localCloud, roleArn, crossAccountDNSEnabled, err = getCloud(req.GetSecrets(), d)
 	if err != nil {
 		return nil, err
 	}
@@ -326,13 +329,22 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 
 	volContext := map[string]string{}
 
-	// Fetch mount target Ip for cross-account mount
+	// Enable cross-account dns resolution or fetch mount target Ip for cross-account mount
 	if roleArn != "" {
-		mountTarget, err := localCloud.DescribeMountTargets(ctx, accessPointsOptions.FileSystemId, azName)
-		if err != nil {
-			klog.Warningf("Failed to describe mount targets for file system %v. Skip using `mounttargetip` mount option: %v", accessPointsOptions.FileSystemId, err)
+		if crossAccountDNSEnabled {
+			// This option indicates the customer would like to use DNS to resolve
+			// the cross-account mount target ip address (in order to mount to
+			// the same AZ-ID as the client instance); mounttargetip should
+			// not be used as a mount option in this case.
+			volContext[CrossAccount] = strconv.FormatBool(true)
 		} else {
-			volContext[MountTargetIp] = mountTarget.IPAddress
+			mountTarget, err := localCloud.DescribeMountTargets(ctx, accessPointsOptions.FileSystemId, azName)
+			if err != nil {
+				klog.Warningf("Failed to describe mount targets for file system %v. Skip using `mounttargetip` mount option: %v", accessPointsOptions.FileSystemId, err)
+			} else {
+				volContext[MountTargetIp] = mountTarget.IPAddress
+			}
+
 		}
 	}
 
@@ -347,12 +359,13 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 
 func (d *Driver) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequest) (*csi.DeleteVolumeResponse, error) {
 	var (
-		localCloud cloud.Cloud
-		roleArn    string
-		err        error
+		localCloud             cloud.Cloud
+		roleArn                string
+		crossAccountDNSEnabled bool
+		err                    error
 	)
 
-	localCloud, roleArn, err = getCloud(req.GetSecrets(), d)
+	localCloud, roleArn, crossAccountDNSEnabled, err = getCloud(req.GetSecrets(), d)
 	if err != nil {
 		return nil, err
 	}
@@ -392,12 +405,16 @@ func (d *Driver) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequest)
 			//Mount File System at it root and delete access point root directory
 			mountOptions := []string{"tls", "iam"}
 			if roleArn != "" {
-				mountTarget, err := localCloud.DescribeMountTargets(ctx, fileSystemId, "")
-
-				if err == nil {
-					mountOptions = append(mountOptions, MountTargetIp+"="+mountTarget.IPAddress)
+				if crossAccountDNSEnabled {
+					// Connect via dns rather than mounttargetip
+					mountOptions = append(mountOptions, CrossAccount)
 				} else {
-					klog.Warningf("Failed to describe mount targets for file system %v. Skip using `mounttargetip` mount option: %v", fileSystemId, err)
+					mountTarget, err := localCloud.DescribeMountTargets(ctx, fileSystemId, "")
+					if err == nil {
+						mountOptions = append(mountOptions, MountTargetIp+"="+mountTarget.IPAddress)
+					} else {
+						klog.Warningf("Failed to describe mount targets for file system %v. Skip using `mounttargetip` mount option: %v", fileSystemId, err)
+					}
 				}
 			}
 
@@ -520,10 +537,11 @@ func (d *Driver) ControllerGetVolume(ctx context.Context, req *csi.ControllerGet
 	return nil, status.Error(codes.Unimplemented, "")
 }
 
-func getCloud(secrets map[string]string, driver *Driver) (cloud.Cloud, string, error) {
+func getCloud(secrets map[string]string, driver *Driver) (cloud.Cloud, string, bool, error) {
 
 	var localCloud cloud.Cloud
 	var roleArn string
+	var crossAccountDNSEnabled bool
 	var err error
 
 	// Fetch aws role ARN for cross account mount from CSI secrets. Link to CSI secrets below
@@ -531,17 +549,25 @@ func getCloud(secrets map[string]string, driver *Driver) (cloud.Cloud, string, e
 	if value, ok := secrets[RoleArn]; ok {
 		roleArn = value
 	}
+	if value, ok := secrets[CrossAccount]; ok {
+		crossAccountDNSEnabled, err = strconv.ParseBool(value)
+		if err != nil {
+			return nil, "", false, status.Error(codes.InvalidArgument, "crossaccount parameter must have boolean value.")
+		}
+	} else {
+		crossAccountDNSEnabled = false
+	}
 
 	if roleArn != "" {
 		localCloud, err = cloud.NewCloudWithRole(roleArn)
 		if err != nil {
-			return nil, "", status.Errorf(codes.Unauthenticated, "Unable to initialize aws cloud: %v. Please verify role has the correct AWS permissions for cross account mount", err)
+			return nil, "", false, status.Errorf(codes.Unauthenticated, "Unable to initialize aws cloud: %v. Please verify role has the correct AWS permissions for cross account mount", err)
 		}
 	} else {
 		localCloud = driver.cloud
 	}
 
-	return localCloud, roleArn, nil
+	return localCloud, roleArn, crossAccountDNSEnabled, nil
 }
 
 func interpolateRootDirectoryName(rootDirectoryPath string, volumeParams map[string]string) (string, error) {

--- a/pkg/driver/node_test.go
+++ b/pkg/driver/node_test.go
@@ -498,7 +498,7 @@ func TestNodePublishVolume(t *testing.T) {
 			expectMakeDir: false,
 			expectError: errtyp{
 				code:    "InvalidArgument",
-				message: "Volume context property asdf not supported",
+				message: "Volume context property asdf not supported.",
 			},
 		},
 		{


### PR DESCRIPTION
…count mount option for cross-account AZ mapping between client instance and mount target

**Background**
[efs-utils v1.36.0 added a new feature to allow for AZ mapping between the client instance and EFS mount target](https://github.com/aws/efs-utils/commit/28c522f68aedb5fb6afc74e02acb93e405af26da) over cross-account mounts. This means that, with the [proper setup](https://github.com/aws/efs-utils?tab=readme-ov-file#crossaccount-option-prerequisites), users can ensure their client instances are in the same physical AZ as their EFS mount target, which has been a pain-point for users in the past.

**Is this a bug fix or adding new feature?**
This PR adds a new feature.
**What is this PR about? / Why do we need it?**
This PR adds the option for EFS CSI Driver users to ensure their client instances & EFS mount targets are in the same physical AZ when doing cross-account static & dynamic provisioning. This was impossible to ensure before, and led to unnecessary cross-AZ costs as well as lack of assurance of availability for users' services.
**What testing is done?** 
unit/e2e, manual
```
#DYNAMIC PROVISIONING 
[zatzsea@dev-dsk-zatzsea-1a-5f552df4 eks-dynamic-prov]$ kubectl create secret generic x-account --namespace=kube-system --from-literal=awsRoleArn='arn:aws:iam::673675429741:role/EFSCrossAccountAZMapRole' --from-literal=crossaccount='true'
secret/x-account created
[zatzsea@dev-dsk-zatzsea-1a-5f552df4 eks-dynamic-prov]$ kubectl apply -f storageclass.yaml 
storageclass.storage.k8s.io/efs-sc created
[zatzsea@dev-dsk-zatzsea-1a-5f552df4 eks-dynamic-prov]$ kubectl apply -f pod.yaml 
persistentvolumeclaim/efs-claim created
pod/efs-app created
[zatzsea@dev-dsk-zatzsea-1a-5f552df4 eks-dynamic-prov]$ kubectl get pod -A
NAMESPACE     NAME                                  READY   STATUS    RESTARTS        AGE
default       efs-app                               1/1     Running   0               22s
kube-system   aws-node-6wwzc                        2/2     Running   10 (7d1h ago)   41d
kube-system   aws-node-wvvkk                        2/2     Running   10 (7d1h ago)   41d
kube-system   coredns-6787556b84-d9pfd              1/1     Running   5 (7d1h ago)    41d
kube-system   coredns-6787556b84-fgz9t              1/1     Running   5 (7d1h ago)    41d
kube-system   efs-csi-controller-7b588877b5-grtx5   3/3     Running   0               2m3s
kube-system   efs-csi-controller-7b588877b5-ljh2m   3/3     Running   0               2m3s
kube-system   efs-csi-node-m8ssm                    3/3     Running   0               2m2s
kube-system   efs-csi-node-tw6qf                    3/3     Running   0               2m2s
kube-system   kube-proxy-rdgpk                      1/1     Running   5 (7d1h ago)    41d
kube-system   kube-proxy-wzjsk                      1/1     Running   5 (7d1h ago)    41d
[zatzsea@dev-dsk-zatzsea-1a-5f552df4 eks-dynamic-prov]$ kubectl exec --stdin --tty efs-app /bin/bash
kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead.
[root@efs-app /]# cat data/out 
Wed Mar 27 17:04:32 UTC 2024
Wed Mar 27 17:04:37 UTC 2024
Wed Mar 27 17:04:42 UTC 2024
Wed Mar 27 17:04:47 UTC 2024
Wed Mar 27 17:04:52 UTC 2024
Wed Mar 27 17:04:57 UTC 2024
Wed Mar 27 17:05:02 UTC 2024
Wed Mar 27 17:05:07 UTC 2024
Wed Mar 27 17:05:12 UTC 2024
Wed Mar 27 17:05:17 UTC 2024
Wed Mar 27 17:05:22 UTC 2024
Wed Mar 27 17:05:27 UTC 2024
Wed Mar 27 17:05:32 UTC 2024
Wed Mar 27 17:05:37 UTC 2024
[root@efs-app /]# echo $(date)
Wed Mar 27 17:05:53 UTC 2024
[root@efs-app /]# exit
exit
[zatzsea@dev-dsk-zatzsea-1a-5f552df4 eks-dynamic-prov]$ kubectl delete -f pod.yaml 
persistentvolumeclaim "efs-claim" deleted
pod "efs-app" deleted
[zatzsea@dev-dsk-zatzsea-1a-5f552df4 eks-dynamic-prov]$ kubectl delete -f storageclass.yaml 
storageclass.storage.k8s.io "efs-sc" deleted
[zatzsea@dev-dsk-zatzsea-1a-5f552df4 eks-dynamic-prov]$ kubectl delete secret x-account -n kube-system
secret "x-account" deleted
[zatzsea@dev-dsk-zatzsea-1a-5f552df4 eks-dynamic-prov]$ cd ../eks
eks-dynamic-prov/ eks-static-prov/  
[zatzsea@dev-dsk-zatzsea-1a-5f552df4 eks-dynamic-prov]$ cd ../eks-static-prov/


# STATIC PROVISIONING
[zatzsea@dev-dsk-zatzsea-1a-5f552df4 eks-static-prov]$ kubectl apply -f storageclass.yaml 
storageclass.storage.k8s.io/efs-sc created
[zatzsea@dev-dsk-zatzsea-1a-5f552df4 eks-static-prov]$ cat pv.yaml 
apiVersion: v1
kind: PersistentVolume
metadata:
  name: efs-pv
spec:
  capacity:
    storage: 5Gi
  volumeMode: Filesystem
  accessModes:
    - ReadWriteOnce
  storageClassName: efs-sc
  persistentVolumeReclaimPolicy: Retain
  csi:
    driver: efs.csi.aws.com
    volumeHandle: fs-0c5a0e9cd917e2c9a
    volumeAttributes:
      crossaccount: "true"
[zatzsea@dev-dsk-zatzsea-1a-5f552df4 eks-static-prov]$ kubectl apply -f pv.yaml 
persistentvolume/efs-pv created
[zatzsea@dev-dsk-zatzsea-1a-5f552df4 eks-static-prov]$ kubectl apply -f claim.yaml 
persistentvolumeclaim/efs-claim created
[zatzsea@dev-dsk-zatzsea-1a-5f552df4 eks-static-prov]$ kubectl get pod -A
NAMESPACE     NAME                                  READY   STATUS    RESTARTS        AGE
kube-system   aws-node-6wwzc                        2/2     Running   10 (7d1h ago)   41d
kube-system   aws-node-wvvkk                        2/2     Running   10 (7d1h ago)   41d
kube-system   coredns-6787556b84-d9pfd              1/1     Running   5 (7d1h ago)    41d
kube-system   coredns-6787556b84-fgz9t              1/1     Running   5 (7d1h ago)    41d
kube-system   efs-csi-controller-7b588877b5-grtx5   3/3     Running   0               5m51s
kube-system   efs-csi-controller-7b588877b5-ljh2m   3/3     Running   0               5m51s
kube-system   efs-csi-node-m8ssm                    3/3     Running   0               5m50s
kube-system   efs-csi-node-tw6qf                    3/3     Running   0               5m50s
kube-system   kube-proxy-rdgpk                      1/1     Running   5 (7d1h ago)    41d
kube-system   kube-proxy-wzjsk                      1/1     Running   5 (7d1h ago)    41d
[zatzsea@dev-dsk-zatzsea-1a-5f552df4 eks-static-prov]$ kubectl apply -f pod.yaml 
pod/efs-app created
[zatzsea@dev-dsk-zatzsea-1a-5f552df4 eks-static-prov]$ kubectl get pod -A
NAMESPACE     NAME                                  READY   STATUS    RESTARTS        AGE
default       efs-app                               1/1     Running   0               3s
kube-system   aws-node-6wwzc                        2/2     Running   10 (7d1h ago)   41d
kube-system   aws-node-wvvkk                        2/2     Running   10 (7d1h ago)   41d
kube-system   coredns-6787556b84-d9pfd              1/1     Running   5 (7d1h ago)    41d
kube-system   coredns-6787556b84-fgz9t              1/1     Running   5 (7d1h ago)    41d
kube-system   efs-csi-controller-7b588877b5-grtx5   3/3     Running   0               6m3s
kube-system   efs-csi-controller-7b588877b5-ljh2m   3/3     Running   0               6m3s
kube-system   efs-csi-node-m8ssm                    3/3     Running   0               6m2s
kube-system   efs-csi-node-tw6qf                    3/3     Running   0               6m2s
kube-system   kube-proxy-rdgpk                      1/1     Running   5 (7d1h ago)    41d
kube-system   kube-proxy-wzjsk                      1/1     Running   5 (7d1h ago)    41d
[zatzsea@dev-dsk-zatzsea-1a-5f552df4 eks-static-prov]$ kubectl exec --stdin --tty efs-app /bin/bash
kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead.
[root@efs-app /]# echo $(date)
Wed Mar 27 17:09:09 UTC 2024
[root@efs-app /]# cat data/out.txt 
Wed Mar 27 17:08:50 UTC 2024
Wed Mar 27 17:08:55 UTC 2024
Wed Mar 27 17:09:00 UTC 2024
Wed Mar 27 17:09:05 UTC 2024
Wed Mar 27 17:09:10 UTC 2024
[root@efs-app /]# exit
exit
```