### PR TITLE
Fix OpenSSL version mismatch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,6 +63,7 @@ COPY --from=rpm-provider /tmp/rpms/* /tmp/download/
 # cd, ls, cat, vim, tcpdump, are for debugging
 RUN clean_install amazon-efs-utils true && \
     clean_install crypto-policies true && \
+    clean_install "openssl-3.0.8 openssl-libs-3.0.8" true && \
     install_binary \
         /usr/bin/cat \
         /usr/bin/cd \
@@ -75,7 +76,6 @@ RUN clean_install amazon-efs-utils true && \
         /usr/bin/mount \
         /usr/bin/umount \
         /sbin/mount.nfs4 \
-        /usr/bin/openssl \
         /usr/bin/sed \
         /usr/bin/stat \
         /usr/bin/stunnel \


### PR DESCRIPTION
When installing OpenSSL packages separately in the rpm-installer stage:
- openssl package defaulted to version 3.2.2
- openssl-libs package defaulted to version 3.0.8

This version mismatch caused runtime failures when mounting EFS volumes:
"openssl: /lib64/libssl.so.3: version `OPENSSL_3.2.0' not found"

Fix by explicitly installing matching versions:
clean_install "openssl-3.0.8 openssl-libs-3.0.8"
