### PR TITLE
add allowVolumeExpansion to storageclass

### DIFF
--- a/charts/aws-efs-csi-driver/templates/storageclass.yaml
+++ b/charts/aws-efs-csi-driver/templates/storageclass.yaml
@@ -9,6 +9,9 @@ metadata:
   {{- end }}
 provisioner: efs.csi.aws.com
 {{- with .mountOptions }}
+{{- with .allowVolumeExpansion }}
+allowVolumeExpansion: {{ . }}
+{{- end }}
 mountOptions:
 {{ toYaml . }}
 {{- end }}

--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -219,6 +219,7 @@ storageClasses: []
 #   annotations:
 #     # Use that annotation if you want this to your default storageclass
 #     storageclass.kubernetes.io/is-default-class: "true"
+#   allowVolumeExpansion: true
 #   mountOptions:
 #   - tls
 #   parameters:


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
This is a new feature.

**What is this PR about? / Why do we need it?**
relates to https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/1591

This will add the possibility to set allowVolumeExpansion in the created storage class(es). 

**What testing is done?** 
Tested this via `helm template`. The template got created and included the expected storage class with `allowVolumeExpansion: true`.