### PR TITLE
Update the Helm configuration to use Public ECR image  default rather…

### DIFF
--- a/charts/aws-efs-csi-driver/CHANGELOG.md
+++ b/charts/aws-efs-csi-driver/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Helm chart
+# v3.0.2
+* Update Helm to use the image from Public ECR rather than DockerHub
 # v3.0.1
 * Bump app/driver version to `v2.0.1`
 # v3.0.0

--- a/charts/aws-efs-csi-driver/Chart.yaml
+++ b/charts/aws-efs-csi-driver/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: aws-efs-csi-driver
-version: 3.0.1
+version: 3.0.2
 appVersion: 2.0.1
 kubeVersion: ">=1.17.0-0"
 description: "A Helm chart for AWS EFS CSI Driver"

--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -10,7 +10,7 @@ replicaCount: 2
 useFIPS: false
 
 image:
-  repository: amazon/aws-efs-csi-driver
+  repository: public.ecr.aws/efs-csi-driver/amazon/aws-efs-csi-driver
   tag: "v2.0.1"
   pullPolicy: IfNotPresent
 

--- a/deploy/kubernetes/overlays/stable/ecr/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/ecr/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 bases:
   - ../../../base
 images:
-  - name: amazon/aws-efs-csi-driver
+  - name: public.ecr.aws/efs-csi-driver/amazon/aws-efs-csi-driver
     newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/aws-efs-csi-driver
     newTag: v2.0.1
   - name: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe

--- a/deploy/kubernetes/overlays/stable/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 bases:
   - ../../base
 images:
-  - name: amazon/aws-efs-csi-driver
+  - name: public.ecr.aws/efs-csi-driver/amazon/aws-efs-csi-driver
     newTag: v2.0.1
   - name: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe
     newTag: v2.12.0-eks-1-29-7


### PR DESCRIPTION
… than Dockerhub

**Is this a bug fix or adding new feature?**

**What is this PR about? / Why do we need it?**
Update the Helm configuration to use Public ECR image as default rather than Dockerhub

**What testing is done?** 
