### PR TITLE
feat: add portRangeUpperBound to be exposed in the helm chart

### DIFF
--- a/charts/aws-efs-csi-driver/Chart.yaml
+++ b/charts/aws-efs-csi-driver/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: aws-efs-csi-driver
 version: 3.1.1
-appVersion: 2.1.0
+appVersion: 2.1.1
 kubeVersion: ">=1.17.0-0"
 description: "A Helm chart for AWS EFS CSI Driver"
 home: https://github.com/kubernetes-sigs/aws-efs-csi-driver

--- a/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
+++ b/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
@@ -93,6 +93,8 @@ spec:
             - name: AWS_USE_FIPS_ENDPOINT
               value: "true"
             {{- end }}
+            - name: PORT_RANGE_UPPER_BOUND
+              value: "{{ .Values.portRangeUpperBound }}"
             {{- with .Values.controller.env }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
+++ b/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
@@ -91,6 +91,8 @@ spec:
             - name: AWS_USE_FIPS_ENDPOINT
               value: "true"
             {{- end }}
+            - name: PORT_RANGE_UPPER_BOUND
+              value: "{{ .Values.portRangeUpperBound }}"
             {{- with .Values.node.env }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -7,6 +7,8 @@ fullnameOverride: ""
 
 useFIPS: false
 
+portRangeUpperBound: "21049"
+
 image:
   repository: public.ecr.aws/efs-csi-driver/amazon/aws-efs-csi-driver
   tag: "v2.1.0"

--- a/deploy/kubernetes/base/controller-deployment.yaml
+++ b/deploy/kubernetes/base/controller-deployment.yaml
@@ -51,6 +51,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: PORT_RANGE_UPPER_BOUND
+              value: "21049"
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/

--- a/deploy/kubernetes/base/node-daemonset.yaml
+++ b/deploy/kubernetes/base/node-daemonset.yaml
@@ -64,6 +64,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: PORT_RANGE_UPPER_BOUND
+              value: "21049"
           volumeMounts:
             - name: kubelet-dir
               mountPath: /var/lib/kubelet

--- a/pkg/driver/efs_watch_dog.go
+++ b/pkg/driver/efs_watch_dog.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"sync"
 	"text/template"
 
@@ -73,7 +74,7 @@ fips_mode_enabled = {{.FipsEnabled -}}
 
 # Define the port range that the TLS tunnel will choose from
 port_range_lower_bound = 20049
-port_range_upper_bound = 21049
+port_range_upper_bound = {{.PortRangeUpperBound}}
 
 # Optimize read_ahead_kb for Linux 5.4+
 optimize_readahead = true
@@ -179,9 +180,10 @@ type execWatchdog struct {
 }
 
 type efsUtilsConfig struct {
-	EfsClientSource string
-	Region          string
-	FipsEnabled     string
+	EfsClientSource     string
+	Region              string
+	FipsEnabled         string
+	PortRangeUpperBound string
 }
 
 func newExecWatchdog(efsUtilsCfgPath, efsUtilsStaticFilesPath, cmd string, arg ...string) Watchdog {
@@ -284,7 +286,12 @@ func (w *execWatchdog) updateConfig(efsClientSource string) error {
 	// used on Fargate, IMDS queries suffice otherwise
 	region := os.Getenv("AWS_DEFAULT_REGION")
 	fipsEnabled := os.Getenv("FIPS_ENABLED")
-	efsCfg := efsUtilsConfig{EfsClientSource: efsClientSource, Region: region, FipsEnabled: fipsEnabled}
+	portRangeUpperBound := os.Getenv("PORT_RANGE_UPPER_BOUND")
+	val, err := strconv.Atoi(portRangeUpperBound)
+	if err != nil || val < 21049 {
+		portRangeUpperBound = "21049"
+	}
+	efsCfg := efsUtilsConfig{EfsClientSource: efsClientSource, Region: region, FipsEnabled: fipsEnabled, PortRangeUpperBound: portRangeUpperBound}
 	if err = efsCfgTemplate.Execute(f, efsCfg); err != nil {
 		return fmt.Errorf("cannot update config %s for efs-utils. Error: %v", w.efsUtilsCfgPath, err)
 	}


### PR DESCRIPTION
We have a large amount of pvc deploys in our cluster and often we reach the error `Could not mount` pvc due to available port

Even the port_range_upper_bound property has been increased recently https://github.com/kubernetes-sigs/aws-efs-csi-driver/blob/b0af6bc4965ec01c86cdc3792c4207f24197d65e/pkg/driver/efs_watch_dog.go#L74 still we need this number to be configurable as FIPS it is at the moment.

For this reason, adding a new helm value that can instantiated from a `kustomize.config.k8s.io/v1beta1` component it is our goal.

**What testing is done?** 

We have deployed in our dev environment through argoCD