### PR TITLE
Pass the availability zone the Kubernetes node is in when mounting EFS filesystem

### DIFF
--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -106,6 +106,15 @@ func (d *Driver) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolu
 			if err != nil {
 				return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("Volume context property %q must be a boolean value: %v", k, err))
 			}
+		case strings.ToLower(DiscoverAzName):
+			discoverAzNameEnabled, err := strconv.ParseBool(v)
+			if err != nil {
+				return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("Volume context property %q must be a boolean value: %v", k, err))
+			}
+			if discoverAzNameEnabled {
+				az := d.cloud.GetMetadata().GetAvailabilityZone()
+				mountOptions = append(mountOptions, "az="+az)
+			}
 		default:
 			return nil, status.Errorf(codes.InvalidArgument, "Volume context property %s not supported.", k)
 		}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
New feature

**What is this PR about? / Why do we need it?**
We noticed a problem in our clusters where EFS filesystems were being mounted across AZs. We managed to troubleshoot this back to the way that our DNS servers are set up, in that they are not guaranteed to exist in the same availability zone as the server making the DNS request. This can lead to the CSI driver resolving the wrong IP address for a mount target, as it will get the IP address of the mount target in the AZ that the DNS server receiving the request is in.

We tried several different approaches to solve the problem, like trying to ensure our DNS requests stayed in the same AZ as the server making the request (tricky as we wanted inter-AZ DNS requests for redundancy) and making use of the ability to pass an explicit AZ in the `StorageClass` (would have made our storage classes too restrictive)

Ultimately, we found the easiest way would be to have the EFS CSI driver detect the availability zone the Kubernetes node was in and pass that information along when mounting the filesystem

**What testing is done?** 
We have been running a forked version of the EFS CSI driver that includes this change for about 4 weeks now. Since including the change we have seen all inter-AZ traffic related to EFS disappear