### PR TITLE
Upgrade python distro and create symlink to stunnel5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN mkdir -p /tmp/rpms && \
     then echo "Installing efs-utils from Amazon Linux 2 yum repo" && \
          yum -y install --downloadonly --downloaddir=/tmp/rpms amazon-efs-utils-1.35.0-1.amzn2.noarch; \
     else echo "Installing efs-utils from github using the latest git tag" && \
-        yum -y install systemd git rpm-build make openssl-devel curl && \
+         yum -y install systemd git rpm-build make openssl-devel curl && \
          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && \
          source $HOME/.cargo/env && \
          rustup update && \
@@ -62,6 +62,7 @@ COPY --from=rpm-provider /tmp/rpms/* /tmp/download/
 # second param indicates to skip installing dependency rpms, these will be installed manually
 # cd, ls, cat, vim, tcpdump, are for debugging
 RUN clean_install amazon-efs-utils true && \
+    clean_install crypto-policies true && \
     install_binary \
         /usr/bin/cat \
         /usr/bin/cd \


### PR DESCRIPTION
Upgrade python distros. Add symlink for stunnel5 -> stunnel to keep backwards compatibility for upgrade process where binary is expected at /usr/bin/stunnel5. 