### PR TITLE
Volume create delete hardening

### DIFF
--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -25,6 +25,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 
@@ -62,6 +63,7 @@ const (
 	ReuseAccessPointKey   = "reuseAccessPoint"
 	PvcNameKey            = "csi.storage.k8s.io/pvc/name"
 	CrossAccount          = "crossaccount"
+	ApLockWaitTimeSec     = 3
 )
 
 var (
@@ -178,6 +180,13 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 				FileSystemId:  existingAP.FileSystemId,
 				CapacityGiB:   accessPointsOptions.CapacityGiB,
 			}
+
+			// Take the lock to prevent this access point from being deleted while creating volume
+			if d.lockManager.lockMutex(accessPoint.AccessPointId, ApLockWaitTimeSec*time.Second) {
+				defer d.lockManager.unlockMutex(accessPoint.AccessPointId)
+			} else {
+				return nil, status.Errorf(codes.Internal, "Could not take the lock for existing access point: %v", accessPoint.AccessPointId)
+			}
 		}
 	}
 
@@ -213,7 +222,7 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 			if err != nil {
 				return nil, status.Errorf(codes.InvalidArgument, "Failed to parse invalid %v: %v", Gid, err)
 			}
-			if uid < 0 {
+			if gid < 0 {
 				return nil, status.Errorf(codes.InvalidArgument, "%v must be greater or equal than 0", Gid)
 			}
 		}
@@ -348,6 +357,13 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 			}
 			return nil, status.Errorf(codes.Internal, "Failed to create Access point in File System %v : %v", accessPointsOptions.FileSystemId, err)
 		}
+
+		// Lock on the new access point to prevent accidental deletion before creation is done
+		if d.lockManager.lockMutex(accessPoint.AccessPointId, ApLockWaitTimeSec*time.Second) {
+			defer d.lockManager.unlockMutex(accessPoint.AccessPointId)
+		} else {
+			return nil, status.Errorf(codes.Internal, "Could not take the lock after creating access point: %v", accessPoint.AccessPointId)
+		}
 	}
 
 	volContext := map[string]string{}
@@ -411,9 +427,43 @@ func (d *Driver) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequest)
 		return &csi.DeleteVolumeResponse{}, nil
 	}
 
+	// Lock on the access point ID to ensure a retry won't race with the in-progress deletion
+	if d.lockManager.lockMutex(accessPointId, ApLockWaitTimeSec*time.Second) {
+		defer d.lockManager.unlockMutex(accessPointId)
+	} else {
+		return nil, status.Errorf(codes.Internal, "Could not take the lock to delete access point: %v", accessPointId)
+	}
+
 	//TODO: Add Delete File System when FS provisioning is implemented
 	// Delete access point root directory if delete-access-point-root-dir is set.
 	if d.deleteAccessPointRootDir {
+		fsRoot := TempMountPathPrefix + "/" + accessPointId
+		deleteCompleted := false
+
+		// Ensure the volume is cleaned up properly in case of an incomplete deletion
+		defer func() {
+			if !deleteCompleted {
+				// Check if the FS is still mounted
+				isNotMounted, err := d.mounter.IsLikelyNotMountPoint(fsRoot)
+				if err != nil {
+					return // Skip cleanup, we can't verify mount status
+				}
+
+				if !isNotMounted {
+					if err := d.mounter.Unmount(fsRoot); err != nil {
+						klog.Warningf("Failed to unmount %v: %v", fsRoot, err)
+						return // Don't remove any data if the unmount fails
+					}
+				}
+
+				// Only try folder removal if the unmount succeeded or wasn't mounted
+				// If the directory already doesn't exist it will be treated as success
+				if err := os.Remove(fsRoot); err != nil && !os.IsNotExist(err) {
+					klog.Warningf("Failed to remove %v: %v", fsRoot, err)
+				}
+			}
+		}()
+
 		// Check if Access point exists.
 		// If access point exists, retrieve its root directory and delete it/
 		accessPoint, err := localCloud.DescribeAccessPoint(ctx, accessPointId)
@@ -444,26 +494,41 @@ func (d *Driver) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequest)
 			}
 		}
 
-		target := TempMountPathPrefix + "/" + accessPointId
-		if err := d.mounter.MakeDir(target); err != nil {
-			return nil, status.Errorf(codes.Internal, "Could not create dir %q: %v", target, err)
+		// Create the target directory, This won't fail if it already exists
+		if err := d.mounter.MakeDir(fsRoot); err != nil {
+			return nil, status.Errorf(codes.Internal, "Could not create dir %q: %v", fsRoot, err)
 		}
-		if err := d.mounter.Mount(fileSystemId, target, "efs", mountOptions); err != nil {
-			os.Remove(target)
-			return nil, status.Errorf(codes.Internal, "Could not mount %q at %q: %v", fileSystemId, target, err)
+
+		// Only attempt to mount the target filesystem if its not already mounted
+		isNotMounted, err := d.mounter.IsLikelyNotMountPoint(fsRoot)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "Could not check if %q is mounted: %v", fsRoot, err)
 		}
-		err = os.RemoveAll(target + accessPoint.AccessPointRootDir)
+		if isNotMounted {
+			if err := d.mounter.Mount(fileSystemId, fsRoot, "efs", mountOptions); err != nil {
+				return nil, status.Errorf(codes.Internal, "Could not mount %q at %q: %v", fileSystemId, fsRoot, err)
+			}
+		}
+
+		// Before removing, ensure the removal path exists and is a directory
+		apRootPath := fsRoot + accessPoint.AccessPointRootDir
+		if pathInfo, err := d.mounter.Stat(apRootPath); err == nil && !os.IsNotExist(err) && pathInfo.IsDir() {
+			err = os.RemoveAll(apRootPath)
+		}
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "Could not delete access point root directory %q: %v", accessPoint.AccessPointRootDir, err)
 		}
-		err = d.mounter.Unmount(target)
+		err = d.mounter.Unmount(fsRoot)
 		if err != nil {
-			return nil, status.Errorf(codes.Internal, "Could not unmount %q: %v", target, err)
+			return nil, status.Errorf(codes.Internal, "Could not unmount %q: %v", fsRoot, err)
 		}
-		err = os.Remove(target)
+		err = os.Remove(fsRoot)
 		if err != nil && !os.IsNotExist(err) {
-			return nil, status.Errorf(codes.Internal, "Could not delete %q: %v", target, err)
+			return nil, status.Errorf(codes.Internal, "Could not delete %q: %v", fsRoot, err)
 		}
+
+		//Mark the delete as complete, Nothing needs cleanup in the deferred function
+		deleteCompleted = true
 	}
 
 	// Delete access point

--- a/pkg/driver/controller_test.go
+++ b/pkg/driver/controller_test.go
@@ -4,9 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math/rand"
 	"regexp"
 	"strconv"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"google.golang.org/grpc/codes"
@@ -50,6 +54,7 @@ func TestCreateVolume(t *testing.T) {
 					endpoint:     endpoint,
 					cloud:        mockCloud,
 					gidAllocator: NewGidAllocator(),
+					lockManager:  NewLockManagerMap(),
 				}
 
 				req := &csi.CreateVolumeRequest{
@@ -115,6 +120,7 @@ func TestCreateVolume(t *testing.T) {
 					endpoint:     endpoint,
 					cloud:        mockCloud,
 					gidAllocator: NewGidAllocator(),
+					lockManager:  NewLockManagerMap(),
 				}
 
 				req := &csi.CreateVolumeRequest{
@@ -182,6 +188,7 @@ func TestCreateVolume(t *testing.T) {
 					endpoint:     endpoint,
 					cloud:        mockCloud,
 					gidAllocator: NewGidAllocator(),
+					lockManager:  NewLockManagerMap(),
 				}
 
 				req := &csi.CreateVolumeRequest{
@@ -264,6 +271,7 @@ func TestCreateVolume(t *testing.T) {
 					endpoint:     endpoint,
 					cloud:        mockCloud,
 					gidAllocator: NewGidAllocator(),
+					lockManager:  NewLockManagerMap(),
 				}
 
 				req := &csi.CreateVolumeRequest{
@@ -393,6 +401,7 @@ func TestCreateVolume(t *testing.T) {
 					endpoint:     endpoint,
 					cloud:        mockCloud,
 					gidAllocator: NewGidAllocator(),
+					lockManager:  NewLockManagerMap(),
 				}
 
 				req := &csi.CreateVolumeRequest{
@@ -483,6 +492,7 @@ func TestCreateVolume(t *testing.T) {
 					endpoint:     endpoint,
 					cloud:        mockCloud,
 					gidAllocator: NewGidAllocator(),
+					lockManager:  NewLockManagerMap(),
 				}
 
 				req := &csi.CreateVolumeRequest{
@@ -542,6 +552,7 @@ func TestCreateVolume(t *testing.T) {
 					endpoint:     endpoint,
 					cloud:        mockCloud,
 					gidAllocator: NewGidAllocator(),
+					lockManager:  NewLockManagerMap(),
 					tags:         parseTagsFromStr(""),
 				}
 
@@ -593,6 +604,131 @@ func TestCreateVolume(t *testing.T) {
 			},
 		},
 		{
+			name: "Success: Race Normal flow",
+			testFunc: func(t *testing.T) {
+				numGoRoutines := 100
+				rand.Seed(time.Now().UnixNano())
+				mockCtl := gomock.NewController(t)
+				mockCloud := mocks.NewMockCloud(mockCtl)
+
+				driver := &Driver{
+					endpoint:     endpoint,
+					cloud:        mockCloud,
+					gidAllocator: NewGidAllocator(),
+					lockManager:  NewLockManagerMap(),
+					tags:         parseTagsFromStr(""),
+				}
+
+				req := &csi.CreateVolumeRequest{
+					Name: volumeName,
+					VolumeCapabilities: []*csi.VolumeCapability{
+						stdVolCap,
+					},
+					CapacityRange: &csi.CapacityRange{
+						RequiredBytes: capacityRange,
+					},
+					Parameters: map[string]string{
+						ProvisioningMode: "efs-ap",
+						FsId:             fsId,
+						GidMin:           "1000",
+						GidMax:           "2000",
+						DirectoryPerms:   "777",
+						AzName:           "us-east-1a",
+					},
+				}
+
+				ctx := context.Background()
+				// Generate random access points so we can return a new one every time
+				accessPointArr := make([]*cloud.AccessPoint, numGoRoutines)
+				for i := range accessPointArr {
+					accessPointArr[i] = &cloud.AccessPoint{
+						AccessPointId: fmt.Sprintf("fsap-%s", randStringBytes(12)),
+						FileSystemId:  fsId,
+						PosixUser: &cloud.PosixUser{
+							Gid: 1000,
+							Uid: 1000,
+						},
+					}
+				}
+
+				// Don't need to return any access points, but don't return any errors so the filesystems shows up as found
+				mockCloud.EXPECT().ListAccessPoints(gomock.Eq(ctx), gomock.Any()).Return(nil, nil).Times(numGoRoutines)
+
+				// Return a different generated access point every time this function is called
+				var createCounter int32 = 0
+				mockCloud.EXPECT().CreateAccessPoint(gomock.Eq(ctx), gomock.Eq(volumeName), gomock.Any()).DoAndReturn(
+					func(_ context.Context, _ interface{}, _ interface{}) (*cloud.AccessPoint, error) {
+						current := atomic.AddInt32(&createCounter, 1) - 1
+						return accessPointArr[current], nil
+					},
+				).Times(numGoRoutines)
+
+				// Lock the volume mutex to hold threads until they are all scheduled
+				for _, ap := range accessPointArr {
+					driver.lockManager.lockMutex(ap.AccessPointId)
+				}
+
+				var wg sync.WaitGroup
+				resultChan := make(chan struct {
+					index int
+					resp  *csi.CreateVolumeResponse
+					err   error
+				}, numGoRoutines)
+
+				for i := 0; i < numGoRoutines; i++ {
+					wg.Add(1)
+					go func(index int) {
+						defer wg.Done()
+						resp, err := driver.CreateVolume(ctx, req)
+						resultChan <- struct {
+							index int
+							resp  *csi.CreateVolumeResponse
+							err   error
+						}{index, resp, err}
+					}(i)
+				}
+
+				// Unlock the mutex to force a race
+				for _, ap := range accessPointArr {
+					driver.lockManager.unlockMutex(ap.AccessPointId)
+				}
+
+				go func() {
+					wg.Wait()
+					close(resultChan)
+				}()
+
+				for result := range resultChan {
+					if result.err != nil {
+						t.Fatalf("CreateVolume failed: %v", result.err)
+					}
+
+					if result.resp.Volume == nil {
+						t.Fatal("Volume is nil")
+					}
+
+					found := false
+					for _, ap := range accessPointArr {
+						if result.resp.Volume.VolumeId == fmt.Sprintf("%s::%s", ap.FileSystemId, ap.AccessPointId) {
+							found = true
+							break
+						}
+					}
+
+					if !found {
+						t.Fatalf("Volume Id %v was not found in the access point array", result.resp.Volume.VolumeId)
+					}
+				}
+
+				// Ensure all keys were properly deleted from the lock manager
+				keys, _ := driver.lockManager.GetLockCount()
+				if keys > 0 {
+					t.Fatalf("%d Keys are still in the lockManager", keys)
+				}
+				mockCtl.Finish()
+			},
+		},
+		{
 			name: "Success: Using Default GID ranges",
 			testFunc: func(t *testing.T) {
 				mockCtl := gomock.NewController(t)
@@ -602,6 +738,7 @@ func TestCreateVolume(t *testing.T) {
 					endpoint:     endpoint,
 					cloud:        mockCloud,
 					gidAllocator: NewGidAllocator(),
+					lockManager:  NewLockManagerMap(),
 				}
 
 				req := &csi.CreateVolumeRequest{
@@ -658,6 +795,7 @@ func TestCreateVolume(t *testing.T) {
 					endpoint:     endpoint,
 					cloud:        mockCloud,
 					gidAllocator: NewGidAllocator(),
+					lockManager:  NewLockManagerMap(),
 					tags:         parseTagsFromStr("cluster:efs"),
 				}
 
@@ -717,6 +855,7 @@ func TestCreateVolume(t *testing.T) {
 					endpoint:     endpoint,
 					cloud:        mockCloud,
 					gidAllocator: NewGidAllocator(),
+					lockManager:  NewLockManagerMap(),
 					tags:         parseTagsFromStr("cluster-efs"),
 				}
 
@@ -776,6 +915,7 @@ func TestCreateVolume(t *testing.T) {
 					endpoint:     endpoint,
 					cloud:        mockCloud,
 					gidAllocator: NewGidAllocator(),
+					lockManager:  NewLockManagerMap(),
 					tags:         parseTagsFromStr(""),
 				}
 				pvcNameVal := "test-pvc"
@@ -830,6 +970,261 @@ func TestCreateVolume(t *testing.T) {
 			},
 		},
 		{
+			name: "Success: reuseAccessPointName is true with existing access point not found",
+			testFunc: func(t *testing.T) {
+				mockCtl := gomock.NewController(t)
+				mockCloud := mocks.NewMockCloud(mockCtl)
+
+				driver := &Driver{
+					endpoint:     endpoint,
+					cloud:        mockCloud,
+					gidAllocator: NewGidAllocator(),
+					lockManager:  NewLockManagerMap(),
+					tags:         parseTagsFromStr(""),
+				}
+				pvcNameVal := "test-pvc"
+
+				req := &csi.CreateVolumeRequest{
+					Name: volumeName,
+					VolumeCapabilities: []*csi.VolumeCapability{
+						stdVolCap,
+					},
+					CapacityRange: &csi.CapacityRange{
+						RequiredBytes: capacityRange,
+					},
+					Parameters: map[string]string{
+						ProvisioningMode:    "efs-ap",
+						FsId:                fsId,
+						GidMin:              "1000",
+						GidMax:              "2000",
+						DirectoryPerms:      "777",
+						AzName:              "us-east-1a",
+						ReuseAccessPointKey: "true",
+						PvcNameKey:          pvcNameVal,
+					},
+				}
+
+				ctx := context.Background()
+
+				accessPoint := &cloud.AccessPoint{
+					AccessPointId: apId,
+					FileSystemId:  fsId,
+					PosixUser: &cloud.PosixUser{
+						Gid: 1000,
+						Uid: 1000,
+					},
+				}
+				mockCloud.EXPECT().FindAccessPointByClientToken(gomock.Eq(ctx), gomock.Any(), gomock.Eq(fsId)).Return(nil, nil)
+				// When createVolume can't find existing access point name, it should create a new one
+				accessPoints := []*cloud.AccessPoint{accessPoint}
+				mockCloud.EXPECT().ListAccessPoints(gomock.Eq(ctx), gomock.Any()).Return(accessPoints, nil)
+				mockCloud.EXPECT().CreateAccessPoint(gomock.Eq(ctx), gomock.Any(), gomock.Any()).Return(accessPoint, nil)
+
+				res, err := driver.CreateVolume(ctx, req)
+
+				if err != nil {
+					t.Fatalf("CreateVolume failed: %v", err)
+				}
+
+				if res.Volume == nil {
+					t.Fatal("Volume is nil")
+				}
+
+				if res.Volume.VolumeId != volumeId {
+					t.Fatalf("Volume Id mismatched. Expected: %v, Actual: %v", volumeId, res.Volume.VolumeId)
+				}
+
+				mockCtl.Finish()
+			},
+		},
+		{
+			name: "Success: Race with reuseAccessPointName is true",
+			testFunc: func(t *testing.T) {
+				const numGoRoutines = 100
+				mockCtl := gomock.NewController(t)
+				mockCloud := mocks.NewMockCloud(mockCtl)
+
+				driver := &Driver{
+					endpoint:     endpoint,
+					cloud:        mockCloud,
+					gidAllocator: NewGidAllocator(),
+					lockManager:  NewLockManagerMap(),
+					tags:         parseTagsFromStr(""),
+				}
+				pvcNameVal := "test-pvc"
+
+				req := &csi.CreateVolumeRequest{
+					Name: volumeName,
+					VolumeCapabilities: []*csi.VolumeCapability{
+						stdVolCap,
+					},
+					CapacityRange: &csi.CapacityRange{
+						RequiredBytes: capacityRange,
+					},
+					Parameters: map[string]string{
+						ProvisioningMode:    "efs-ap",
+						FsId:                fsId,
+						GidMin:              "1000",
+						GidMax:              "2000",
+						DirectoryPerms:      "777",
+						AzName:              "us-east-1a",
+						ReuseAccessPointKey: "true",
+						PvcNameKey:          pvcNameVal,
+					},
+				}
+
+				ctx := context.Background()
+
+				accessPoint := &cloud.AccessPoint{
+					AccessPointId: apId,
+					FileSystemId:  fsId,
+					PosixUser: &cloud.PosixUser{
+						Gid: 1000,
+						Uid: 1000,
+					},
+				}
+				mockCloud.EXPECT().FindAccessPointByClientToken(gomock.Eq(ctx), gomock.Any(), gomock.Eq(fsId)).Return(accessPoint, nil).Times(numGoRoutines)
+
+				// Lock the volume mutex to hold threads until they are all scheduled
+				driver.lockManager.lockMutex(apId)
+
+				var wg sync.WaitGroup
+				resultChan := make(chan struct {
+					index int
+					resp  *csi.CreateVolumeResponse
+					err   error
+				}, numGoRoutines)
+
+				for i := 0; i < numGoRoutines; i++ {
+					wg.Add(1)
+					go func(index int) {
+						defer wg.Done()
+						resp, err := driver.CreateVolume(ctx, req)
+						resultChan <- struct {
+							index int
+							resp  *csi.CreateVolumeResponse
+							err   error
+						}{index, resp, err}
+					}(i)
+				}
+
+				// Unlock the mutex to force a race
+				driver.lockManager.unlockMutex(apId)
+
+				go func() {
+					wg.Wait()
+					close(resultChan)
+				}()
+
+				for result := range resultChan {
+					if result.err != nil {
+						t.Fatalf("CreateVolume failed: %v", result.err)
+					}
+
+					if result.resp.Volume == nil {
+						t.Fatal("Volume is nil")
+					}
+
+					if result.resp.Volume.VolumeId != volumeId {
+						t.Fatalf("Volume Id mismatched. Expected: %v, Actual: %v", volumeId, result.resp.Volume.VolumeId)
+					}
+				}
+
+				// Ensure all keys were properly deleted from the lock manager
+				keys, _ := driver.lockManager.GetLockCount()
+				if keys > 0 {
+					t.Fatalf("%d Keys are still in the lockManager", keys)
+				}
+
+				mockCtl.Finish()
+			},
+		},
+		{
+			name: "Fail: create volume mutex timeout",
+			testFunc: func(t *testing.T) {
+				const timeout = 3 * time.Second
+				mockCtl := gomock.NewController(t)
+				mockCloud := mocks.NewMockCloud(mockCtl)
+
+				driver := &Driver{
+					endpoint:     endpoint,
+					cloud:        mockCloud,
+					gidAllocator: NewGidAllocator(),
+					lockManager:  NewLockManagerMap(),
+					tags:         parseTagsFromStr(""),
+				}
+				pvcNameVal := "test-pvc"
+
+				req := &csi.CreateVolumeRequest{
+					Name: volumeName,
+					VolumeCapabilities: []*csi.VolumeCapability{
+						stdVolCap,
+					},
+					CapacityRange: &csi.CapacityRange{
+						RequiredBytes: capacityRange,
+					},
+					Parameters: map[string]string{
+						ProvisioningMode:    "efs-ap",
+						FsId:                fsId,
+						GidMin:              "1000",
+						GidMax:              "2000",
+						DirectoryPerms:      "777",
+						AzName:              "us-east-1a",
+						ReuseAccessPointKey: "true",
+						PvcNameKey:          pvcNameVal,
+					},
+				}
+
+				ctx := context.Background()
+
+				accessPoint := &cloud.AccessPoint{
+					AccessPointId: apId,
+					FileSystemId:  fsId,
+					PosixUser: &cloud.PosixUser{
+						Gid: 1000,
+						Uid: 1000,
+					},
+				}
+				mockCloud.EXPECT().FindAccessPointByClientToken(gomock.Eq(ctx), gomock.Any(), gomock.Eq(fsId)).Return(accessPoint, nil).Times(1)
+
+				// Lock the volume mutex to hold threads to force a timeout
+				driver.lockManager.lockMutex(apId)
+
+				start := time.Now()
+				resp, err := driver.CreateVolume(ctx, req)
+				elapsed := time.Since(start)
+
+				// Check that it waited for at least the timeout duration
+				if elapsed < timeout {
+					t.Errorf("lockMutex returned before timeout. Expected to wait %v, but waited %v", timeout, elapsed)
+				}
+
+				// Check that it didn't wait too much longer than the timeout
+				// We'll allow a 100ms buffer for system scheduling variations
+				if elapsed > timeout+100*time.Millisecond {
+					t.Errorf("lockMutex waited too long. Expected to wait %v, but waited %v", timeout, elapsed)
+				}
+
+				if err == nil {
+					t.Fatalf("CreateVolume should have failed")
+				}
+
+				if resp != nil {
+					t.Fatal("Response should have been nil")
+				}
+
+				driver.lockManager.unlockMutex(apId)
+
+				// Ensure all keys were properly deleted from the lock manager even with a timeout
+				keys, _ := driver.lockManager.GetLockCount()
+				if keys > 0 {
+					t.Fatalf("%d Keys are still in the lockManager", keys)
+				}
+
+				mockCtl.Finish()
+			},
+		},
+		{
 			name: "Success: Normal flow with a valid directory structure set",
 			testFunc: func(t *testing.T) {
 				mockCtl := gomock.NewController(t)
@@ -839,6 +1234,7 @@ func TestCreateVolume(t *testing.T) {
 					endpoint:     endpoint,
 					cloud:        mockCloud,
 					gidAllocator: NewGidAllocator(),
+					lockManager:  NewLockManagerMap(),
 					tags:         parseTagsFromStr(""),
 				}
 
@@ -909,6 +1305,7 @@ func TestCreateVolume(t *testing.T) {
 					endpoint:     endpoint,
 					cloud:        mockCloud,
 					gidAllocator: NewGidAllocator(),
+					lockManager:  NewLockManagerMap(),
 					tags:         parseTagsFromStr(""),
 				}
 
@@ -977,6 +1374,7 @@ func TestCreateVolume(t *testing.T) {
 					endpoint:     endpoint,
 					cloud:        mockCloud,
 					gidAllocator: NewGidAllocator(),
+					lockManager:  NewLockManagerMap(),
 					tags:         parseTagsFromStr(""),
 				}
 
@@ -1048,6 +1446,7 @@ func TestCreateVolume(t *testing.T) {
 					endpoint:     endpoint,
 					cloud:        mockCloud,
 					gidAllocator: NewGidAllocator(),
+					lockManager:  NewLockManagerMap(),
 					tags:         parseTagsFromStr(""),
 				}
 
@@ -1120,6 +1519,7 @@ func TestCreateVolume(t *testing.T) {
 					endpoint:     endpoint,
 					cloud:        mockCloud,
 					gidAllocator: NewGidAllocator(),
+					lockManager:  NewLockManagerMap(),
 					tags:         parseTagsFromStr(""),
 				}
 
@@ -1189,6 +1589,7 @@ func TestCreateVolume(t *testing.T) {
 					endpoint:     endpoint,
 					cloud:        mockCloud,
 					gidAllocator: NewGidAllocator(),
+					lockManager:  NewLockManagerMap(),
 					tags:         parseTagsFromStr(""),
 				}
 
@@ -1254,6 +1655,7 @@ func TestCreateVolume(t *testing.T) {
 					endpoint:     endpoint,
 					cloud:        mockCloud,
 					gidAllocator: NewGidAllocator(),
+					lockManager:  NewLockManagerMap(),
 					tags:         parseTagsFromStr(""),
 				}
 
@@ -1320,6 +1722,7 @@ func TestCreateVolume(t *testing.T) {
 					endpoint:     endpoint,
 					cloud:        mockCloud,
 					gidAllocator: NewGidAllocator(),
+					lockManager:  NewLockManagerMap(),
 					tags:         parseTagsFromStr(""),
 				}
 
@@ -2658,10 +3061,12 @@ func TestCreateVolume(t *testing.T) {
 
 func TestDeleteVolume(t *testing.T) {
 	var (
-		apId     = "fsap-abcd1234xyz987"
-		fsId     = "fs-abcd1234"
-		endpoint = "endpoint"
-		volumeId = "fs-abcd1234::fsap-abcd1234xyz987"
+		apId      = "fsap-abcd1234xyz987"
+		apId2     = "fsap-abcd1234xyz988"
+		fsId      = "fs-abcd1234"
+		endpoint  = "endpoint"
+		volumeId  = "fs-abcd1234::fsap-abcd1234xyz987"
+		volumeId2 = "fs-abcd1234::fsap-abcd1234xyz988"
 	)
 
 	testCases := []struct {
@@ -2678,6 +3083,7 @@ func TestDeleteVolume(t *testing.T) {
 					endpoint:     endpoint,
 					cloud:        mockCloud,
 					gidAllocator: NewGidAllocator(),
+					lockManager:  NewLockManagerMap(),
 				}
 
 				req := &csi.DeleteVolumeRequest{
@@ -2705,6 +3111,7 @@ func TestDeleteVolume(t *testing.T) {
 					cloud:                    mockCloud,
 					mounter:                  mockMounter,
 					gidAllocator:             NewGidAllocator(),
+					lockManager:              NewLockManagerMap(),
 					deleteAccessPointRootDir: true,
 				}
 
@@ -2715,20 +3122,338 @@ func TestDeleteVolume(t *testing.T) {
 				accessPoint := &cloud.AccessPoint{
 					AccessPointId:      apId,
 					FileSystemId:       fsId,
-					AccessPointRootDir: "",
+					AccessPointRootDir: "/testDir",
 					CapacityGiB:        0,
 				}
+
+				dirPresent := mocks.NewMockFileInfo(
+					"testFile",
+					0,
+					0755,
+					time.Now(),
+					true,
+					nil,
+				)
 
 				ctx := context.Background()
 				mockMounter.EXPECT().MakeDir(gomock.Any()).Return(nil)
 				mockMounter.EXPECT().Mount(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 				mockMounter.EXPECT().Unmount(gomock.Any()).Return(nil)
+				mockMounter.EXPECT().Stat(gomock.Any()).Return(dirPresent, nil)
+				mockMounter.EXPECT().IsLikelyNotMountPoint(gomock.Any()).Return(true, nil)
 				mockCloud.EXPECT().DescribeAccessPoint(gomock.Eq(ctx), gomock.Eq(apId)).Return(accessPoint, nil)
 				mockCloud.EXPECT().DeleteAccessPoint(gomock.Eq(ctx), gomock.Eq(apId)).Return(nil)
 				_, err := driver.DeleteVolume(ctx, req)
 				if err != nil {
 					t.Fatalf("Delete Volume failed: %v", err)
 				}
+				mockCtl.Finish()
+			},
+		},
+		{
+			name: "Success: Race Delete with deleteAccessPointRootDir",
+			testFunc: func(t *testing.T) {
+				const numGoRoutines = 100
+				mockCtl := gomock.NewController(t)
+				mockCloud := mocks.NewMockCloud(mockCtl)
+				mockMounter := mocks.NewMockMounter(mockCtl)
+
+				driver := &Driver{
+					endpoint:                 endpoint,
+					cloud:                    mockCloud,
+					mounter:                  mockMounter,
+					gidAllocator:             NewGidAllocator(),
+					lockManager:              NewLockManagerMap(),
+					deleteAccessPointRootDir: true,
+				}
+
+				req := &csi.DeleteVolumeRequest{
+					VolumeId: volumeId,
+				}
+
+				accessPoint := &cloud.AccessPoint{
+					AccessPointId:      apId,
+					FileSystemId:       fsId,
+					AccessPointRootDir: "/testDir",
+					CapacityGiB:        0,
+				}
+
+				dirPresent := mocks.NewMockFileInfo(
+					"testFile",
+					0,
+					0755,
+					time.Now(),
+					true,
+					nil,
+				)
+
+				ctx := context.Background()
+				// Expect the deletion scenario to only happen once
+				mockMounter.EXPECT().MakeDir(gomock.Any()).Return(nil).Times(1)
+				mockMounter.EXPECT().Mount(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+				mockMounter.EXPECT().Unmount(gomock.Any()).Return(nil).Times(1)
+				mockMounter.EXPECT().Stat(gomock.Any()).Return(dirPresent, nil).Times(1)
+				mockCloud.EXPECT().DeleteAccessPoint(gomock.Eq(ctx), gomock.Eq(apId)).Return(nil).Times(1)
+
+				mockMounter.EXPECT().IsLikelyNotMountPoint(gomock.Any()).Return(true, nil).Times(numGoRoutines)
+
+				// Expect the first describe call to see the access point, then subsequent calls to see it as deleted
+				var describeCallCount int32 = 0
+				mockCloud.EXPECT().DescribeAccessPoint(gomock.Eq(ctx), gomock.Eq(apId)).
+					DoAndReturn(func(ctx, accessPointId interface{}) (*cloud.AccessPoint, error) {
+						current := atomic.AddInt32(&describeCallCount, 1)
+						if current == 1 {
+							return accessPoint, nil
+						}
+						return accessPoint, cloud.ErrNotFound
+					}).Times(numGoRoutines)
+
+				// Lock the volume mutex to hold threads until they are all scheduled
+				driver.lockManager.lockMutex(apId)
+
+				var wg sync.WaitGroup
+				resultChan := make(chan struct {
+					index int
+					resp  *csi.DeleteVolumeResponse
+					err   error
+				}, numGoRoutines)
+
+				for i := 0; i < numGoRoutines; i++ {
+					wg.Add(1)
+					go func(index int) {
+						defer wg.Done()
+						resp, err := driver.DeleteVolume(ctx, req)
+						resultChan <- struct {
+							index int
+							resp  *csi.DeleteVolumeResponse
+							err   error
+						}{index, resp, err}
+					}(i)
+				}
+
+				// Unlock the mutex to force a race
+				driver.lockManager.unlockMutex(apId)
+
+				go func() {
+					wg.Wait()
+					close(resultChan)
+				}()
+
+				for result := range resultChan {
+					if result.err != nil {
+						t.Fatalf("Delete Volume failed on routine %d: %v", result.index, result.err)
+					}
+				}
+
+				// Ensure all keys were properly deleted from the lock manager
+				keys, _ := driver.lockManager.GetLockCount()
+				if keys > 0 {
+					t.Fatalf("%d Keys are still in the lockManager", keys)
+				}
+
+				mockCtl.Finish()
+			},
+		},
+		{
+			name: "Success: Race Delete different access points with deleteAccessPointRootDir",
+			testFunc: func(t *testing.T) {
+				const numGoRoutines = 100
+				mockCtl := gomock.NewController(t)
+				mockCloud := mocks.NewMockCloud(mockCtl)
+				mockMounter := mocks.NewMockMounter(mockCtl)
+
+				driver := &Driver{
+					endpoint:                 endpoint,
+					cloud:                    mockCloud,
+					mounter:                  mockMounter,
+					gidAllocator:             NewGidAllocator(),
+					lockManager:              NewLockManagerMap(),
+					deleteAccessPointRootDir: true,
+				}
+
+				req := &csi.DeleteVolumeRequest{
+					VolumeId: volumeId,
+				}
+
+				req2 := &csi.DeleteVolumeRequest{
+					VolumeId: volumeId2,
+				}
+
+				accessPoint1 := &cloud.AccessPoint{
+					AccessPointId:      apId,
+					FileSystemId:       fsId,
+					AccessPointRootDir: "/ap1",
+					CapacityGiB:        0,
+				}
+
+				accessPoint2 := &cloud.AccessPoint{
+					AccessPointId:      apId2,
+					FileSystemId:       fsId,
+					AccessPointRootDir: "/ap2",
+					CapacityGiB:        0,
+				}
+
+				dirPresent := mocks.NewMockFileInfo(
+					"testFile",
+					0,
+					0755,
+					time.Now(),
+					true,
+					nil,
+				)
+
+				ctx := context.Background()
+				// Expect the deletion scenario to only happen once per access point
+				mockMounter.EXPECT().MakeDir(gomock.Any()).Return(nil).Times(2)
+				mockMounter.EXPECT().Mount(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(2)
+				mockMounter.EXPECT().Unmount(gomock.Any()).Return(nil).Times(2)
+				mockMounter.EXPECT().Stat(gomock.Any()).Return(dirPresent, nil).Times(2)
+				mockCloud.EXPECT().DeleteAccessPoint(gomock.Eq(ctx), gomock.Eq(apId)).Return(nil).Times(1)
+				mockCloud.EXPECT().DeleteAccessPoint(gomock.Eq(ctx), gomock.Eq(apId2)).Return(nil).Times(1)
+
+				mockMounter.EXPECT().IsLikelyNotMountPoint(gomock.Any()).Return(true, nil).Times(2 * numGoRoutines)
+
+				// Expect the first describe call to see the access point, then subsequent calls to see it as deleted
+				describeCallCountAp1 := 0
+				mockCloud.EXPECT().DescribeAccessPoint(gomock.Eq(ctx), gomock.Eq(apId)).
+					DoAndReturn(func(ctx, accessPointId interface{}) (*cloud.AccessPoint, error) {
+						describeCallCountAp1++
+						if describeCallCountAp1 == 1 {
+							return accessPoint1, nil
+						}
+						return accessPoint1, cloud.ErrNotFound
+					}).Times(numGoRoutines)
+
+				describeCallCountAp2 := 0
+				mockCloud.EXPECT().DescribeAccessPoint(gomock.Eq(ctx), gomock.Eq(apId2)).
+					DoAndReturn(func(ctx, accessPointId interface{}) (*cloud.AccessPoint, error) {
+						describeCallCountAp2++
+						if describeCallCountAp2 == 1 {
+							return accessPoint2, nil
+						}
+						return accessPoint2, cloud.ErrNotFound
+					}).Times(numGoRoutines)
+
+				// Lock the volume mutex to hold threads until they are all scheduled
+				driver.lockManager.lockMutex(apId)
+				driver.lockManager.lockMutex(apId2)
+
+				var wg sync.WaitGroup
+				resultChan := make(chan struct {
+					index int
+					resp  *csi.DeleteVolumeResponse
+					err   error
+				}, numGoRoutines)
+
+				// Add apId1 threads
+				for i := 0; i < numGoRoutines; i++ {
+					wg.Add(1)
+					go func(index int) {
+						defer wg.Done()
+						resp, err := driver.DeleteVolume(ctx, req)
+						resultChan <- struct {
+							index int
+							resp  *csi.DeleteVolumeResponse
+							err   error
+						}{index, resp, err}
+					}(i)
+				}
+
+				// Add apId2 threads
+				for i := 0; i < numGoRoutines; i++ {
+					wg.Add(1)
+					go func(index int) {
+						defer wg.Done()
+						resp, err := driver.DeleteVolume(ctx, req2)
+						resultChan <- struct {
+							index int
+							resp  *csi.DeleteVolumeResponse
+							err   error
+						}{index, resp, err}
+					}(i)
+				}
+
+				// Unlock the mutex to force a race
+				driver.lockManager.unlockMutex(apId)
+				driver.lockManager.unlockMutex(apId2)
+
+				go func() {
+					wg.Wait()
+					close(resultChan)
+				}()
+
+				for result := range resultChan {
+					if result.err != nil {
+						t.Fatalf("Delete Volume failed on routine %d: %v", result.index, result.err)
+					}
+				}
+
+				// Ensure all keys were properly deleted from the lock manager
+				keys, _ := driver.lockManager.GetLockCount()
+				if keys > 0 {
+					t.Fatalf("%d Keys are still in the lockManager", keys)
+				}
+
+				mockCtl.Finish()
+			},
+		},
+		{
+			name: "Fail: Delete volume mutex timeout",
+			testFunc: func(t *testing.T) {
+				const timeout = 3 * time.Second
+				mockCtl := gomock.NewController(t)
+				mockCloud := mocks.NewMockCloud(mockCtl)
+				mockMounter := mocks.NewMockMounter(mockCtl)
+
+				driver := &Driver{
+					endpoint:                 endpoint,
+					cloud:                    mockCloud,
+					mounter:                  mockMounter,
+					gidAllocator:             NewGidAllocator(),
+					lockManager:              NewLockManagerMap(),
+					deleteAccessPointRootDir: true,
+				}
+
+				req := &csi.DeleteVolumeRequest{
+					VolumeId: volumeId,
+				}
+
+				ctx := context.Background()
+
+				// Lock the volume mutex to hold thread and force it to timeout
+				driver.lockManager.lockMutex(apId)
+
+				start := time.Now()
+				resp, err := driver.DeleteVolume(ctx, req)
+				elapsed := time.Since(start)
+
+				// Check that it waited for at least the timeout duration
+				if elapsed < timeout {
+					t.Errorf("lockMutex returned before timeout. Expected to wait %v, but waited %v", timeout, elapsed)
+				}
+
+				// Check that it didn't wait too much longer than the timeout
+				// We'll allow a 100ms buffer for system scheduling variations
+				if elapsed > timeout+100*time.Millisecond {
+					t.Errorf("lockMutex waited too long. Expected to wait %v, but waited %v", timeout, elapsed)
+				}
+
+				if resp != nil {
+					t.Errorf("Expected resp to be nil, but got %v", resp)
+				}
+
+				if err == nil {
+					t.Errorf("Expected err to not be nil, but got %v", err)
+				}
+
+				driver.lockManager.unlockMutex(apId)
+
+				// Ensure all keys were properly deleted from the lock manager even with a timeout
+				keys, _ := driver.lockManager.GetLockCount()
+				if keys > 0 {
+					t.Fatalf("%d Keys are still in the lockManager", keys)
+				}
+
 				mockCtl.Finish()
 			},
 		},
@@ -2744,6 +3469,7 @@ func TestDeleteVolume(t *testing.T) {
 					cloud:                    mockCloud,
 					mounter:                  mockMounter,
 					gidAllocator:             NewGidAllocator(),
+					lockManager:              NewLockManagerMap(),
 					deleteAccessPointRootDir: true,
 				}
 
@@ -2752,6 +3478,7 @@ func TestDeleteVolume(t *testing.T) {
 				}
 
 				ctx := context.Background()
+				mockMounter.EXPECT().IsLikelyNotMountPoint(gomock.Any()).Return(true, nil)
 				mockCloud.EXPECT().DescribeAccessPoint(gomock.Eq(ctx), gomock.Eq(apId)).Return(nil, cloud.ErrNotFound)
 				_, err := driver.DeleteVolume(ctx, req)
 				if err != nil {
@@ -2772,6 +3499,7 @@ func TestDeleteVolume(t *testing.T) {
 					cloud:                    mockCloud,
 					mounter:                  mockMounter,
 					gidAllocator:             NewGidAllocator(),
+					lockManager:              NewLockManagerMap(),
 					deleteAccessPointRootDir: true,
 				}
 
@@ -2780,6 +3508,7 @@ func TestDeleteVolume(t *testing.T) {
 				}
 
 				ctx := context.Background()
+				mockMounter.EXPECT().IsLikelyNotMountPoint(gomock.Any()).Return(true, nil)
 				mockCloud.EXPECT().DescribeAccessPoint(gomock.Eq(ctx), gomock.Eq(apId)).Return(nil, cloud.ErrAccessDenied)
 				_, err := driver.DeleteVolume(ctx, req)
 				if err == nil {
@@ -2800,6 +3529,7 @@ func TestDeleteVolume(t *testing.T) {
 					cloud:                    mockCloud,
 					mounter:                  mockMounter,
 					gidAllocator:             NewGidAllocator(),
+					lockManager:              NewLockManagerMap(),
 					deleteAccessPointRootDir: true,
 				}
 
@@ -2808,6 +3538,7 @@ func TestDeleteVolume(t *testing.T) {
 				}
 
 				ctx := context.Background()
+				mockMounter.EXPECT().IsLikelyNotMountPoint(gomock.Any()).Return(true, nil)
 				mockCloud.EXPECT().DescribeAccessPoint(gomock.Eq(ctx), gomock.Eq(apId)).Return(nil, errors.New("Describe Access Point failed"))
 				_, err := driver.DeleteVolume(ctx, req)
 				if err == nil {
@@ -2828,6 +3559,7 @@ func TestDeleteVolume(t *testing.T) {
 					cloud:                    mockCloud,
 					mounter:                  mockMounter,
 					gidAllocator:             NewGidAllocator(),
+					lockManager:              NewLockManagerMap(),
 					deleteAccessPointRootDir: true,
 				}
 
@@ -2844,6 +3576,7 @@ func TestDeleteVolume(t *testing.T) {
 
 				ctx := context.Background()
 				mockMounter.EXPECT().MakeDir(gomock.Any()).Return(errors.New("Failed to makeDir"))
+				mockMounter.EXPECT().IsLikelyNotMountPoint(gomock.Any()).Return(true, nil)
 				mockCloud.EXPECT().DescribeAccessPoint(gomock.Eq(ctx), gomock.Eq(apId)).Return(accessPoint, nil)
 				_, err := driver.DeleteVolume(ctx, req)
 				if err == nil {
@@ -2864,6 +3597,7 @@ func TestDeleteVolume(t *testing.T) {
 					cloud:                    mockCloud,
 					mounter:                  mockMounter,
 					gidAllocator:             NewGidAllocator(),
+					lockManager:              NewLockManagerMap(),
 					deleteAccessPointRootDir: true,
 				}
 
@@ -2881,6 +3615,7 @@ func TestDeleteVolume(t *testing.T) {
 				ctx := context.Background()
 				mockMounter.EXPECT().MakeDir(gomock.Any()).Return(nil)
 				mockMounter.EXPECT().Mount(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("Failed to mount"))
+				mockMounter.EXPECT().IsLikelyNotMountPoint(gomock.Any()).Return(true, nil).Times(2)
 				mockCloud.EXPECT().DescribeAccessPoint(gomock.Eq(ctx), gomock.Eq(apId)).Return(accessPoint, nil)
 				_, err := driver.DeleteVolume(ctx, req)
 				if err == nil {
@@ -2901,6 +3636,7 @@ func TestDeleteVolume(t *testing.T) {
 					cloud:                    mockCloud,
 					mounter:                  mockMounter,
 					gidAllocator:             NewGidAllocator(),
+					lockManager:              NewLockManagerMap(),
 					deleteAccessPointRootDir: true,
 				}
 
@@ -2915,10 +3651,21 @@ func TestDeleteVolume(t *testing.T) {
 					CapacityGiB:        0,
 				}
 
+				dirPresent := mocks.NewMockFileInfo(
+					"test",
+					0,
+					0755,
+					time.Now(),
+					true,
+					nil,
+				)
+
 				ctx := context.Background()
 				mockMounter.EXPECT().MakeDir(gomock.Any()).Return(nil)
 				mockMounter.EXPECT().Mount(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 				mockMounter.EXPECT().Unmount(gomock.Any()).Return(errors.New("Failed to unmount"))
+				mockMounter.EXPECT().Stat(gomock.Any()).Return(dirPresent, nil).Times(1)
+				mockMounter.EXPECT().IsLikelyNotMountPoint(gomock.Any()).Return(true, nil).Times(2)
 				mockCloud.EXPECT().DescribeAccessPoint(gomock.Eq(ctx), gomock.Eq(apId)).Return(accessPoint, nil)
 				_, err := driver.DeleteVolume(ctx, req)
 				if err == nil {
@@ -2937,6 +3684,7 @@ func TestDeleteVolume(t *testing.T) {
 					endpoint:     endpoint,
 					cloud:        mockCloud,
 					gidAllocator: NewGidAllocator(),
+					lockManager:  NewLockManagerMap(),
 				}
 
 				req := &csi.DeleteVolumeRequest{
@@ -2962,6 +3710,7 @@ func TestDeleteVolume(t *testing.T) {
 					endpoint:     endpoint,
 					cloud:        mockCloud,
 					gidAllocator: NewGidAllocator(),
+					lockManager:  NewLockManagerMap(),
 				}
 
 				req := &csi.DeleteVolumeRequest{
@@ -2987,6 +3736,7 @@ func TestDeleteVolume(t *testing.T) {
 					endpoint:     endpoint,
 					cloud:        mockCloud,
 					gidAllocator: NewGidAllocator(),
+					lockManager:  NewLockManagerMap(),
 				}
 
 				req := &csi.DeleteVolumeRequest{
@@ -3012,6 +3762,7 @@ func TestDeleteVolume(t *testing.T) {
 					endpoint:     endpoint,
 					cloud:        mockCloud,
 					gidAllocator: NewGidAllocator(),
+					lockManager:  NewLockManagerMap(),
 				}
 
 				req := &csi.DeleteVolumeRequest{
@@ -3036,6 +3787,7 @@ func TestDeleteVolume(t *testing.T) {
 					endpoint:     endpoint,
 					cloud:        mockCloud,
 					gidAllocator: NewGidAllocator(),
+					lockManager:  NewLockManagerMap(),
 					tags:         parseTagsFromStr(""),
 				}
 
@@ -3055,6 +3807,340 @@ func TestDeleteVolume(t *testing.T) {
 					t.Fatalf("DeleteVolume did not fail")
 				}
 
+				mockCtl.Finish()
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, tc.testFunc)
+	}
+}
+
+func TestCreateDeleteVolumeRace(t *testing.T) {
+	var (
+		apId                = "fsap-abcd1234xyz987"
+		fsId                = "fs-abcd1234"
+		endpoint            = "endpoint"
+		volumeId            = "fs-abcd1234::fsap-abcd1234xyz987"
+		volumeName          = "volumeName"
+		capacityRange int64 = 5368709120
+		stdVolCap           = &csi.VolumeCapability{
+			AccessType: &csi.VolumeCapability_Mount{
+				Mount: &csi.VolumeCapability_MountVolume{},
+			},
+			AccessMode: &csi.VolumeCapability_AccessMode{
+				Mode: csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER,
+			},
+		}
+	)
+
+	testCases := []struct {
+		name     string
+		testFunc func(t *testing.T)
+	}{
+		{
+			name: "Success: Race Create with reused access point while Deleting with deleteAccessPointRootDir",
+			testFunc: func(t *testing.T) {
+				mockCtl := gomock.NewController(t)
+				mockCloud := mocks.NewMockCloud(mockCtl)
+				mockMounter := mocks.NewMockMounter(mockCtl)
+
+				driver := &Driver{
+					endpoint:                 endpoint,
+					cloud:                    mockCloud,
+					mounter:                  mockMounter,
+					gidAllocator:             NewGidAllocator(),
+					lockManager:              NewLockManagerMap(),
+					tags:                     parseTagsFromStr(""),
+					deleteAccessPointRootDir: true,
+				}
+				pvcNameVal := "test-pvc"
+
+				createReq := &csi.CreateVolumeRequest{
+					Name: volumeName,
+					VolumeCapabilities: []*csi.VolumeCapability{
+						stdVolCap,
+					},
+					CapacityRange: &csi.CapacityRange{
+						RequiredBytes: capacityRange,
+					},
+					Parameters: map[string]string{
+						ProvisioningMode:    "efs-ap",
+						FsId:                fsId,
+						GidMin:              "1000",
+						GidMax:              "2000",
+						DirectoryPerms:      "777",
+						AzName:              "us-east-1a",
+						ReuseAccessPointKey: "true",
+						PvcNameKey:          pvcNameVal,
+					},
+				}
+
+				deleteReq := &csi.DeleteVolumeRequest{
+					VolumeId: volumeId,
+				}
+
+				ctx := context.Background()
+
+				accessPoint := &cloud.AccessPoint{
+					AccessPointId: apId,
+					FileSystemId:  fsId,
+					PosixUser: &cloud.PosixUser{
+						Gid: 1000,
+						Uid: 1000,
+					},
+					AccessPointRootDir: "/testDir",
+					CapacityGiB:        0,
+				}
+
+				dirPresent := mocks.NewMockFileInfo(
+					"testFile",
+					0,
+					0755,
+					time.Now(),
+					true,
+					nil,
+				)
+
+				// Expected create function calls
+				mockCloud.EXPECT().DescribeAccessPoint(gomock.Eq(ctx), gomock.Eq(apId)).Return(accessPoint, nil)
+				mockCloud.EXPECT().FindAccessPointByClientToken(gomock.Eq(ctx), gomock.Any(), gomock.Eq(fsId)).Return(accessPoint, nil)
+
+				// Expected delete function calls
+				mockMounter.EXPECT().MakeDir(gomock.Any()).Return(nil).Times(1)
+				mockMounter.EXPECT().Mount(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+				mockMounter.EXPECT().Unmount(gomock.Any()).Return(nil).Times(1)
+				mockMounter.EXPECT().Stat(gomock.Any()).Return(dirPresent, nil).Times(1)
+				mockCloud.EXPECT().DeleteAccessPoint(gomock.Eq(ctx), gomock.Eq(apId)).Return(nil).Times(1)
+
+				mockMounter.EXPECT().IsLikelyNotMountPoint(gomock.Any()).Return(true, nil).Times(1)
+
+				// Lock the volume mutex to hold threads until they are all scheduled
+				driver.lockManager.lockMutex(apId)
+
+				var wg sync.WaitGroup
+				deleteResultChan := make(chan struct {
+					resp *csi.DeleteVolumeResponse
+					err  error
+				})
+
+				// Schedule delete volume first
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					resp, err := driver.DeleteVolume(ctx, deleteReq)
+					deleteResultChan <- struct {
+						resp *csi.DeleteVolumeResponse
+						err  error
+					}{resp, err}
+				}()
+
+				// Let the deletion thread settle on the lock to ensure it goes first
+				time.Sleep(100 * time.Millisecond)
+
+				createResultChan := make(chan struct {
+					resp *csi.CreateVolumeResponse
+					err  error
+				})
+
+				// Schedule the volume create second
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					resp, err := driver.CreateVolume(ctx, createReq)
+					createResultChan <- struct {
+						resp *csi.CreateVolumeResponse
+						err  error
+					}{resp, err}
+				}()
+
+				// Let the threads settle to force the race
+				time.Sleep(100 * time.Millisecond)
+
+				driver.lockManager.unlockMutex(apId)
+
+				go func() {
+					wg.Wait()
+					close(createResultChan)
+					close(deleteResultChan)
+				}()
+
+				createResult := <-createResultChan
+				if createResult.err != nil {
+					t.Fatalf("CreateVolume failed: %v", createResult.err)
+				}
+
+				if createResult.resp.Volume == nil {
+					t.Fatal("Volume is nil")
+				}
+
+				if createResult.resp.Volume.VolumeId != volumeId {
+					t.Fatalf("Volume Id mismatched. Expected: %v, Actual: %v", volumeId, createResult.resp.Volume.VolumeId)
+				}
+
+				deleteResult := <-deleteResultChan
+				if deleteResult.err != nil {
+					t.Fatalf("Delete Volume failed: %v", deleteResult.err)
+				}
+
+				// Ensure all keys were properly deleted from the lock manager
+				keys, _ := driver.lockManager.GetLockCount()
+				if keys > 0 {
+					t.Fatalf("%d Keys are still in the lockManager", keys)
+				}
+				mockCtl.Finish()
+			},
+		},
+		{
+			name: "Success: Race Delete with deleteAccessPointRootDir while creating volume with reused access point",
+			testFunc: func(t *testing.T) {
+				mockCtl := gomock.NewController(t)
+				mockCloud := mocks.NewMockCloud(mockCtl)
+				mockMounter := mocks.NewMockMounter(mockCtl)
+
+				driver := &Driver{
+					endpoint:                 endpoint,
+					cloud:                    mockCloud,
+					mounter:                  mockMounter,
+					gidAllocator:             NewGidAllocator(),
+					lockManager:              NewLockManagerMap(),
+					tags:                     parseTagsFromStr(""),
+					deleteAccessPointRootDir: true,
+				}
+				pvcNameVal := "test-pvc"
+
+				createReq := &csi.CreateVolumeRequest{
+					Name: volumeName,
+					VolumeCapabilities: []*csi.VolumeCapability{
+						stdVolCap,
+					},
+					CapacityRange: &csi.CapacityRange{
+						RequiredBytes: capacityRange,
+					},
+					Parameters: map[string]string{
+						ProvisioningMode:    "efs-ap",
+						FsId:                fsId,
+						GidMin:              "1000",
+						GidMax:              "2000",
+						DirectoryPerms:      "777",
+						AzName:              "us-east-1a",
+						ReuseAccessPointKey: "true",
+						PvcNameKey:          pvcNameVal,
+					},
+				}
+
+				deleteReq := &csi.DeleteVolumeRequest{
+					VolumeId: volumeId,
+				}
+
+				ctx := context.Background()
+
+				accessPoint := &cloud.AccessPoint{
+					AccessPointId: apId,
+					FileSystemId:  fsId,
+					PosixUser: &cloud.PosixUser{
+						Gid: 1000,
+						Uid: 1000,
+					},
+					AccessPointRootDir: "/testDir",
+					CapacityGiB:        0,
+				}
+
+				dirPresent := mocks.NewMockFileInfo(
+					"testFile",
+					0,
+					0755,
+					time.Now(),
+					true,
+					nil,
+				)
+
+				// Expected create function calls
+				mockCloud.EXPECT().DescribeAccessPoint(gomock.Eq(ctx), gomock.Eq(apId)).Return(accessPoint, nil)
+				mockCloud.EXPECT().FindAccessPointByClientToken(gomock.Eq(ctx), gomock.Any(), gomock.Eq(fsId)).Return(accessPoint, nil)
+
+				// Expected delete function calls
+				mockMounter.EXPECT().MakeDir(gomock.Any()).Return(nil).Times(1)
+				mockMounter.EXPECT().Mount(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+				mockMounter.EXPECT().Unmount(gomock.Any()).Return(nil).Times(1)
+				mockMounter.EXPECT().Stat(gomock.Any()).Return(dirPresent, nil).Times(1)
+				mockMounter.EXPECT().IsLikelyNotMountPoint(gomock.Any()).Return(true, nil).Times(1)
+				mockCloud.EXPECT().DeleteAccessPoint(gomock.Eq(ctx), gomock.Eq(apId)).Return(nil).Times(1)
+
+				// Lock the volume mutex to hold threads until they are all scheduled
+				driver.lockManager.lockMutex(apId)
+
+				var wg sync.WaitGroup
+				createResultChan := make(chan struct {
+					resp *csi.CreateVolumeResponse
+					err  error
+				})
+
+				// Schedule the volume create first
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					resp, err := driver.CreateVolume(ctx, createReq)
+					createResultChan <- struct {
+						resp *csi.CreateVolumeResponse
+						err  error
+					}{resp, err}
+				}()
+
+				// Let the creation thread settle on the lock to ensure it goes first
+				time.Sleep(100 * time.Millisecond)
+
+				// Schedule the delete volume function
+				deleteResultChan := make(chan struct {
+					resp *csi.DeleteVolumeResponse
+					err  error
+				})
+
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					resp, err := driver.DeleteVolume(ctx, deleteReq)
+					deleteResultChan <- struct {
+						resp *csi.DeleteVolumeResponse
+						err  error
+					}{resp, err}
+				}()
+
+				// Let the threads settle to force the race
+				time.Sleep(100 * time.Millisecond)
+
+				driver.lockManager.unlockMutex(apId)
+
+				go func() {
+					wg.Wait()
+					close(createResultChan)
+					close(deleteResultChan)
+				}()
+
+				createResult := <-createResultChan
+				if createResult.err != nil {
+					t.Fatalf("CreateVolume failed: %v", createResult.err)
+				}
+
+				if createResult.resp.Volume == nil {
+					t.Fatal("Volume is nil")
+				}
+
+				if createResult.resp.Volume.VolumeId != volumeId {
+					t.Fatalf("Volume Id mismatched. Expected: %v, Actual: %v", volumeId, createResult.resp.Volume.VolumeId)
+				}
+
+				deleteResult := <-deleteResultChan
+				if deleteResult.err != nil {
+					t.Fatalf("Delete Volume failed: %v", deleteResult.err)
+				}
+
+				// Ensure all keys were properly deleted from the lock manager
+				keys, _ := driver.lockManager.GetLockCount()
+				if keys > 0 {
+					t.Fatalf("%d Keys are still in the lockManager", keys)
+				}
 				mockCtl.Finish()
 			},
 		},
@@ -3228,4 +4314,14 @@ func verifyPathWhenUUIDIncluded(pathToVerify string, expectedPathWithoutUUID str
 	doesPathMatchWithUuid := matches[1] == expectedPathWithoutUUID
 	_, err := uuid.Parse(matches[2])
 	return err == nil && doesPathMatchWithUuid
+}
+
+// Helper function to return a random string of a specified length. Useful when generating random apIds
+func randStringBytes(n int) string {
+	const chars = "abcdefghijklmnopqrstuvwxyz0123456789"
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = chars[rand.Intn(len(chars))]
+	}
+	return string(b)
 }

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -53,6 +53,7 @@ type Driver struct {
 	deleteAccessPointRootDir bool
 	adaptiveRetryMode        bool
 	tags                     map[string]string
+	lockManager              LockManagerMap
 }
 
 func NewDriver(endpoint, efsUtilsCfgPath, efsUtilsStaticFilesPath, tags string, volMetricsOptIn bool, volMetricsRefreshPeriod float64, volMetricsFsRateLimit int, deleteAccessPointRootDir bool, adaptiveRetryMode bool) *Driver {
@@ -78,6 +79,7 @@ func NewDriver(endpoint, efsUtilsCfgPath, efsUtilsStaticFilesPath, tags string, 
 		deleteAccessPointRootDir: deleteAccessPointRootDir,
 		adaptiveRetryMode:        adaptiveRetryMode,
 		tags:                     parseTagsFromStr(strings.TrimSpace(tags)),
+		lockManager:              NewLockManagerMap(),
 	}
 }
 

--- a/pkg/driver/lock_manager.go
+++ b/pkg/driver/lock_manager.go
@@ -1,0 +1,121 @@
+package driver
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"k8s.io/klog/v2"
+)
+
+type LockManager struct {
+	mutex    sync.Mutex
+	refCount atomic.Int32
+	isLocked atomic.Bool
+}
+
+type LockManagerMap struct {
+	locks sync.Map
+}
+
+func NewLockManagerMap() LockManagerMap {
+	return LockManagerMap{
+		locks: sync.Map{},
+	}
+}
+
+// lockMutex Locks a mutex for the given ID. The ref count will be
+// incremented while the lock is in use by multiple threads to prevent
+// it from being cleaned up prematurely
+func (lmm *LockManagerMap) lockMutex(id string, timeout ...time.Duration) bool {
+	const maxRetries = 3
+	retryCount := 0
+
+	for retryCount < maxRetries {
+		value, _ := lmm.locks.LoadOrStore(id, &LockManager{})
+		entry := value.(*LockManager)
+
+		currentRef := entry.refCount.Add(1)
+
+		// Check if the entry still exists in the map
+		if currentRef <= 1 {
+			if _, exists := lmm.locks.Load(id); !exists {
+				// If the entry was deleted, retry
+				entry.refCount.Add(-1)
+				retryCount++
+				continue
+			}
+		}
+
+		// If a timeout is provided, return false and cleanup if that timeout is exceeded
+		if len(timeout) > 0 {
+			timer := time.NewTimer(timeout[0])
+			defer timer.Stop()
+
+			signalChan := make(chan struct{})
+			go func() {
+				entry.mutex.Lock()
+				entry.isLocked.Store(true)
+				close(signalChan)
+			}()
+
+			select {
+			case <-signalChan:
+				// Successfully acquired the lock
+				return true
+			case <-timer.C:
+				// Timed out, decrement refCount and remove the lock from the map if it's no longer needed
+				if entry.refCount.Add(-1) == 0 {
+					lmm.locks.Delete(id)
+				}
+				return false
+			}
+		}
+
+		entry.mutex.Lock()
+		entry.isLocked.Store(true)
+		return true
+	}
+
+	// Exceeded max retries
+	return false
+}
+
+// unlockMutex Unlocks the mutex for a given id and deletes it if nobody else is waiting on it
+func (lmm *LockManagerMap) unlockMutex(id string) {
+	value, ok := lmm.locks.Load(id)
+	if !ok {
+		klog.Warningf("unlockMutex: LockManager not found for id: %s", id)
+		return
+	}
+	entry := value.(*LockManager)
+
+	// Decrease the reference count first
+	newCount := entry.refCount.Add(-1)
+
+	// Only unlock if it's currently locked
+	if entry.isLocked.Swap(false) {
+		entry.mutex.Unlock()
+	}
+
+	// Remove the lock from the map if needed
+	if newCount == 0 {
+		lmm.locks.Delete(id)
+	}
+}
+
+// GetLockCount returns the current number of locks currently active in the map.
+// For each active lock, the number of references for each lock ID is returned
+func (lmm *LockManagerMap) GetLockCount() (int, map[string]int32) {
+	count := 0
+	refCounts := make(map[string]int32)
+
+	lmm.locks.Range(func(key, value interface{}) bool {
+		count++
+		entry := value.(*LockManager)
+		refCounts[key.(string)] = entry.refCount.Load()
+		return true
+	})
+
+	return count, refCounts
+}

--- a/pkg/driver/mocks/mock_mount.go
+++ b/pkg/driver/mocks/mock_mount.go
@@ -5,7 +5,9 @@
 package mocks
 
 import (
+	"os"
 	reflect "reflect"
+	"time"
 
 	gomock "github.com/golang/mock/gomock"
 	mount_utils "k8s.io/mount-utils"
@@ -21,6 +23,35 @@ type MockMounter struct {
 // MockMounterMockRecorder is the mock recorder for MockMounter.
 type MockMounterMockRecorder struct {
 	mock *MockMounter
+}
+
+// Mock struct used for stat
+type MockFileInfo struct {
+	name    string
+	size    int64
+	mode    os.FileMode
+	modTime time.Time
+	isDir   bool
+	sys     interface{}
+}
+
+func (m MockFileInfo) Name() string       { return m.name }
+func (m MockFileInfo) Size() int64        { return m.size }
+func (m MockFileInfo) Mode() os.FileMode  { return m.mode }
+func (m MockFileInfo) ModTime() time.Time { return m.modTime }
+func (m MockFileInfo) IsDir() bool        { return m.isDir }
+func (m MockFileInfo) Sys() interface{}   { return m.sys }
+
+// NewMockFileInfo creates a new mock file info structure for Stat
+func NewMockFileInfo(name string, size int64, mode os.FileMode, modTime time.Time, isDir bool, sys interface{}) MockFileInfo {
+	return MockFileInfo{
+		name:    name,
+		size:    size,
+		mode:    mode,
+		modTime: modTime,
+		isDir:   isDir,
+		sys:     sys,
+	}
 }
 
 // NewMockMounter creates a new mock instance.
@@ -137,6 +168,21 @@ func (m *MockMounter) MakeDir(arg0 string) error {
 func (mr *MockMounterMockRecorder) MakeDir(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeDir", reflect.TypeOf((*MockMounter)(nil).MakeDir), arg0)
+}
+
+// Stat mocks base method.
+func (m *MockMounter) Stat(arg0 string) (os.FileInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Stat", arg0)
+	ret0, _ := ret[0].(os.FileInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Stat indicates an expected call of MakeDir.
+func (mr *MockMounterMockRecorder) Stat(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stat", reflect.TypeOf((*MockMounter)(nil).Stat), arg0)
 }
 
 // Mount mocks base method.

--- a/pkg/driver/mounter.go
+++ b/pkg/driver/mounter.go
@@ -23,7 +23,9 @@ import (
 type Mounter interface {
 	mount_utils.Interface
 	MakeDir(pathname string) error
+	Stat(pathname string) (os.FileInfo, error)
 	GetDeviceName(mountPath string) (string, int, error)
+	IsLikelyNotMountPoint(target string) (bool, error)
 }
 
 type NodeMounter struct {
@@ -46,6 +48,21 @@ func (m *NodeMounter) MakeDir(pathname string) error {
 	return nil
 }
 
+func (m *NodeMounter) Stat(pathname string) (os.FileInfo, error) {
+	return os.Stat(pathname)
+}
+
 func (m *NodeMounter) GetDeviceName(mountPath string) (string, int, error) {
 	return mount_utils.GetDeviceNameFromMount(m, mountPath)
+}
+
+func (m *NodeMounter) IsLikelyNotMountPoint(target string) (bool, error) {
+	notMnt, err := m.Interface.IsLikelyNotMountPoint(target)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return notMnt, nil
 }

--- a/pkg/driver/sanity_test.go
+++ b/pkg/driver/sanity_test.go
@@ -80,6 +80,7 @@ func TestSanityEFSCSI(t *testing.T) {
 		volMetricsOptIn: true,
 		volStatter:      NewVolStatter(),
 		gidAllocator:    NewGidAllocator(),
+		lockManager:     NewLockManagerMap(),
 	}
 	defer func() {
 		if r := recover(); r != nil {


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
This change is to harden the logic around volume creation and deletion to ensure idempotency and avoid race conditions in the creation and deletion logic.

**What is this PR about? / Why do we need it?**
In rare cases, volume creation and deletion functions can race against each other if kubernetes attempts a retry while either creation or deletion is in progress. This PR will serialize concurrent requests to the same access point and adds additional cleanup logic to ensure each individual request can complete and clean up after itself before allowing a subsequent operation on that access point.

**What testing is done?** 
- New unit tests were added to prove out concurrent access to the create and delete functions are handled correctly.
- e2e and driver upgrade tests were run and passed successfully
- Workload with many concurrent PV creations and deletions was run on a cluster and no adverse effects