### PR TITLE
Post-release updates for release v2.0.9

### DIFF
--- a/charts/aws-efs-csi-driver/CHANGELOG.md
+++ b/charts/aws-efs-csi-driver/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Helm chart
+# v3.1.0
+* Bump app/driver version to `v2.0.9`
 # v3.0.9
 * Bump app/driver version to `v2.0.8`
 # v3.0.8

--- a/charts/aws-efs-csi-driver/Chart.yaml
+++ b/charts/aws-efs-csi-driver/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: aws-efs-csi-driver
-version: 3.0.9
-appVersion: 2.0.8
+version: 3.1.0
+appVersion: 2.0.9
 kubeVersion: ">=1.17.0-0"
 description: "A Helm chart for AWS EFS CSI Driver"
 home: https://github.com/kubernetes-sigs/aws-efs-csi-driver

--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -9,7 +9,7 @@ useFIPS: false
 
 image:
   repository: public.ecr.aws/efs-csi-driver/amazon/aws-efs-csi-driver
-  tag: "v2.0.8"
+  tag: "v2.0.9"
   pullPolicy: IfNotPresent
 
 sidecars:

--- a/deploy/kubernetes/base/controller-deployment.yaml
+++ b/deploy/kubernetes/base/controller-deployment.yaml
@@ -37,7 +37,7 @@ spec:
         - name: efs-plugin
           securityContext:
             privileged: true
-          image: public.ecr.aws/efs-csi-driver/amazon/aws-efs-csi-driver:v2.0.8
+          image: public.ecr.aws/efs-csi-driver/amazon/aws-efs-csi-driver:v2.0.9
           imagePullPolicy: IfNotPresent
           args:
             - --endpoint=$(CSI_ENDPOINT)

--- a/deploy/kubernetes/base/node-daemonset.yaml
+++ b/deploy/kubernetes/base/node-daemonset.yaml
@@ -48,7 +48,7 @@ spec:
         - name: efs-plugin
           securityContext:
             privileged: true
-          image: public.ecr.aws/efs-csi-driver/amazon/aws-efs-csi-driver:v2.0.8
+          image: public.ecr.aws/efs-csi-driver/amazon/aws-efs-csi-driver:v2.0.9
           imagePullPolicy: IfNotPresent
           args:
             - --endpoint=$(CSI_ENDPOINT)

--- a/deploy/kubernetes/overlays/stable/ecr/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/ecr/kustomization.yaml
@@ -5,7 +5,7 @@ bases:
 images:
   - name: public.ecr.aws/efs-csi-driver/amazon/aws-efs-csi-driver
     newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/aws-efs-csi-driver
-    newTag: v2.0.8
+    newTag: v2.0.9
   - name: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe
     newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/livenessprobe
     newTag: v2.13.0-eks-1-30-8

--- a/deploy/kubernetes/overlays/stable/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/kustomization.yaml
@@ -4,7 +4,7 @@ bases:
   - ../../base
 images:
   - name: public.ecr.aws/efs-csi-driver/amazon/aws-efs-csi-driver
-    newTag: v2.0.8
+    newTag: v2.0.9
   - name: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe
     newTag: v2.13.0-eks-1-30-8
   - name: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
No

**What is this PR about? / Why do we need it?**
 This PR updates references to the previous EFS CSI Driver version (`v2.0.8`) in favor of the newly released `v.2.0.9` version
