### PR TITLE
fix mounting volumes with FIPS enabled

### DIFF
--- a/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
+++ b/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
@@ -93,6 +93,8 @@ spec:
             {{- if .Values.useFIPS }}
             - name: AWS_USE_FIPS_ENDPOINT
               value: "true"
+            - name: FIPS_ENABLED
+              value: "true"
             {{- end }}
             - name: PORT_RANGE_UPPER_BOUND
               value: "{{ .Values.portRangeUpperBound }}"

--- a/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
+++ b/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
@@ -91,6 +91,8 @@ spec:
             {{- if .Values.useFIPS }}
             - name: AWS_USE_FIPS_ENDPOINT
               value: "true"
+            - name: FIPS_ENABLED
+              value: "true"
             {{- end }}
             - name: PORT_RANGE_UPPER_BOUND
               value: "{{ .Values.portRangeUpperBound }}"

--- a/docs/README.md
+++ b/docs/README.md
@@ -254,7 +254,7 @@ This procedure requires Helm V3 or later. To install or upgrade Helm, see [Using
 
    To force the Amazon EFS CSI driver to use FIPS for mounting the file system, add the following argument.
    ```sh
-   --set useFips=true
+   --set useFIPS=true
    ```
 **Note**  
 `hostNetwork: true` (should be added under spec/deployment on kubernetes installations where AWS metadata is not reachable from pod network. To fix the following error `NoCredentialProviders: no valid providers in chain` this parameter should be added.)


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

Bug

**What is this PR about? / Why do we need it?**

The documentation suggests setting `useFIPS: true` is sufficient to ensure mounts are made using FIPS crypto, but it is not.

Using EKS cluster addons, passing the `useFIPS` configuration does nothing but ensure AWS API calls are bould by FIPS.

**What testing is done?** 

Working on it. Floating to get feedback.