### PR TITLE
Fix StorageClass example parameters

### DIFF
--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -229,7 +229,7 @@ storageClasses: []
 #     gidRangeEnd: "2000"
 #     basePath: "/dynamic_provisioning"
 #     subPathPattern: "/subPath"
-#     ensureUniqueDirectory: true
+#     ensureUniqueDirectory: "true"
 #   reclaimPolicy: Delete
 #   volumeBindingMode: Immediate
 


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
No

**What is this PR about? / Why do we need it?**
The ensureUniqueDirectory should be a string, not a bool. If just uncommented, this piece of code breaks Helm apply.