### PR TITLE
Minor change to align with typical helm chart conventions

### DIFF
--- a/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
+++ b/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
@@ -136,7 +136,7 @@ spec:
             {{- if hasKey .Values.controller "leaderElectionLeaseDuration" }}
             - --leader-election-lease-duration={{ .Values.controller.leaderElectionLeaseDuration }}
             {{- end }}
-            {{- range .Values.sidecars.provisioner.additionalArgs }}
+            {{- range .Values.sidecars.csiProvisioner.additionalArgs }}
             - {{ . }}
             {{- end }}
           env:

--- a/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
+++ b/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
@@ -136,10 +136,8 @@ spec:
             {{- if hasKey .Values.controller "leaderElectionLeaseDuration" }}
             - --leader-election-lease-duration={{ .Values.controller.leaderElectionLeaseDuration }}
             {{- end }}
-            {{- if .Values.sidecars.csiProvisioner.additionalArgs }}
-            {{- range .Values.sidecars.csiProvisioner.additionalArgs }}
+            {{- range .Values.sidecars.provisioner.additionalArgs }}
             - {{ . }}
-            {{- end }}
             {{- end }}
           env:
             - name: ADDRESS


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

Minor change to align with typical helm chart conventions

**What is this PR about? / Why do we need it?**

Minor change to align with typical helm chart conventions

**What testing is done?** 

Confirmed that the additional argument appears when I describe the csi controller pod