### PR TITLE
Bump sidecar versions to fix CVE-2023-45288 and CVE-2024-24786

### DIFF
--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -18,7 +18,7 @@ sidecars:
   livenessProbe:
     image:
       repository: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe
-      tag: v2.12.0-eks-1-29-7
+      tag: v2.13.0-eks-1-30-7
       pullPolicy: IfNotPresent
     resources: {}
     securityContext:
@@ -27,7 +27,7 @@ sidecars:
   nodeDriverRegistrar:
     image:
       repository: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar
-      tag: v2.10.0-eks-1-29-7
+      tag: v2.11.0-eks-1-30-7
       pullPolicy: IfNotPresent
     resources: {}
     securityContext:
@@ -36,7 +36,7 @@ sidecars:
   csiProvisioner:
     image:
       repository: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner
-      tag: v4.0.0-eks-1-29-7
+      tag: v4.0.1-eks-1-30-7
       pullPolicy: IfNotPresent
     resources: {}
     securityContext:

--- a/deploy/kubernetes/base/controller-deployment.yaml
+++ b/deploy/kubernetes/base/controller-deployment.yaml
@@ -67,7 +67,7 @@ spec:
             periodSeconds: 10
             failureThreshold: 5
         - name: csi-provisioner
-          image: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner:v4.0.0-eks-1-29-7
+          image: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner:v4.0.1-eks-1-30-7
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)
@@ -85,7 +85,7 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
         - name: liveness-probe
-          image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.12.0-eks-1-29-7
+          image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-7
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=/csi/csi.sock

--- a/deploy/kubernetes/base/node-daemonset.yaml
+++ b/deploy/kubernetes/base/node-daemonset.yaml
@@ -89,7 +89,7 @@ spec:
             periodSeconds: 2
             failureThreshold: 5
         - name: csi-driver-registrar
-          image: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar:v2.10.0-eks-1-29-7
+          image: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar:v2.11.0-eks-1-30-7
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)
@@ -113,7 +113,7 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
         - name: liveness-probe
-          image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.12.0-eks-1-29-7
+          image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-7
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=/csi/csi.sock

--- a/deploy/kubernetes/overlays/stable/ecr/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/ecr/kustomization.yaml
@@ -8,10 +8,10 @@ images:
     newTag: v2.0.4
   - name: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe
     newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/livenessprobe
-    newTag: v2.12.0-eks-1-29-7
+    newTag: v2.13.0-eks-1-30-7
   - name: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar
     newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-node-driver-registrar
-    newTag: v2.10.0-eks-1-29-7
+    newTag: v2.11.0-eks-1-30-7
   - name: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner
     newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-provisioner
-    newTag: v4.0.0-eks-1-29-7
+    newTag: v4.0.1-eks-1-30-7

--- a/deploy/kubernetes/overlays/stable/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/kustomization.yaml
@@ -6,8 +6,8 @@ images:
   - name: public.ecr.aws/efs-csi-driver/amazon/aws-efs-csi-driver
     newTag: v2.0.4
   - name: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe
-    newTag: v2.12.0-eks-1-29-7
+    newTag: v2.13.0-eks-1-30-7
   - name: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar
-    newTag: v2.10.0-eks-1-29-7
+    newTag: v2.11.0-eks-1-30-7
   - name: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner
-    newTag: v4.0.0-eks-1-29-7
+    newTag: v4.0.1-eks-1-30-7


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
bug fix.
fixes: #1365 

**What is this PR about? / Why do we need it?**
Mitigating CVE-2023-45288 and CVE-2024-24786

**What testing is done?** 
Following tests:
```bash
 ~/Desktop/PersonlRepos/aws-efs-csi-driver/ [sidecarsversionsbump] trivy image public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-7
2024-06-11T09:40:26+03:00	INFO	Vulnerability scanning is enabled
2024-06-11T09:40:26+03:00	INFO	Secret scanning is enabled
2024-06-11T09:40:26+03:00	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-06-11T09:40:26+03:00	INFO	Please see also https://aquasecurity.github.io/trivy/v0.52/docs/scanner/secret/#recommendation for faster secret detection
2024-06-11T09:40:28+03:00	INFO	Detected OS	family="amazon" version="2 (Karoo)"
2024-06-11T09:40:28+03:00	INFO	[amazon] Detecting vulnerabilities...	os_version="2" pkg_num=6
2024-06-11T09:40:28+03:00	INFO	Number of language-specific files	num=1
2024-06-11T09:40:28+03:00	INFO	[gobinary] Detecting vulnerabilities...

public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-7 (amazon 2 (Karoo))

Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)
```
and

```bash
 ~/Desktop/PersonlRepos/aws-efs-csi-driver/ [sidecarsversionsbump] trivy image public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar:v2.11.0-eks-1-30-7
2024-06-11T09:41:19+03:00	INFO	Vulnerability scanning is enabled
2024-06-11T09:41:19+03:00	INFO	Secret scanning is enabled
2024-06-11T09:41:19+03:00	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-06-11T09:41:19+03:00	INFO	Please see also https://aquasecurity.github.io/trivy/v0.52/docs/scanner/secret/#recommendation for faster secret detection
2024-06-11T09:41:22+03:00	INFO	Detected OS	family="amazon" version="2 (Karoo)"
2024-06-11T09:41:22+03:00	INFO	[amazon] Detecting vulnerabilities...	os_version="2" pkg_num=6
2024-06-11T09:41:22+03:00	INFO	Number of language-specific files	num=1
2024-06-11T09:41:22+03:00	INFO	[gobinary] Detecting vulnerabilities...

public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar:v2.11.0-eks-1-30-7 (amazon 2 (Karoo))

Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)
```

and

```bash
 ~/Desktop/PersonlRepos/aws-efs-csi-driver/ [sidecarsversionsbump] trivy image public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner:v4.0.1-eks-1-30-7
2024-06-11T09:42:05+03:00	INFO	Vulnerability scanning is enabled
2024-06-11T09:42:05+03:00	INFO	Secret scanning is enabled
2024-06-11T09:42:05+03:00	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-06-11T09:42:05+03:00	INFO	Please see also https://aquasecurity.github.io/trivy/v0.52/docs/scanner/secret/#recommendation for faster secret detection
2024-06-11T09:42:07+03:00	INFO	Detected OS	family="amazon" version="2 (Karoo)"
2024-06-11T09:42:07+03:00	INFO	[amazon] Detecting vulnerabilities...	os_version="2" pkg_num=6
2024-06-11T09:42:07+03:00	INFO	Number of language-specific files	num=1
2024-06-11T09:42:07+03:00	INFO	[gobinary] Detecting vulnerabilities...

public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner:v4.0.1-eks-1-30-7 (amazon 2 (Karoo))

Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)
```


