### PR TITLE
Fix deprecated kustomization fields

### DIFF
--- a/deploy/kubernetes/overlays/dev/kustomization.yaml
+++ b/deploy/kubernetes/overlays/dev/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-bases:
+resources:
 - ../../base
-patchesStrategicMerge:
-- master_image.yaml
+patches:
+- path: master_image.yaml

--- a/deploy/kubernetes/overlays/stable/ecr/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/ecr/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-bases:
+resources:
   - ../../../base
 images:
   - name: public.ecr.aws/efs-csi-driver/amazon/aws-efs-csi-driver

--- a/deploy/kubernetes/overlays/stable/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-bases:
+resources:
   - ../../base
 images:
   - name: public.ecr.aws/efs-csi-driver/amazon/aws-efs-csi-driver


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

Chore.

**What is this PR about? / Why do we need it?**

Fix deprecated kustomization fields.

- Replace `bases` with `resources` as the former was deprecated since kustomize v2.1.0.
- Replace `patchesStrategicMerge` with `patches` as the former was deprecated since kustomize v5.0.0.

**What testing is done?**

I ensured that the `kustomize build` command generates the same manifests as before.

```bash
$ kustomize version
v5.6.0

$ diff <(kustomize build https://github.com/kubernetes-sigs/aws-efs-csi-driver/deploy/kubernetes/base) <(kustomize build https://github.com/shibataka000/aws-efs-csi-driver/deploy/kubernetes/base?ref=fix-deprecated-kustomization-fields)

$ diff <(kustomize build https://github.com/kubernetes-sigs/aws-efs-csi-driver/deploy/kubernetes/overlays/stable) <(kustomize build https://github.com/shibataka000/aws-efs-csi-driver/deploy/kubernetes/overlays/stable?ref=fix-deprecated-kustomization-fields)
# Warning: 'bases' is deprecated. Please use 'resources' instead. Run 'kustomize edit fix' to update your Kustomization automatically.

$ diff <(kustomize build https://github.com/kubernetes-sigs/aws-efs-csi-driver/deploy/kubernetes/overlays/stable/ecr) <(kustomize build https://github.com/shibataka000/aws-efs-csi-driver/deploy/kubernetes/overlays/stable/ecr?ref=fix-deprecated-kustomization-fields)
# Warning: 'bases' is deprecated. Please use 'resources' instead. Run 'kustomize edit fix' to update your Kustomization automatically.

$ diff <(kustomize build https://github.com/kubernetes-sigs/aws-efs-csi-driver/deploy/kubernetes/overlays/dev) <(kustomize build https://github.com/shibataka000/aws-efs-csi-driver/deploy/kubernetes/overlays/dev?ref=fix-deprecated-kustomization-fields)
# Warning: 'bases' is deprecated. Please use 'resources' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
# Warning: 'patchesStrategicMerge' is deprecated. Please use 'patches' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
```
