### PR TITLE
openssl version mismatch fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,6 @@ COPY --from=rpm-provider /tmp/rpms/* /tmp/download/
 # cd, ls, cat, vim, tcpdump, are for debugging
 RUN clean_install amazon-efs-utils true && \
     clean_install crypto-policies true && \
-    clean_install "openssl-3.0.8 openssl-libs-3.0.8" true && \
     install_binary \
         /usr/bin/cat \
         /usr/bin/cd \
@@ -76,6 +75,7 @@ RUN clean_install amazon-efs-utils true && \
         /usr/bin/mount \
         /usr/bin/umount \
         /sbin/mount.nfs4 \
+        /usr/bin/openssl \
         /usr/bin/sed \
         /usr/bin/stat \
         /usr/bin/stunnel \

--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ test-e2e:
 .PHONY: test-e2e-external-eks
 test-e2e-external-eks:
 	CLUSTER_TYPE=eksctl \
-	K8S_VERSION="1.25" \
+	K8S_VERSION="1.27" \
 	DRIVER_NAME=aws-efs-csi-driver \
 	HELM_VALUES_FILE="./hack/values_eksctl.yaml" \
 	CONTAINER_NAME=efs-plugin \


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
bug fix
https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/1635

**What is this PR about? / Why do we need it?**
remove the pinned openssl image `openssl-3.0.8 openssl-libs-3.0.8`

**What testing is done?** 
Deployed to personal cluster and checked that installation and pod creation worked successfully.
