### PR TITLE
Add permissions to all GitHub actions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,6 +20,9 @@ on:
   schedule:
     - cron: '33 20 * * 5'
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/container-image.yaml
+++ b/.github/workflows/container-image.yaml
@@ -1,6 +1,11 @@
 name: Container Images
 
 on: push
+
+permissions:
+  contents: read
+  security-events: write
+
 jobs:
   build:
     # this is to prevent the job to run at forked projects

--- a/.github/workflows/helm-chart-release.yaml
+++ b/.github/workflows/helm-chart-release.yaml
@@ -7,6 +7,10 @@ on:
     paths:
       - "charts/**"
 
+permissions:
+  contents: write # Create new release to host chart artifacts
+  pages: write # Publish chart to pages
+
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,10 @@ on:
     # Sequence of patterns matched against refs/tags
     tags:
       - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
+
+permissions:
+  contents: write # Create releases
+
 jobs:
   build:
     name: Release


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
"Bug fix"

**What is this PR about? / Why do we need it?**

The `kubernetes-sigs` GitHub org was moved to a GitHub enterprise account, changing the default permissions for actions. Explicitly define the permissions we need in each action so they continue to run successfully.

**What testing is done?** 
