### PR TITLE
Set `fips_mode_enabled` in `efs-utils.conf`

### DIFF
--- a/pkg/driver/efs_watch_dog_test.go
+++ b/pkg/driver/efs_watch_dog_test.go
@@ -54,6 +54,9 @@ stunnel_check_cert_hostname = true
 # Use OCSP to check certificate validity. This option is not supported by certain stunnel versions.
 stunnel_check_cert_validity = false
 
+# Enable FIPS mode. stunnel complains if FIPS is available and enabled system-wide, but not set here.
+#fips_mode_enabled = false
+
 # Define the port range that the TLS tunnel will choose from
 port_range_lower_bound = 20049
 port_range_upper_bound = 20449


### PR DESCRIPTION
if env var `FIPS_ENABLED` is set: https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/1325 .

**Is this a bug fix or adding new feature?**

This is a bug: if the driver is run in FIPS-enabled environment, `stunnel` fails with "Failed to override system-wide FIPS mode" (see `src/options.c` from [stunnel-5.72](https://www.stunnel.org/downloads/stunnel-5.72.tar.gz)).

**What is this PR about? / Why do we need it?**

The PR ensures that if `FIPS_ENABLED=true` as env var for aws-efs csi driver, it creates `efs-utils.conf` with `fips_mode_enabled = true`.

**What testing is done?** 

In the environment where `stunnel` fails with "Failed to override system-wide FIPS mode", re-create the Pod with aws-efs csi driver adding `FIPS_ENABLED=true` env var. Made sure that `fips_mode_enabled = true` is present in config and stunnel succeeds.

Fixes https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/1325