### PR TITLE
Fix default value for unhealthyPodEvictionPolicy

### DIFF
--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -111,7 +111,7 @@ controller:
     enabled: false
     # maxUnavailable: 1
     minAvailable: 1
-    unhealthyPodEvictionPolicy: "Delete"
+    unhealthyPodEvictionPolicy: IfHealthyBudget
   # securityContext on the controller pod
   securityContext:
     runAsNonRoot: false


### PR DESCRIPTION
`Delete` isn't allowed as value here. Accepted values are `IfHealthyBudget` (default) and `AlwaysAllow`.

https://kubernetes.io/docs/tasks/run-application/configure-pdb/#unhealthy-pod-eviction-policy

**Is this a bug fix or adding new feature?**

Bugfix to https://github.com/kubernetes-sigs/aws-efs-csi-driver/pull/1404.

**What is this PR about? / Why do we need it?**

Chart's default value is invalid. So user who tries to enable PDB has to set `unhealthyPodEvictionPolicy` to a valid expected value.

**What testing is done?** 

Manually by applying chart on real EKS cluster, version 1.31.

This also raises a question how original PR was tested, or tested at all. With original value `helm upgrade` would fail with `Error: UPGRADE FAILED: failed to create resource: PodDisruptionBudget.policy "efs-csi-controller" is invalid: spec.unhealthyPodEvictionPolicy: Unsupported value: "Delete": supported values: "AlwaysAllow", "IfHealthyBudget"`