### PR TITLE
in helm chart add proxy settings as secret

### DIFF
--- a/charts/aws-efs-csi-driver/CHANGELOG.md
+++ b/charts/aws-efs-csi-driver/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Helm chart
+# v3.1.2
+* add proxy settings as secret
 # v3.1.1
 * Bump app/driver version to `v2.1.0`
 # v3.1.0

--- a/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
+++ b/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
@@ -93,6 +93,23 @@ spec:
             - name: AWS_USE_FIPS_ENDPOINT
               value: "true"
             {{- end }}
+            {{- if .Values.controller.httpProxy }}
+            - name: HTTP_PROXY
+              valueFrom:
+                secretKeyRef:
+                  name: efs-csi-controller-proxy
+                  key: httpProxy
+            - name: HTTPS_PROXY
+              valueFrom:
+                secretKeyRef:
+                  name: efs-csi-controller-proxy
+                  key: httpsProxy
+            - name: NO_PROXY
+              valueFrom:
+                secretKeyRef:
+                  name: efs-csi-controller-proxy
+                  key: noProxy
+            {{- end }}
             {{- with .Values.controller.env }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/charts/aws-efs-csi-driver/templates/controller-secret-proxy.yaml
+++ b/charts/aws-efs-csi-driver/templates/controller-secret-proxy.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.controller.httpProxy }}
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: efs-csi-controller-proxy
+data:
+  httpProxy: "{{ .Values.controller.httpProxy | b64enc }}"
+  httpsProxy: "{{ .Values.controller.httpsProxy | default .Values.controller.httpProxy | b64enc }}"
+  noProxy: "{{ printf "%s,.%s.svc,.%s.svc.cluster.local" .Values.controller.noProxy .Release.Namespace .Release.Namespace | b64enc }}"
+{{- end }}

--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -90,6 +90,9 @@ controller:
       operator: Exists
   affinity: {}
   env: []
+  httpProxy: ""
+  httpsProxy: ""
+  noProxy: "localhost,127.0.0.1"
   volumes: []
   volumeMounts: []
   # Specifies whether a service account should be created


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

New feature, implementing https://github.com/kubernetes-sigs/aws-efs-csi-driver/pull/1497

**What is this PR about? / Why do we need it?**

Leaking proxy credentials in open form in deployment env variables is not safe. Set them from a secret.

**What testing is done?** 

Tested in our environment.