### PR TITLE
Update helm install FIPS docs capitalization to FIPS

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -254,7 +254,7 @@ This procedure requires Helm V3 or later. To install or upgrade Helm, see [Using
 
    To force the Amazon EFS CSI driver to use FIPS for mounting the file system, add the following argument.
    ```sh
-   --set useFips=true
+   --set useFIPS=true
    ```
 **Note**  
 `hostNetwork: true` (should be added under spec/deployment on kubernetes installations where AWS metadata is not reachable from pod network. To fix the following error `NoCredentialProviders: no valid providers in chain` this parameter should be added.)


### PR DESCRIPTION
Update documentation for helm install to reflect proper capitalization. 

The Helm values are case-sensitive, and the value in `values.yaml` is defined as `useFIPS`. Using `useFips` (lowercase) doesn't match the template condition `{{- if .Values.useFIPS }}`, resulting in FIPS mode not being enabled correctly.

Using this setting sets the `AWS_USE_FIPS_ENDPOINT` which is read by efs-utils for determining FIPS mode
 https://github.com/kubernetes-sigs/aws-efs-csi-driver/blob/master/charts/aws-efs-csi-driver/templates/node-daemonset.yaml#L92 
https://github.com/aws/efs-utils/blob/master/src/mount_efs/__init__.py#L3474-L3478