### PR TITLE
allow setting of hostNetwork for the node ds

### DIFF
--- a/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
+++ b/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
@@ -53,7 +53,7 @@ spec:
       {{- with .Values.node.affinity }}
       affinity: {{- toYaml . | nindent 8 }}
       {{- end }}
-      hostNetwork: true
+      hostNetwork: {{ .Values.node.hostNetwork }}
       dnsPolicy: {{ .Values.node.dnsPolicy }}
       {{- with .Values.node.dnsConfig }}
       dnsConfig: {{- toYaml . | nindent 8 }}

--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -123,6 +123,7 @@ node:
   volMetricsOptIn: false
   volMetricsRefreshPeriod: 240
   volMetricsFsRateLimit: 5
+  hostNetwork: true
   hostAliases:
     {}
     # For cross VPC EFS, you need to poison or overwrite the DNS for the efs volume as per


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

feature

**What is this PR about? / Why do we need it?**

allows configuration of the hotstNetwork setting for the node daemonset.  This behavior is desired, but can be problematic for existing deployments. Some background:

https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/1179
https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/1127

Providing the option is beneficial for new installs, or people willing to resolve the mount problems when changing modes.

In our case we are using cilium in overlay mode and having this forced to `true` is problematic.

