### PR TITLE
fix centos image in pod config examples

### DIFF
--- a/examples/kubernetes/access_points/specs/example.yaml
+++ b/examples/kubernetes/access_points/specs/example.yaml
@@ -67,7 +67,7 @@ metadata:
 spec:
   containers:
   - name: app
-    image: centos
+    image: centos:7
     command: ["/bin/sh"]
     args: ["-c", "while true; do echo $(date -u) >> /data-dir1/out.txt; sleep 5; done"]
     volumeMounts:

--- a/examples/kubernetes/cross_account_mount/specs/pod-static-prov.yaml
+++ b/examples/kubernetes/cross_account_mount/specs/pod-static-prov.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
   - name: app
-    image: centos
+    image: centos:7
     command: ["/bin/sh"]
     args: ["-c", "while true; do echo $(date -u) >> /data/out.txt; sleep 5; done"]
     volumeMounts:

--- a/examples/kubernetes/cross_account_mount/specs/pod.yaml
+++ b/examples/kubernetes/cross_account_mount/specs/pod.yaml
@@ -18,7 +18,7 @@ metadata:
 spec:
   containers:
     - name: app
-      image: centos
+      image: centos:7
       command: ["/bin/sh"]
       args: ["-c", "while true; do echo $(date -u) >> /data/out; sleep 5; done"]
       volumeMounts:

--- a/examples/kubernetes/dynamic_provisioning/specs/pod.yaml
+++ b/examples/kubernetes/dynamic_provisioning/specs/pod.yaml
@@ -18,7 +18,7 @@ metadata:
 spec:
   containers:
     - name: app
-      image: centos
+      image: centos:7
       command: ["/bin/sh"]
       args: ["-c", "while true; do echo $(date -u) >> /data/out; sleep 5; done"]
       volumeMounts:

--- a/examples/kubernetes/encryption_in_transit/specs/pod.yaml
+++ b/examples/kubernetes/encryption_in_transit/specs/pod.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
   - name: app
-    image: centos
+    image: centos:7
     command: ["/bin/sh"]
     args: ["-c", "while true; do echo $(date -u) >> /data/out.txt; sleep 5; done"]
     volumeMounts:

--- a/examples/kubernetes/static_provisioning/specs/pod.yaml
+++ b/examples/kubernetes/static_provisioning/specs/pod.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
   - name: app
-    image: centos
+    image: centos:7
     command: ["/bin/sh"]
     args: ["-c", "while true; do echo $(date -u) >> /data/out.txt; sleep 5; done"]
     volumeMounts:

--- a/examples/kubernetes/volume_path/specs/example.yaml
+++ b/examples/kubernetes/volume_path/specs/example.yaml
@@ -71,7 +71,7 @@ metadata:
 spec:
   containers:
   - name: app
-    image: centos
+    image: centos:7
     command: ["/bin/sh"]
     args: ["-c", "while true; do echo $(date -u) >> /data-dir1/out.txt; sleep 5; done"]
     volumeMounts:


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Bug fix

**What is this PR about? / Why do we need it?**
Correction of centos image in pod config examples

**What testing is done?** 
We ran the pod with both `centos` and `centos:7`. Pods ran successfully with `centos:7` but crashed when using `centos`.