### PR TITLE
Add resources, topologySpreadConstraints and replicaCount to controller block

### DIFF
--- a/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
+++ b/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
@@ -10,7 +10,7 @@ metadata:
     {{ toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ .Values.controller.replicaCount }}
   selector:
     matchLabels:
       app: efs-csi-controller
@@ -140,7 +140,7 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
-          {{- with .Values.sidecars.csiProvisioner.resources }}
+          {{- with default .Values.controller.resources .Values.sidecars.csiProvisioner.resources }}
           resources: {{ toYaml . | nindent 12 }}
           {{- end }}
           {{- with .Values.sidecars.csiProvisioner.securityContext }}
@@ -159,7 +159,7 @@ spec:
             {{- with .Values.controller.volumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
-          {{- with .Values.sidecars.livenessProbe.resources }}
+          {{- with default .Values.controller.resources .Values.sidecars.livenessProbe.resources }}
           resources: {{ toYaml . | nindent 12 }}
           {{- end }}
           {{- with .Values.sidecars.livenessProbe.securityContext }}
@@ -174,5 +174,14 @@ spec:
         {{- end }}
       {{- with .Values.controller.affinity }}
       affinity: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.controller.topologySpreadConstraints }}
+      {{- $tscLabelSelector := dict "labelSelector" ( dict "matchLabels" ( dict "app" "efs-csi-controller" ) ) }}
+      {{- $constraints := list }}
+      {{- range .Values.controller.topologySpreadConstraints }}
+        {{- $constraints = mustAppend $constraints (mergeOverwrite . $tscLabelSelector) }}
+      {{- end }}
+      topologySpreadConstraints:
+        {{- $constraints | toYaml | nindent 8 }}
       {{- end }}
 {{- end }}

--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -5,8 +5,6 @@
 nameOverride: ""
 fullnameOverride: ""
 
-replicaCount: 2
-
 useFIPS: false
 
 image:
@@ -50,6 +48,8 @@ imagePullSecrets: []
 controller:
   # Specifies whether a deployment should be created
   create: true
+  # Number of replicas for the CSI controller service deployment
+  replicaCount: 2
   # Number for the log level verbosity
   logLevel: 2
   # If set, add pv/pvc metadata to plugin create requests as parameters.
@@ -113,6 +113,18 @@ controller:
     privileged: true
   leaderElectionRenewDeadline: 10s
   leaderElectionLeaseDuration: 15s
+  # TSCs without the label selector stanza
+  #
+  # Example:
+  #
+  # topologySpreadConstraints:
+  #  - maxSkew: 1
+  #    topologyKey: topology.kubernetes.io/zone
+  #    whenUnsatisfiable: ScheduleAnyway
+  #  - maxSkew: 1
+  #    topologyKey: kubernetes.io/hostname
+  #    whenUnsatisfiable: ScheduleAnyway
+  topologySpreadConstraints: []
 
 ## Node daemonset variables
 


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Fix to address issue #1181 

**What is this PR about? / Why do we need it?**
Adds the requested properties to the controller block

**What testing is done?** 
```
➜  jrakas aws-efs-csi-driver git:(controller-config-update ✓) helm install efs-csi-driver . --values values.yaml
NAME: efs-csi-driver
LAST DEPLOYED: Thu Oct 10 18:12:47 2024
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
To verify that aws-efs-csi-driver has started, run:

    kubectl get pod -n default -l "app.kubernetes.io/name=aws-efs-csi-driver,app.kubernetes.io/instance=efs-csi-driver"
➜  jrakas aws-efs-csi-driver git:(controller-config-update ✓) kubectl get pod -n default -l "app.kubernetes.io/name=aws-efs-csi-driver,app.kubernetes.io/instance=efs-csi-driver"
NAME                                  READY   STATUS    RESTARTS   AGE
efs-csi-controller-756665d659-kz9mb   3/3     Running   0          4s
efs-csi-controller-756665d659-mcr68   3/3     Running   0          4s
efs-csi-node-sg2sc                    3/3     Running   0          4s
```
