### PR TITLE
Revert "Pre-release PR for v2.1.2"

### DIFF
--- a/CHANGELOG-2.x.md
+++ b/CHANGELOG-2.x.md
@@ -1,5 +1,3 @@
-# V2.1.2
-* Update k8s dependencies ([#1514](https://github.com/kubernetes-sigs/aws-efs-csi-driver/pull/1514), [@andrewjamesbrown](https://github.com/andrewjamesbrown))
 # V2.1.1
 * Fix volume delete failure for static provisioning when accessPointId is empty ([#1507](https://github.com/kubernetes-sigs/aws-efs-csi-driver/pull/1507), [@dankova22](https://github.com/dankova22))
 * Update Go and dependencies to address CVEs ([#1513](https://github.com/kubernetes-sigs/aws-efs-csi-driver/pull/1513), [@andrewjamesbrown](https://github.com/andrewjamesbrown))

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 
-VERSION=v2.1.2
+VERSION=v2.1.1
 
 PKG=github.com/kubernetes-sigs/aws-efs-csi-driver
 GIT_COMMIT?=$(shell git rev-parse HEAD)

--- a/docs/README.md
+++ b/docs/README.md
@@ -89,7 +89,6 @@ The following sections are Kubernetes specific. If you are a Kubernetes user, us
 | Amazon EFS CSI Driver Version | Image                            |
 |-------------------------------|----------------------------------|
 | master branch                 | amazon/aws-efs-csi-driver:master |
-| v2.1.2                        | amazon/aws-efs-csi-driver:v2.1.2 |
 | v2.1.1                        | amazon/aws-efs-csi-driver:v2.1.1 |
 | v2.1.0                        | amazon/aws-efs-csi-driver:v2.1.0 |
 | v2.0.9                        | amazon/aws-efs-csi-driver:v2.0.9 |
@@ -152,7 +151,7 @@ The following sections are Kubernetes specific. If you are a Kubernetes user, us
 ### ECR Image
 | Driver Version | [ECR](https://gallery.ecr.aws/efs-csi-driver/amazon/aws-efs-csi-driver) Image |
 |----------------|-------------------------------------------------------------------------------|
-| v2.1.2         | public.ecr.aws/efs-csi-driver/amazon/aws-efs-csi-driver:v2.1.2                |
+| v2.1.1         | public.ecr.aws/efs-csi-driver/amazon/aws-efs-csi-driver:v2.1.1                |
 
 **Note**  
 You can find previous efs-csi-driver versions' images from [here](https://gallery.ecr.aws/efs-csi-driver/amazon/aws-efs-csi-driver)
@@ -371,7 +370,7 @@ If you want to update to a specific version, first customize the driver yaml fil
 kubectl kustomize "github.com/kubernetes-sigs/aws-efs-csi-driver/deploy/kubernetes/overlays/stable/?ref=release-2.0" > driver.yaml
 ```
 
-Then, update all lines referencing `image: amazon/aws-efs-csi-driver` to the desired version (e.g., to `image: amazon/aws-efs-csi-driver:v2.1.2`) in the yaml file, and deploy driver yaml again:
+Then, update all lines referencing `image: amazon/aws-efs-csi-driver` to the desired version (e.g., to `image: amazon/aws-efs-csi-driver:v2.1.1`) in the yaml file, and deploy driver yaml again:
 ```sh
 kubectl apply -f driver.yaml
 ```


### PR DESCRIPTION
Reverts kubernetes-sigs/aws-efs-csi-driver#1527

Reverting this PR as we want include delete-access-point-root-dir https://github.com/kubernetes-sigs/aws-efs-csi-driver/pull/1532 in this release