### PR TITLE
Feat/support az multi parameter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,6 @@ COPY --from=rpm-provider /tmp/rpms/* /tmp/download/
 # cd, ls, cat, vim, tcpdump, are for debugging
 RUN clean_install amazon-efs-utils true && \
     clean_install crypto-policies true && \
-    clean_install "openssl-3.0.8 openssl-libs-3.0.8" true && \
     install_binary \
         /usr/bin/cat \
         /usr/bin/cd \
@@ -76,6 +75,7 @@ RUN clean_install amazon-efs-utils true && \
         /usr/bin/mount \
         /usr/bin/umount \
         /sbin/mount.nfs4 \
+        /usr/bin/openssl \
         /usr/bin/sed \
         /usr/bin/stat \
         /usr/bin/stunnel \

--- a/examples/kubernetes/cross_account_mount/README.md
+++ b/examples/kubernetes/cross_account_mount/README.md
@@ -25,6 +25,8 @@ parameters:
   csi.storage.k8s.io/provisioner-secret-namespace: kube-system
 ```
 
+**Note**: driver version > 2.1.0 supports the `az: multi` option, which fetches EFS mount targets in all availability zones and consumes one for a pod in the same zone.
+
 ### Prerequisite setup
 Lets say you have an EKS cluster in aws account `A` & you wish to mount your file system in another aws account `B` using aws-efs-csi-driver, you'll need to perform the following steps before you proceed with cross account mount between accounts `A` & `B` 
 1. Perform [vpc-peering](https://docs.aws.amazon.com/vpc/latest/peering/working-with-vpc-peering.html) between EKS cluster `vpc` in aws account `A` and EFS `vpc` in another aws account `B`.

--- a/pkg/cloud/cloud_test.go
+++ b/pkg/cloud/cloud_test.go
@@ -1006,6 +1006,25 @@ func TestDescribeMountTargets(t *testing.T) {
 			expectError: errtyp{},
 		},
 		{
+			name: "Success: Mount target with multi az. Get all mount targets.",
+			mockOutput: &efs.DescribeMountTargetsOutput{
+				MountTargets: []types.MountTargetDescription{
+					{
+						AvailabilityZoneId:   aws.String("az-id"),
+						AvailabilityZoneName: aws.String("multi"),
+						FileSystemId:         aws.String(fsId),
+						IpAddress:            aws.String("127.0.0.1"),
+						LifeCycleState:       types.LifeCycleStateAvailable,
+						MountTargetId:        aws.String(mtId),
+						NetworkInterfaceId:   aws.String("eni-abcd1234"),
+						OwnerId:              aws.String("1234567890"),
+						SubnetId:             aws.String("subnet-abcd1234"),
+					},
+				},
+			},
+			expectError: errtyp{},
+		},
+		{
 			name: "Fail: File system does not have any mount targets",
 			mockOutput: &efs.DescribeMountTargetsOutput{
 				MountTargets: []types.MountTargetDescription{},

--- a/pkg/cloud/ec2_metadata.go
+++ b/pkg/cloud/ec2_metadata.go
@@ -3,6 +3,7 @@ package cloud
 import (
 	"context"
 	"fmt"
+	"io"
 
 	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
 )
@@ -34,9 +35,18 @@ func (e ec2MetadataProvider) getMetadata() (MetadataService, error) {
 		return nil, fmt.Errorf("could not get valid EC2 availavility zone")
 	}
 
+	availabilityZoneIdResponse, err := e.ec2MetadataService.GetMetadata(context.TODO(), &imds.GetMetadataInput{
+		Path: "placement/availability-zone-id",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("could not get placement availability-zone-id from the EC2 instance identity metadata")
+	}
+	availabilityZoneID, _ := io.ReadAll(availabilityZoneIdResponse.Content)
+
 	return &metadata{
-		instanceID:       doc.InstanceID,
-		region:           doc.Region,
-		availabilityZone: doc.AvailabilityZone,
+		instanceID:         doc.InstanceID,
+		region:             doc.Region,
+		availabilityZone:   doc.AvailabilityZone,
+		availabilityZoneID: string(availabilityZoneID),
 	}, nil
 }

--- a/pkg/cloud/fakes.go
+++ b/pkg/cloud/fakes.go
@@ -16,7 +16,7 @@ type FakeCloudProvider struct {
 
 func NewFakeCloudProvider() *FakeCloudProvider {
 	return &FakeCloudProvider{
-		m:            &metadata{"instanceID", "region", "az"},
+		m:            &metadata{"instanceID", "region", "az", "azId"},
 		fileSystems:  make(map[string]*FileSystem),
 		accessPoints: make(map[string]*AccessPoint),
 		mountTargets: make(map[string]*MountTarget),
@@ -90,11 +90,10 @@ func (c *FakeCloudProvider) DescribeFileSystem(ctx context.Context, fileSystemId
 	return fs, nil
 }
 
-func (c *FakeCloudProvider) DescribeMountTargets(ctx context.Context, fileSystemId, az string) (mountTarget *MountTarget, err error) {
+func (c *FakeCloudProvider) DescribeMountTargets(ctx context.Context, fileSystemId, az string) (mountTarget []*MountTarget, err error) {
 	if mt, ok := c.mountTargets[fileSystemId]; ok {
-		return mt, nil
+		return []*MountTarget{mt}, nil
 	}
-
 	return nil, ErrNotFound
 }
 

--- a/pkg/cloud/metadata.go
+++ b/pkg/cloud/metadata.go
@@ -19,6 +19,7 @@ package cloud
 import (
 	"context"
 	"fmt"
+
 	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
 
 	"k8s.io/client-go/kubernetes"
@@ -34,12 +35,14 @@ type MetadataService interface {
 	GetInstanceID() string
 	GetRegion() string
 	GetAvailabilityZone() string
+	GetAvailabilityZoneID() string
 }
 
 type metadata struct {
-	instanceID       string
-	region           string
-	availabilityZone string
+	instanceID         string
+	region             string
+	availabilityZone   string
+	availabilityZoneID string
 }
 
 var _ MetadataService = &metadata{}
@@ -59,6 +62,11 @@ func (m *metadata) GetRegion() string {
 // GetAvailabilityZone returns the Availability Zone which the instance is in.
 func (m *metadata) GetAvailabilityZone() string {
 	return m.availabilityZone
+}
+
+// GetAvailabilityZoneID returns the Availability Zone Id which the instance is in.
+func (m *metadata) GetAvailabilityZoneID() string {
+	return m.availabilityZoneID
 }
 
 // GetNewMetadataProvider returns a MetadataProvider on which can be invoked getMetadata() to extract the metadata.

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -40,6 +40,7 @@ const (
 type Driver struct {
 	endpoint                 string
 	nodeID                   string
+	availabilityZoneID       string
 	srv                      *grpc.Server
 	mounter                  Mounter
 	efsWatchdog              Watchdog
@@ -67,6 +68,7 @@ func NewDriver(endpoint, efsUtilsCfgPath, efsUtilsStaticFilesPath, tags string, 
 	return &Driver{
 		endpoint:                 endpoint,
 		nodeID:                   cloud.GetMetadata().GetInstanceID(),
+		availabilityZoneID:       cloud.GetMetadata().GetAvailabilityZoneID(),
 		mounter:                  newNodeMounter(),
 		efsWatchdog:              watchdog,
 		cloud:                    cloud,

--- a/pkg/driver/mocks/mock_cloud.go
+++ b/pkg/driver/mocks/mock_cloud.go
@@ -219,10 +219,10 @@ func (mr *MockCloudMockRecorder) DescribeFileSystem(ctx, fileSystemId interface{
 }
 
 // DescribeMountTargets mocks base method.
-func (m *MockCloud) DescribeMountTargets(ctx context.Context, fileSystemId, az string) (*cloud.MountTarget, error) {
+func (m *MockCloud) DescribeMountTargets(ctx context.Context, fileSystemId, az string) ([]*cloud.MountTarget, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeMountTargets", ctx, fileSystemId, az)
-	ret0, _ := ret[0].(*cloud.MountTarget)
+	ret0, _ := ret[0].([]*cloud.MountTarget)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
New feature

**What is this PR about? / Why do we need it?**
Currently, cross-account mounts with dynamic provisioning and without DNS setup, only support mounting a single availability zone, either by providing a specific AZ or by not specifying any and receiving a random one. The AZ multi parameter returns a map of availability zone IDs with their respective mount target IPs to the PV. When combined with the node CSI driver querying the EC2 instance metadata endpoint for its own availability zone, allows it to automatically selects the mount target IP for a pod in the same availability zone.
When used with a multi-AZ EKS deployment, this reduces cross-AZ traffic costs and increases resilience. This does not disrupt the current logic.

**What testing is done?** 
Unit tests have been updated, the logic has been verified on a cluster and EFS file system each in their own VPC and account attached to a transit gateway.
