### PR TITLE
Add revisionHistoryLimit support to Node DaemonSet and Controller Deployment

### DIFF
--- a/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
+++ b/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
@@ -11,6 +11,7 @@ metadata:
     {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: {{ .Values.controller.revisionHistoryLimit }}
   selector:
     matchLabels:
       app: efs-csi-controller

--- a/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
+++ b/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: {{ include "aws-efs-csi-driver.name" . }}
 spec:
+  revisionHistoryLimit: {{ .Values.node.revisionHistoryLimit }}
   selector:
     matchLabels:
       app: efs-csi-node

--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -81,6 +81,7 @@ controller:
     # requests:
     #   cpu: 100m
     #   memory: 128Mi
+  revisionHistoryLimit: 10
   nodeSelector: {}
   updateStrategy: {}
   tolerations:
@@ -152,6 +153,7 @@ node:
     # requests:
     #   cpu: 100m
     #   memory: 128Mi
+  revisionHistoryLimit: 10
   nodeSelector: {}
   updateStrategy: {}
     # Override default strategy (RollingUpdate) to speed up deployment.


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

New Feature

**What is this PR about? / Why do we need it?**

Adds `revisionHistoryLimit` support in `aws-efs-csi-driver` with defaults set to K8s default, following the [lead in `aws-load-balancer-controller`](https://github.com/search?q=repo%3Aaws%2Feks-charts+revisionHistoryLimit+path%3A%2F%5Estable%5C%2Faws-load-balancer-controller%5C%2F%2F&type=code).

**What testing is done?** 

Helm template validation.
