### PR TITLE
feat: enable metrics for csi-provisioner

### DIFF
--- a/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
+++ b/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
@@ -134,12 +134,22 @@ spec:
             {{- if hasKey .Values.controller "leaderElectionLeaseDuration" }}
             - --leader-election-lease-duration={{ .Values.controller.leaderElectionLeaseDuration }}
             {{- end }}
+            {{- if .Values.controller.metrics.enabled }}
+            - --metrics-address=:{{ .Values.controller.metrics.port }}
+            - --metrics-path={{ .Values.controller.metrics.path }}
+            {{- end }}
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
+          {{- if .Values.controller.metrics.enabled }}
+          ports:
+            - name: metrics
+              containerPort: {{ .Values.controller.metrics.port }}
+              protocol: TCP
+          {{- end }}
           {{- with .Values.sidecars.csiProvisioner.resources }}
           resources: {{ toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -113,6 +113,11 @@ controller:
     privileged: true
   leaderElectionRenewDeadline: 10s
   leaderElectionLeaseDuration: 15s
+  # Enable metrics for csi-provisioner
+  metrics:
+    enabled: false
+    port: 8080
+    path: /metrics
 
 
 ## Node daemonset variables


### PR DESCRIPTION
**What is this PR about? / Why do we need it?**
Enable metrics for csi-provisioner

**What testing is done?** 
Manually tested by adding **--metrics-address and** **--metrics-path** args and **port for metrics** to the csi-provisioner container