### PR TITLE
Fix values.yaml default values for controller.podLabels

### DIFF
--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -63,7 +63,7 @@ controller:
   # path on efs when deleteing an access point
   deleteAccessPointRootDir: false
   podAnnotations: {}
-  podLabel: {}
+  podLabels: {}
   hostNetwork: false
   priorityClassName: system-cluster-critical
   dnsPolicy: ClusterFirst


### PR DESCRIPTION


**Is this a bug fix or adding new feature?**
bug fix

**What is this PR about? / Why do we need it?**
There was an error in controller default values for deployment, instead of podLabels - that are referenced in deployment.yaml, there is an example of podLabel (missing "s") that might be misleading

**What testing is done?** 
Helm release using default value for podLabel - is not adding any pod Labels, replacing podLabel with podLabels is working fine.