### PR TITLE
Updated the docker file to install the latest version of Rust.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,11 @@ RUN mkdir -p /tmp/rpms && \
     then echo "Installing efs-utils from Amazon Linux 2 yum repo" && \
          yum -y install --downloadonly --downloaddir=/tmp/rpms amazon-efs-utils-1.35.0-1.amzn2.noarch; \
     else echo "Installing efs-utils from github using the latest git tag" && \
-         yum -y install git rpm-build make rust cargo openssl-devel && \
+         yum -y install git rpm-build make openssl-devel curl && \
+         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && \
+         source $HOME/.cargo/env && \
+         rustup update && \
+         rustup default stable && \
          git clone https://github.com/aws/efs-utils && \
          cd efs-utils && \
          git checkout $(git describe --tags $(git rev-list --tags --max-count=1)) && \


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

**What is this PR about? / Why do we need it?**
Update Dockerfile to install latest stable Rust using rustup

Modified the Dockerfile to install Rust via rustup instead of yum. This change ensures the latest stable version of Rust is used, which is necessary for compatibility with recent dependencies that require newer Rust versions. The update includes:
- Installing curl to fetch the rustup script.
- Using rustup to manage Rust installations and set the default toolchain to the latest stable version.
This modification enhances the build system's reliability and future-proofs the application against upcoming Rust updates.


**What testing is done?** 
