### PR TITLE
feat: enable metrics for csi provisioner

### DIFF
--- a/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
+++ b/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
@@ -133,6 +133,8 @@ spec:
             {{- end }}
             {{- if hasKey .Values.controller "leaderElectionLeaseDuration" }}
             - --leader-election-lease-duration={{ .Values.controller.leaderElectionLeaseDuration }}
+            - --metrics-address=:{{ .Values.controller.metrics.port }}
+            - --metrics-path={{ .Values.controller.metrics.path }}
             {{- end }}
           env:
             - name: ADDRESS
@@ -140,6 +142,10 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
+          ports:
+            - name: metrics
+              containerPort: {{ .Values.controller.metrics.port }}
+              protocol: TCP
           {{- with .Values.sidecars.csiProvisioner.resources }}
           resources: {{ toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -113,6 +113,10 @@ controller:
     privileged: true
   leaderElectionRenewDeadline: 10s
   leaderElectionLeaseDuration: 15s
+  # Enable metrics for CSI Provisioner
+  metrics:
+    port: 8080
+    path: /metrics
 
 
 ## Node daemonset variables


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Enable metrics for csi-provisioner

**What testing is done?** 
manually tested by adding **--metrics-address=:8080** and **--metrics-path=/metrics** args and **the containerPort 8080** to csi-provisioner container 