### PR TITLE
use protobuf content type instead of json for k8s client

### DIFF
--- a/pkg/cloud/k8s_metadata.go
+++ b/pkg/cloud/k8s_metadata.go
@@ -17,6 +17,8 @@ var DefaultKubernetesAPIClient = func() (kubernetes.Interface, error) {
 	if err != nil {
 		return nil, err
 	}
+	config.AcceptContentTypes = "application/vnd.kubernetes.protobuf,application/json"
+	config.ContentType = "application/vnd.kubernetes.protobuf"
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

**What is this PR about? / Why do we need it?**
This MR is a part of effort to elevate single eks cluster performance by migrating the EKS components to use protobuf instead of json.

Modify kubeconfig type to use content type application/vnd.kubernetes.protobuf instead of json for performance gain.

**What testing is done?** 
