### PR TITLE
Update Kustomize files to avoid deprecation warnings

### DIFF
--- a/deploy/kubernetes/overlays/dev/kustomization.yaml
+++ b/deploy/kubernetes/overlays/dev/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-bases:
+resources:
 - ../../base
-patchesStrategicMerge:
-- master_image.yaml
+patches:
+- path: master_image.yaml

--- a/deploy/kubernetes/overlays/stable/ecr/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/ecr/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-bases:
+resources:
   - ../../../base
 images:
   - name: public.ecr.aws/efs-csi-driver/amazon/aws-efs-csi-driver

--- a/deploy/kubernetes/overlays/stable/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-bases:
+resources:
   - ../../base
 images:
   - name: public.ecr.aws/efs-csi-driver/amazon/aws-efs-csi-driver


### PR DESCRIPTION
About the deprecation: 
`bases`: https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/bases/
`patchesStrategicMerge`: https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/patchesstrategicmerge/


**Is this a bug fix or adding new feature?**
A bug fix

**What is this PR about? / Why do we need it?**
Update Kustomize files to avoid warnings

**What testing is done?** 
`Kustomize build` stop warn about deprecations