### PR TITLE
Fix typo in kustomization tag

### DIFF
--- a/deploy/kubernetes/overlays/stable/ecr/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/ecr/kustomization.yaml
@@ -5,7 +5,7 @@ bases:
 images:
   - name: public.ecr.aws/efs-csi-driver/amazon/aws-efs-csi-driver
     newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/aws-efs-csi-driver
-    newTag: v2
+    newTag: v2.1.2
   - name: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe
     newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/livenessprobe
     newTag: v2.14.0-eks-1-31-5


### PR DESCRIPTION
**What is this PR about? / Why do we need it?**
Fix typo in kustomization tag
- Should be `v.2.1.2` instead of `v2`

