### PR TITLE
Adds anti-affinity for incompatible compute types

### DIFF
--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -181,6 +181,7 @@ node:
                 operator: NotIn
                 values:
                   - fargate
+                  - hybrid
   # Specifies whether a service account should be created
   serviceAccount:
     create: true


### PR DESCRIPTION
**What is this PR about? / Why do we need it?**
Adds node affinity rules to prevent `efs-csi-node` from running on incompatible node types

