### PR TITLE
Update securityContext:privileged to false as EKS Fargate do not sup…

### DIFF
--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -105,9 +105,10 @@ controller:
     runAsGroup: 0
     fsGroup: 0
   # securityContext on the controller container
-  # Setting privileged=false will cause the "delete-access-point-root-dir" controller option to fail
+  # Setting privileged=false as privileged access are not supported by EKS Fargate.
+  # Customers who wants to enable delete-access-point-root-dir parameter can set this to true.
   containerSecurityContext:
-    privileged: true
+    privileged: false
   leaderElectionRenewDeadline: 10s
   leaderElectionLeaseDuration: 15s
 

--- a/deploy/kubernetes/base/controller-deployment.yaml
+++ b/deploy/kubernetes/base/controller-deployment.yaml
@@ -36,7 +36,7 @@ spec:
       containers:
         - name: efs-plugin
           securityContext:
-            privileged: true
+            privileged: false
           image: public.ecr.aws/efs-csi-driver/amazon/aws-efs-csi-driver:v2.0.2
           imagePullPolicy: IfNotPresent
           args:

--- a/docs/README.md
+++ b/docs/README.md
@@ -344,6 +344,9 @@ Enabling the vol-metrics-opt-in parameter activates the gathering of inode and d
 |-----------------------------|--------|---------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | delete-access-point-root-dir|        | false  | true     | Opt in to delete access point root directory by DeleteVolume. By default, DeleteVolume will delete the access point behind Persistent Volume and deleting access point will not delete the access point root directory or its contents. |
 | tags                         |       |         | true     | Space separated key:value pairs which will be added as tags for Amazon EFS resources. For example, '--tags=name:efs-tag-test date:Jan24'                                                                                               |
+
+ ##### Note: 
+When enabling `delete-access-point-root-dir`, ensure that you also set `securityContext:privileged` to **true** under the efs-plugin in the controller. By default, this is set to false because EKS Fargate does not support privileged access.
 ### Upgrading the Amazon EFS CSI Driver
 
 


### PR DESCRIPTION
…port privileged access.

**Is this a bug fix or adding new feature?**

**What is this PR about? / Why do we need it?**
EKS Fargate does not support privileged access, so setting the parameter `containerSecurityContext: privileged: true` will break Fargate deployments. This parameter was mainly introduced because enabling it allows the deletion of the access point root directory when `delete-access-point-root-dir` is enabled. Users who want to delete the access point root directory can enable this manually.

**What testing is done?** 
