### PR TITLE
Issue 1452: Update kubernetes to version 1.27.16 to patch CVE-2024-5321

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	k8s.io/apimachinery v0.26.15
 	k8s.io/client-go v0.26.15
 	k8s.io/klog/v2 v2.90.1
-	k8s.io/kubernetes v1.26.15
+	k8s.io/kubernetes v1.27.16
 	k8s.io/mount-utils v0.26.15
 	k8s.io/pod-security-admission v0.26.15
 )

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1130,7 +1130,7 @@ k8s.io/kube-openapi/pkg/validation/spec
 ## explicit; go 1.19
 k8s.io/kubectl/pkg/scale
 k8s.io/kubectl/pkg/util/podutils
-# k8s.io/kubernetes v1.26.15
+# k8s.io/kubernetes v1.27.16 
 ## explicit; go 1.19
 k8s.io/kubernetes/pkg/api/legacyscheme
 k8s.io/kubernetes/pkg/api/service


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

CVE patch

**What is this PR about? / Why do we need it?**

Bumps kubernetes to v1.27.16 from v1.26.15 for vulnerability patching



