### PR TITLE
Helm chart configurable model for cross account role

### DIFF
--- a/charts/aws-efs-csi-driver/CHANGELOG.md
+++ b/charts/aws-efs-csi-driver/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Helm chart
+# v3.1.0
+* Allow user to enable/disable cross account role creation and able to customize cross account secret name or provide more than one.
+* This change is not breaking and the default values will create the same x-account as before.
 # v3.0.6
 * Bump app/driver version to `v2.0.5`
 # v3.0.5
@@ -44,7 +47,7 @@
 # v2.4.3
 * Bump app/driver version to `v1.5.6`
 # v2.4.2
-* Bump app/driver version to `v1.5.5` 
+* Bump app/driver version to `v1.5.5`
 # v2.4.1
 * Bump app/driver version to `v1.5.4`
 # v2.4.0
@@ -116,7 +119,7 @@
 * Add node.serviceAccount values for creating and/or specifying daemonset service account
 
 # v2.1.3
-* Bump app/driver version to `v1.3.2` 
+* Bump app/driver version to `v1.3.2`
 
 # v2.1.2
 * Add extra-create-metadata

--- a/charts/aws-efs-csi-driver/Chart.yaml
+++ b/charts/aws-efs-csi-driver/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: aws-efs-csi-driver
-version: 3.0.6
+version: 3.1.0
 appVersion: 2.0.5
 kubeVersion: ">=1.17.0-0"
 description: "A Helm chart for AWS EFS CSI Driver"

--- a/charts/aws-efs-csi-driver/templates/controller-serviceaccount.yaml
+++ b/charts/aws-efs-csi-driver/templates/controller-serviceaccount.yaml
@@ -11,7 +11,6 @@ metadata:
   {{- end }}
 {{- end }}
 ---
-
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -41,6 +40,7 @@ rules:
     resources: ["leases"]
     verbs: ["get", "watch", "list", "delete", "update", "create"]
 ---
+{{- if .Values.crossAccountRole.create }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -48,10 +48,14 @@ metadata:
   labels:
     app.kubernetes.io/name: {{ include "aws-efs-csi-driver.name" . }}
 rules:
-  - apiGroups: [ "" ]
-    resources: [ "secrets" ]
-    resourceNames: ["x-account"]
-    verbs: [ "get", "watch", "list" ]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    {{- with .Values.crossAccountRole.secrets }}
+    resourceNames:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    verbs: ["get", "watch", "list"]
+{{- end }}
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -68,7 +72,8 @@ roleRef:
   name: efs-csi-external-provisioner-role
   apiGroup: rbac.authorization.k8s.io
 ---
-# We use a RoleBinding to restrict Secret access to the namespace that the 
+{{- if .Values.crossAccountRole.create }}
+# We use a RoleBinding to restrict Secret access to the namespace that the
 # RoleBinding is created in (typically kube-system)
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -84,3 +89,4 @@ roleRef:
   kind: ClusterRole
   name: efs-csi-external-provisioner-role-describe-secrets
   apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -207,3 +207,13 @@ storageClasses: []
 #     ensureUniqueDirectory: true
 #   reclaimPolicy: Delete
 #   volumeBindingMode: Immediate
+
+# It will create ClusterRole and RoleBinding resources to allow the
+# controller access the Secret resources to read cross accounts' arns.
+crossAccountRole:
+  create: true
+  # If empty list provided, it means the controller has access to read
+  # all secrets in the same namespace as the efs csi driver.
+  # secrets: []
+  secrets:
+    - x-account


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Adding a new feature to the helm chart. Non-breaking.

**What is this PR about? / Why do we need it?**
To allow the user to dynamically manage secret names for cross account or disable it.

**What testing is done?** 
- [x] Deployment to the platform.
- [x] Deployment with the same behaviour before this change.
- [x] Deployment with customized secret names.
- [x] Deployment with allowing access to all secrets in the same namespace.
