### PR TITLE
Templatize priorityClassName and additional labels

### DIFF
--- a/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
+++ b/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
@@ -21,6 +21,9 @@ spec:
         app: efs-csi-node
         app.kubernetes.io/name: {{ include "aws-efs-csi-driver.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- with .Values.node.podLabels }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
       {{- if .Values.node.podAnnotations }}
       annotations: {{ toYaml .Values.node.podAnnotations | nindent 8 }}
       {{- end }}
@@ -53,7 +56,7 @@ spec:
       dnsConfig: {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ .Values.node.serviceAccount.name }}
-      priorityClassName: system-node-critical
+      priorityClassName: {{ .Values.node.priorityClassName}}
       {{- with .Values.node.tolerations }}
       tolerations: {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -130,6 +130,7 @@ node:
     # "fs-01234567":
     #   ip: 10.10.2.2
     #   region: us-east-2
+  priorityClassName: system-node-critical
   dnsPolicy: ClusterFirst
   dnsConfig:
     {}
@@ -138,6 +139,7 @@ node:
     # dnsConfig:
     #   nameservers:
     #     - 169.254.169.253
+  podLabels: {}
   podAnnotations: {}
   resources:
     {}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Adding back non-"hostNetwork" changes from [this PR](https://github.com/kubernetes-sigs/aws-efs-csi-driver/pull/1281). 
This PR was reverted due to the bugs introduced with the hostNetwork functionality added, but only the hostNetwork values should have been reverted. 

**What is this PR about? / Why do we need it?**

The PR is about adding changes to the aws-efs-csi-driver helm chart.

In node-daemonset.yaml
- templatize priorityClassName
- add additional labels to node-daemonset.yaml

