### PR TITLE
adding new regions' dns suffixes to watchdog

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,8 +45,7 @@ RUN mkdir -p /tmp/rpms && \
          rustup default stable && \
          git clone https://github.com/aws/efs-utils && \
          cd efs-utils && \
-         git checkout $(git describe --tags $(git rev-list --tags --max-count=1)) && \
-         make rpm && mv build/amazon-efs-utils*rpm /tmp/rpms && \
+         make rpm-without-system-rust && mv build/amazon-efs-utils*rpm /tmp/rpms && \
          # clean up efs-utils folder after install
          cd .. && rm -rf efs-utils && \
          yum clean all; \

--- a/pkg/driver/efs_watch_dog.go
+++ b/pkg/driver/efs_watch_dog.go
@@ -88,7 +88,6 @@ disable_fetch_ec2_metadata_token = false
 [mount.cn-north-1]
 dns_name_suffix = amazonaws.com.cn
 
-
 [mount.cn-northwest-1]
 dns_name_suffix = amazonaws.com.cn
 
@@ -106,6 +105,18 @@ stunnel_cafile = /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
 
 [mount.us-isob-east-1]
 dns_name_suffix = sc2s.sgov.gov
+stunnel_cafile = /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+
+[mount.us-isof-east-1]
+dns_name_suffix = csp.hci.ic.gov
+stunnel_cafile = /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+
+[mount.us-isof-south-1]
+dns_name_suffix = csp.hci.ic.gov
+stunnel_cafile = /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+
+[mount.eu-isoe-west-1]
+dns_name_suffix = cloud.adc-e.uk
 stunnel_cafile = /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
 
 [mount-watchdog]

--- a/pkg/driver/efs_watch_dog_test.go
+++ b/pkg/driver/efs_watch_dog_test.go
@@ -74,7 +74,6 @@ disable_fetch_ec2_metadata_token = false
 [mount.cn-north-1]
 dns_name_suffix = amazonaws.com.cn
 
-
 [mount.cn-northwest-1]
 dns_name_suffix = amazonaws.com.cn
 
@@ -92,6 +91,18 @@ stunnel_cafile = /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
 
 [mount.us-isob-east-1]
 dns_name_suffix = sc2s.sgov.gov
+stunnel_cafile = /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+
+[mount.us-isof-east-1]
+dns_name_suffix = csp.hci.ic.gov
+stunnel_cafile = /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+
+[mount.us-isof-south-1]
+dns_name_suffix = csp.hci.ic.gov
+stunnel_cafile = /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+
+[mount.eu-isoe-west-1]
+dns_name_suffix = cloud.adc-e.uk
 stunnel_cafile = /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
 
 [mount-watchdog]


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
It is an extension of the watchdog functionality to allow mounts in new regions that have custom dns domain suffixes.

**What is this PR about? / Why do we need it?**

**What testing is done?** 
No additional functionality was added, just updating the embedded config file so did not add any additional testing. make test passes all tests (attached).
[4c54256.make_test.output.txt.gz](https://github.com/user-attachments/files/17029914/4c54256.make_test.output.txt.gz)
