### PR TITLE
Modify delete access point root directory logic to only remove temporary directory if empty

### DIFF
--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -460,8 +460,8 @@ func (d *Driver) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequest)
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "Could not unmount %q: %v", target, err)
 		}
-		err = os.RemoveAll(target)
-		if err != nil {
+		err = os.Remove(target)
+		if err != nil && !os.IsNotExist(err) {
 			return nil, status.Errorf(codes.Internal, "Could not delete %q: %v", target, err)
 		}
 	}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Addresses issues encountered in 
- https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/1085

**What is this PR about? / Why do we need it?**
To delete the access point root directory when `delete-access-point-root-dir` is set to `true`, the controller mounts the EFS file system to a temporary directory and deletes the corresponding access point directory from there. This PR ensures that this temporary directory is unmounted and empty before proceeding to delete the temporary directory as part of it's cleanup process.

**What testing is done?**  
We came up with a workload that is able to consistently and quickly reproduce the issue in https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/1085. We ran extensive experiments with and without the fix and found the fix in this PR works to prevent the issue from occurring. 