### PR TITLE
Update remaining documentation and efs-csi-driver version tags as part of post-release PR for release v2.1.2

### DIFF
--- a/charts/aws-efs-csi-driver/CHANGELOG.md
+++ b/charts/aws-efs-csi-driver/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Helm chart
+# v3.1.3
+* Bump app/driver version to `v2.1.2`
 # v3.1.2
 * Bump app/driver version to `v2.1.1`
 # v3.1.1

--- a/charts/aws-efs-csi-driver/Chart.yaml
+++ b/charts/aws-efs-csi-driver/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: aws-efs-csi-driver
 version: 3.1.2
-appVersion: 2.1.1
+appVersion: 2.1.2
 kubeVersion: ">=1.17.0-0"
 description: "A Helm chart for AWS EFS CSI Driver"
 home: https://github.com/kubernetes-sigs/aws-efs-csi-driver

--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -11,7 +11,7 @@ portRangeUpperBound: "21049"
 
 image:
   repository: public.ecr.aws/efs-csi-driver/amazon/aws-efs-csi-driver
-  tag: "v2.1.1"
+  tag: "v2.1.2"
   pullPolicy: IfNotPresent
 
 sidecars:

--- a/deploy/kubernetes/base/controller-deployment.yaml
+++ b/deploy/kubernetes/base/controller-deployment.yaml
@@ -37,7 +37,7 @@ spec:
         - name: efs-plugin
           securityContext:
             privileged: true
-          image: public.ecr.aws/efs-csi-driver/amazon/aws-efs-csi-driver:v2.1.1
+          image: public.ecr.aws/efs-csi-driver/amazon/aws-efs-csi-driver:v2.1.2
           imagePullPolicy: IfNotPresent
           args:
             - --endpoint=$(CSI_ENDPOINT)

--- a/deploy/kubernetes/base/node-daemonset.yaml
+++ b/deploy/kubernetes/base/node-daemonset.yaml
@@ -48,7 +48,7 @@ spec:
         - name: efs-plugin
           securityContext:
             privileged: true
-          image: public.ecr.aws/efs-csi-driver/amazon/aws-efs-csi-driver:v2.1.1
+          image: public.ecr.aws/efs-csi-driver/amazon/aws-efs-csi-driver:v2.1.2
           imagePullPolicy: IfNotPresent
           args:
             - --endpoint=$(CSI_ENDPOINT)

--- a/deploy/kubernetes/overlays/stable/ecr/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/ecr/kustomization.yaml
@@ -5,7 +5,7 @@ bases:
 images:
   - name: public.ecr.aws/efs-csi-driver/amazon/aws-efs-csi-driver
     newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/aws-efs-csi-driver
-    newTag: v2.1.1
+    newTag: v2
   - name: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe
     newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/livenessprobe
     newTag: v2.14.0-eks-1-31-5

--- a/deploy/kubernetes/overlays/stable/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/kustomization.yaml
@@ -4,7 +4,7 @@ bases:
   - ../../base
 images:
   - name: public.ecr.aws/efs-csi-driver/amazon/aws-efs-csi-driver
-    newTag: v2.1.1
+    newTag: v2.1.2
   - name: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe
     newTag: v2.14.0-eks-1-31-5
   - name: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar


### PR DESCRIPTION
**What is this PR about? / Why do we need it?**
Updates remaining documentation and efs-csi-driver version tags to reflect latest release `v2.1.2`