### PR TITLE
chore: update Python base images to newer versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ ENV EFS_CLIENT_SOURCE=$client_source
 
 RUN OS=${TARGETOS} ARCH=${TARGETARCH} make $TARGETOS/$TARGETARCH
 
-FROM public.ecr.aws/eks-distro-build-tooling/python:3.9-gcc-al2 as rpm-provider
+FROM public.ecr.aws/eks-distro-build-tooling/python:3.9-gcc-al23 as rpm-provider
 
 # Install efs-utils from github by default. It can be overriden to `yum` with --build-arg when building the Docker image.
 # If value of `EFSUTILSSOURCE` build arg is overriden with `yum`, docker will install efs-utils from Amazon Linux 2's yum repo.
@@ -38,7 +38,7 @@ RUN mkdir -p /tmp/rpms && \
     then echo "Installing efs-utils from Amazon Linux 2 yum repo" && \
          yum -y install --downloadonly --downloaddir=/tmp/rpms amazon-efs-utils-1.35.0-1.amzn2.noarch; \
     else echo "Installing efs-utils from github using the latest git tag" && \
-         yum -y install git rpm-build make openssl-devel curl && \
+         yum -y install systemd git rpm-build make openssl-devel curl && \
          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && \
          source $HOME/.cargo/env && \
          rustup update && \
@@ -55,13 +55,14 @@ RUN mkdir -p /tmp/rpms && \
 RUN pip3 install --user botocore
 
 # This image is equivalent to the eks-distro-minimal-base-python image but with pip installed as well
-FROM public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-python-builder:3.9-al2 as rpm-installer
+FROM public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-python-builder:3.9.16-al23 as rpm-installer
 
 COPY --from=rpm-provider /tmp/rpms/* /tmp/download/
 
 # second param indicates to skip installing dependency rpms, these will be installed manually
 # cd, ls, cat, vim, tcpdump, are for debugging
 RUN clean_install amazon-efs-utils true && \
+    clean_install crypto-policies true && \
     install_binary \
         /usr/bin/cat \
         /usr/bin/cd \
@@ -76,7 +77,7 @@ RUN clean_install amazon-efs-utils true && \
         /usr/bin/openssl \
         /usr/bin/sed \
         /usr/bin/stat \
-        /usr/bin/stunnel5 \
+        /usr/bin/stunnel \
         /usr/sbin/tcpdump \
         /usr/bin/which && \
     cleanup "efs-csi"
@@ -88,7 +89,7 @@ RUN clean_install amazon-efs-utils true && \
 # Those static files need to be copied back to the config directory when the driver starts up.
 RUN mv /newroot/etc/amazon/efs /newroot/etc/amazon/efs-static-files
 
-FROM public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-python:3.9.14-al2 AS linux-amazon
+FROM public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-python:3.9.16-al23 AS linux-amazon
 
 COPY --from=rpm-installer /newroot /
 COPY --from=rpm-provider /root/.local/lib/python3.9/site-packages/ /usr/lib/python3.9/site-packages/


### PR DESCRIPTION
`grype` lists several outstanding vulnerabilities on the base image, this PR fixes the majority of them:

Previous images:
```
% grype registry:public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-python:3.9.14-al2
 ✔ Parsed image                                                                                     sha256:8b70be76542bf426d7e8cf7123913b6e19ab2bd36017bf7ba870cd6dacf5f544
 ✔ Cataloged contents                                                                                      aeaf72f5fdd0f1945b267ff76c5993f8524f78a00fed837b7ef5290780edc7ab
   ├── ✔ Packages                        [35 packages]
   ├── ✔ File digests                    [1,735 files]
   ├── ✔ File metadata                   [1,735 locations]
   └── ✔ Executables                     [430 executables]
 ✔ Scanned for vulnerabilities     [18 vulnerability matches]
   ├── by severity: 1 critical, 10 high, 5 medium, 0 low, 0 negligible (2 unknown)
   └── by status:   17 fixed, 1 not-fixed, 0 ignored
NAME    INSTALLED  FIXED-IN                                             TYPE    VULNERABILITY   SEVERITY
python  3.9.14     3.10.9, 3.7.16, 3.8.16, 3.9.16                       binary  CVE-2022-37454  Critical
python  3.9.14     3.10.15, 3.11.10, 3.12.6, 3.13.0rc2, 3.8.20, 3.9.20  binary  CVE-2024-7592   High
python  3.9.14     3.10.15, 3.11.10, 3.12.6, 3.13.0rc2, 3.8.20, 3.9.20  binary  CVE-2024-6232   High
python  3.9.14     3.10.15, 3.11.10, 3.12.4, 3.13.0a6, 3.8.20, 3.9.20   binary  CVE-2024-4032   High
python  3.9.14     3.10.14, 3.11.9, 3.12.3, 3.13.0a5, 3.8.20, 3.9.20    binary  CVE-2024-0397   High
python  3.9.14     3.10.14, 3.11.9, 3.12.3, 3.8.19, 3.9.19              binary  CVE-2023-6597   High
python  3.9.14                                                          binary  CVE-2023-36632  High
python  3.9.14     3.10.12, 3.11.4, 3.7.17, 3.8.17, 3.9.17              binary  CVE-2023-24329  High
python  3.9.14     3.10.9, 3.11.1, 3.12.0a3, 3.7.16, 3.8.16, 3.9.16     binary  CVE-2022-45061  High
python  3.9.14     3.10.9, 3.9.16                                       binary  CVE-2022-42919  High
python  3.9.14     3.10.8                                               binary  CVE-2015-20107  High
python  3.9.14     3.10.15, 3.11.10, 3.12.5, 3.13.0rc2, 3.8.20, 3.9.20  binary  CVE-2024-6923   Medium
python  3.9.14     3.10.14, 3.11.9, 3.12.3, 3.8.19, 3.9.19              binary  CVE-2024-0450   Medium
python  3.9.14     3.10.13, 3.11.5, 3.8.18, 3.9.18                      binary  CVE-2023-40217  Medium
python  3.9.14     3.10.15, 3.11.10, 3.12.6, 3.13.0a1, 3.8.20, 3.9.20   binary  CVE-2023-27043  Medium
python  3.9.14     3.10.12, 3.11.4, 3.6.16, 3.8.17, 3.9.17              binary  CVE-2007-4559   Medium
python  3.9.14     3.10.15, 3.11.10, 3.12.6, 3.13.0rc2, 3.8.20, 3.9.20  binary  CVE-2024-8088   Unknown
python  3.9.14     3.10.0b1                                             binary  CVE-2024-5642   Unknown
```

```
% grype public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-python-builder:3.9-al2
 ✔ Parsed image                                                                                     sha256:36fb27a29a3204fd36048e36f2584be610fa592f6055e13606e2b0f020c4f49d
 ✔ Cataloged contents                                                                                      584f58add600139bad4f19e58f8b6630e9e206ffe7d872414638f3cac59d10a5
   ├── ✔ Packages                        [165 packages]
   ├── ✔ File digests                    [6,398 files]
   ├── ✔ File metadata                   [6,398 locations]
   └── ✔ Executables                     [1,181 executables]
 ✔ Scanned for vulnerabilities     [18 vulnerability matches]
   ├── by severity: 1 critical, 10 high, 5 medium, 0 low, 0 negligible (2 unknown)
   └── by status:   17 fixed, 1 not-fixed, 0 ignored
NAME    INSTALLED  FIXED-IN                                             TYPE    VULNERABILITY   SEVERITY
python  3.9.14     3.10.9, 3.7.16, 3.8.16, 3.9.16                       binary  CVE-2022-37454  Critical
python  3.9.14     3.10.15, 3.11.10, 3.12.6, 3.13.0rc2, 3.8.20, 3.9.20  binary  CVE-2024-7592   High
python  3.9.14     3.10.15, 3.11.10, 3.12.6, 3.13.0rc2, 3.8.20, 3.9.20  binary  CVE-2024-6232   High
python  3.9.14     3.10.15, 3.11.10, 3.12.4, 3.13.0a6, 3.8.20, 3.9.20   binary  CVE-2024-4032   High
python  3.9.14     3.10.14, 3.11.9, 3.12.3, 3.13.0a5, 3.8.20, 3.9.20    binary  CVE-2024-0397   High
python  3.9.14     3.10.14, 3.11.9, 3.12.3, 3.8.19, 3.9.19              binary  CVE-2023-6597   High
python  3.9.14                                                          binary  CVE-2023-36632  High
python  3.9.14     3.10.12, 3.11.4, 3.7.17, 3.8.17, 3.9.17              binary  CVE-2023-24329  High
python  3.9.14     3.10.9, 3.11.1, 3.12.0a3, 3.7.16, 3.8.16, 3.9.16     binary  CVE-2022-45061  High
python  3.9.14     3.10.9, 3.9.16                                       binary  CVE-2022-42919  High
python  3.9.14     3.10.8                                               binary  CVE-2015-20107  High
python  3.9.14     3.10.15, 3.11.10, 3.12.5, 3.13.0rc2, 3.8.20, 3.9.20  binary  CVE-2024-6923   Medium
python  3.9.14     3.10.14, 3.11.9, 3.12.3, 3.8.19, 3.9.19              binary  CVE-2024-0450   Medium
python  3.9.14     3.10.13, 3.11.5, 3.8.18, 3.9.18                      binary  CVE-2023-40217  Medium
python  3.9.14     3.10.15, 3.11.10, 3.12.6, 3.13.0a1, 3.8.20, 3.9.20   binary  CVE-2023-27043  Medium
python  3.9.14     3.10.12, 3.11.4, 3.6.16, 3.8.17, 3.9.17              binary  CVE-2007-4559   Medium
python  3.9.14     3.10.15, 3.11.10, 3.12.6, 3.13.0rc2, 3.8.20, 3.9.20  binary  CVE-2024-8088   Unknown
python  3.9.14     3.10.0b1                                             binary  CVE-2024-5642   Unknown
```

New images:
```
% grype registry:public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-python:3.9.16-al23
 ✔ Parsed image                                                                                     sha256:e7f94b033cf5c677fe2dda30b4b6a49026052dde28e93afb035d8311c406cf5f
 ✔ Cataloged contents                                                                                      6f6ca23710e79f493ab14b49119873ca88b932c6d3b753005d5e3ea5d7f8f18c
   ├── ✔ Packages                        [42 packages]
   ├── ✔ File digests                    [3,406 files]
   ├── ✔ File metadata                   [3,406 locations]
   └── ✔ Executables                     [161 executables]
 ✔ Scanned for vulnerabilities     [0 vulnerability matches]
   ├── by severity: 0 critical, 0 high, 0 medium, 0 low, 0 negligible
   └── by status:   0 fixed, 0 not-fixed, 0 ignored
No vulnerabilities found
```

```
% grype public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-python-builder:3.9.16-al23
 ✔ Parsed image                                                                                     sha256:0dda66e78f4bee954b1f6d261f448076888fb62e86b224d5fa74f89b6b0fce32
 ✔ Cataloged contents                                                                                      a3481a7bb6a135b81a8d36d5d6b25ae204b5e675d8bc0214cb5751d653182d4c
   ├── ✔ Packages                        [182 packages]
   ├── ✔ File digests                    [6,797 files]
   ├── ✔ File metadata                   [6,797 locations]
   └── ✔ Executables                     [608 executables]
 ✔ Scanned for vulnerabilities     [6 vulnerability matches]
   ├── by severity: 0 critical, 2 high, 4 medium, 0 low, 0 negligible
   └── by status:   6 fixed, 0 not-fixed, 0 ignored
NAME               INSTALLED                FIXED-IN               TYPE    VULNERABILITY        SEVERITY
libgcrypt          1.10.2-1.amzn2023.0.1    1.10.2-1.amzn2023.0.2  rpm     ALAS-2024-736        Medium
openssl-libs       1:3.0.8-1.amzn2023.0.14  3.0.8-1.amzn2023.0.16  rpm     ALAS-2024-727        Medium
openssl-libs       1:3.0.8-1.amzn2023.0.14  3.0.8-1.amzn2023.0.15  rpm     ALAS-2024-721        Medium
python3-pip-wheel  21.3.1-2.amzn2023.0.7    21.3.1-2.amzn2023.0.8  rpm     ALAS-2024-730        Medium
setuptools         59.6.0                   65.5.1                 python  GHSA-r9hx-vwmv-q579  High
setuptools         59.6.0                   70.0.0                 python  GHSA-cx63-2mw6-8hw5  High
```

**What is this PR about? / Why do we need it?**

**What testing is done?** 
