### PR TITLE
fix: don't ignore kubernetes API access failure during node taint removal

### DIFF
--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -477,8 +477,7 @@ func removeNotReadyTaint(k8sClient cloud.KubernetesAPIClient) error {
 
 	clientset, err := k8sClient()
 	if err != nil {
-		klog.V(4).InfoS("Failed to communicate with k8s API, skipping taint removal")
-		return nil //lint:ignore nilerr Failing to communicate with k8s API is a soft failure
+		return err
 	}
 
 	node, err := clientset.CoreV1().Nodes().Get(context.Background(), nodeName, metav1.GetOptions{})

--- a/pkg/driver/node_test.go
+++ b/pkg/driver/node_test.go
@@ -916,7 +916,7 @@ func TestRemoveNotReadyTaint(t *testing.T) {
 					return nil, fmt.Errorf("Failed setup!")
 				}
 			},
-			expResult: nil,
+			expResult: fmt.Errorf("Failed setup!"),
 		},
 		{
 			name: "failed to get node",


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

Bug fix

**What is this PR about? / Why do we need it?**

Prior to #1287, it made sense to not fail initialization if the driver could not talk to the K8s API. Now that it's being retried, it shouldn't silently fail if the K8s API isn't accessible.

**What testing is done?** 

