### PR TITLE
Add additionalLabels to node-daemonset

### DIFF
--- a/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
+++ b/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
@@ -5,6 +5,9 @@ metadata:
   name: efs-csi-node
   labels:
     app.kubernetes.io/name: {{ include "aws-efs-csi-driver.name" . }}
+    {{- with .Values.node.additionalLabels }}
+    {{ toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   selector:
     matchLabels:

--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -144,6 +144,7 @@ node:
     #     - 169.254.169.253
   podLabels: {}
   podAnnotations: {}
+  additionalLabels: {}
   resources:
     {}
     # limits:


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
New feature - adding additionalLabels to node-daemonset

**What is this PR about? / Why do we need it?**
Fixes: #1388

**What testing is done?** 
Manually testes. using this values file snippet:
```yaml
node:
  # Number for the log level verbosity
  logLevel: 2
  volMetricsOptIn: false
  volMetricsRefreshPeriod: 240
  volMetricsFsRateLimit: 5
  hostAliases:
    {}
    # For cross VPC EFS, you need to poison or overwrite the DNS for the efs volume as per
    # https://docs.aws.amazon.com/efs/latest/ug/efs-different-vpc.html#wt6-efs-utils-step3
    # implementing the suggested solution found here:
    # https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/240#issuecomment-676849346
    # EFS Vol ID, IP, Region
    # "fs-01234567":
    #   ip: 10.10.2.2
    #   region: us-east-2
  priorityClassName: system-node-critical
  dnsPolicy: ClusterFirst
  dnsConfig:
    {}
    # Example config which uses the AWS nameservers
    # dnsPolicy: "None"
    # dnsConfig:
    #   nameservers:
    #     - 169.254.169.253
  podLabels: {}
  podAnnotations: {}
  additionalLabels:
    app.kubernetes.io/version: 1.1.0
    app.kubernetes.io/managed-by: helm 
    app.kubernetes.io/part-of: aws-efs-csi-driver
  resources:
    {}
    # limits:
    #   cpu: 100m
    #   memory: 128Mi
    # requests:
    #   cpu: 100m
    #   memory: 128Mi
  nodeSelector: {}
  updateStrategy: {}
    # Override default strategy (RollingUpdate) to speed up deployment.
    # This can be useful if helm timeouts are observed.
    # type: OnDelete
  tolerations:
    - operator: Exists
  affinity:
    nodeAffinity:
      requiredDuringSchedulingIgnoredDuringExecution:
        nodeSelectorTerms:
          - matchExpressions:
              - key: eks.amazonaws.com/compute-type
                operator: NotIn
                values:
                  - fargate
  # Specifies whether a service account should be created
  serviceAccount:
    create: true
    name: efs-csi-node-sa
    annotations: {}
    ## Enable if EKS IAM for SA is used
    #  eks.amazonaws.com/role-arn: arn:aws:iam::111122223333:role/efs-csi-role
  healthPort: 9809
  # securityContext on the node pod
  securityContext:
    # The node pod must be run as root to bind to the registration/driver sockets
    runAsNonRoot: false
    runAsUser: 0
    runAsGroup: 0
    fsGroup: 0
  env: []
  volumes: []
  volumeMounts: []

storageClasses: []
# Add StorageClass resources like:
# - name: efs-sc
#   annotations:
#     # Use that annotation if you want this to your default storageclass
#     storageclass.kubernetes.io/is-default-class: "true"
#   mountOptions:
#   - tls
#   parameters:
#     provisioningMode: efs-ap
#     fileSystemId: fs-1122aabb
#     directoryPerms: "700"
#     gidRangeStart: "1000"
#     gidRangeEnd: "2000"
#     basePath: "/dynamic_provisioning"
#     subPathPattern: "/subPath"
#     ensureUniqueDirectory: true
#   reclaimPolicy: Delete
#   volumeBindingMode: Immediate
```

will generate this manifest:
```yaml
---
# Source: aws-efs-csi-driver/templates/node-daemonset.yaml
# Node Service
kind: DaemonSet
apiVersion: apps/v1
metadata:
  name: efs-csi-node
  labels:
    app.kubernetes.io/name: aws-efs-csi-driver
    
    app.kubernetes.io/managed-by: helm
    app.kubernetes.io/part-of: aws-efs-csi-driver
    app.kubernetes.io/version: 1.1.0
spec:
  selector:
    matchLabels:
      app: efs-csi-node
      app.kubernetes.io/name: aws-efs-csi-driver
      app.kubernetes.io/instance: release-name
  template:
    metadata:
      labels:
        app: efs-csi-node
        app.kubernetes.io/name: aws-efs-csi-driver
        app.kubernetes.io/instance: release-name
    spec:
      nodeSelector:
        kubernetes.io/os: linux
      affinity:
        nodeAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
            nodeSelectorTerms:
            - matchExpressions:
              - key: eks.amazonaws.com/compute-type
                operator: NotIn
                values:
                - fargate
      hostNetwork: true
      dnsPolicy: ClusterFirst
      serviceAccountName: efs-csi-node-sa
      priorityClassName: system-node-critical
      tolerations:
        - operator: Exists
      securityContext:
        fsGroup: 0
        runAsGroup: 0
        runAsNonRoot: false
        runAsUser: 0
      containers:
        - name: efs-plugin
          securityContext:
            privileged: true
          image: public.ecr.aws/efs-csi-driver/amazon/aws-efs-csi-driver:v2.0.4
          imagePullPolicy: IfNotPresent
          args:
            - --endpoint=$(CSI_ENDPOINT)
            - --logtostderr
            - --v=2
            - --vol-metrics-opt-in=false
            - --vol-metrics-refresh-period=240
            - --vol-metrics-fs-rate-limit=5
          env:
            - name: CSI_ENDPOINT
              value: unix:/csi/csi.sock
            - name: CSI_NODE_NAME
              valueFrom:
                fieldRef:
                  fieldPath: spec.nodeName
          volumeMounts:
            - name: kubelet-dir
              mountPath: /var/lib/kubelet
              mountPropagation: "Bidirectional"
            - name: plugin-dir
              mountPath: /csi
            - name: efs-state-dir
              mountPath: /var/run/efs
            - name: efs-utils-config
              mountPath: /var/amazon/efs
            - name: efs-utils-config-legacy
              mountPath: /etc/amazon/efs-legacy
          ports:
            - name: healthz
              containerPort: 9809
              protocol: TCP
          livenessProbe:
            httpGet:
              path: /healthz
              port: healthz
            initialDelaySeconds: 10
            timeoutSeconds: 3
            periodSeconds: 2
            failureThreshold: 5
        - name: csi-driver-registrar
          image: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar:v2.11.0-eks-1-30-8
          imagePullPolicy: IfNotPresent
          args:
            - --csi-address=$(ADDRESS)
            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
            - --v=2
          env:
            - name: ADDRESS
              value: /csi/csi.sock
            - name: DRIVER_REG_SOCK_PATH
              value: /var/lib/kubelet/plugins/efs.csi.aws.com/csi.sock
            - name: KUBE_NODE_NAME
              valueFrom:
                fieldRef:
                  fieldPath: spec.nodeName
          volumeMounts:
            - name: plugin-dir
              mountPath: /csi
            - name: registration-dir
              mountPath: /registration
          securityContext:
            allowPrivilegeEscalation: false
            readOnlyRootFilesystem: true
        - name: liveness-probe
          image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-8
          imagePullPolicy: IfNotPresent
          args:
            - --csi-address=/csi/csi.sock
            - --health-port=9809
            - --v=2
          volumeMounts:
            - name: plugin-dir
              mountPath: /csi
          securityContext:
            allowPrivilegeEscalation: false
            readOnlyRootFilesystem: true
      volumes:
        - name: kubelet-dir
          hostPath:
            path: /var/lib/kubelet
            type: Directory
        - name: plugin-dir
          hostPath:
            path: /var/lib/kubelet/plugins/efs.csi.aws.com/
            type: DirectoryOrCreate
        - name: registration-dir
          hostPath:
            path: /var/lib/kubelet/plugins_registry/
            type: Directory
        - name: efs-state-dir
          hostPath:
            path: /var/run/efs
            type: DirectoryOrCreate
        - name: efs-utils-config
          hostPath:
            path: /var/amazon/efs
            type: DirectoryOrCreate
        - name: efs-utils-config-legacy
          hostPath:
            path: /etc/amazon/efs
            type: DirectoryOrCreate
```

