### PR TITLE
Fix annotation indentation in storageClass template

### DIFF
--- a/charts/aws-efs-csi-driver/templates/storageclass.yaml
+++ b/charts/aws-efs-csi-driver/templates/storageclass.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ .name }}
   {{- with .annotations }}
   annotations:
-  {{ toYaml . | indent 4 }}
+  {{- toYaml . | nindent 4 }}
   {{- end }}
 provisioner: efs.csi.aws.com
 {{- with .mountOptions }}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
bug

**What is this PR about? / Why do we need it?**
Current implementation of annotations on storageClass template only allows for a single annotation before resulting in a parsing error.

**What testing is done?** 
Example values with multiple annotations
```
storageClasses:
- name: efs-sc
  annotations:
    storageclass.kubernetes.io/is-default-class: "true"
    annotation2: foo
  mountOptions:
  - tls
  parameters:
    provisioningMode: efs-ap
    fileSystemId: fs-1122aabb
    directoryPerms: "700"
    gidRangeStart: "1000"
    gidRangeEnd: "2000"
    basePath: "/dynamic_provisioning"
    subPathPattern: "/subPath"
    ensureUniqueDirectory: true
  reclaimPolicy: Delete
  volumeBindingMode: Immediate
```
Resulting error before change:
`Error: YAML parse error on aws-efs-csi-driver/templates/storageclass.yaml: error converting YAML to JSON: yaml: line 6: did not find expected key`

Debug output (note indentation issue on annotations):
```
---
# Source: aws-efs-csi-driver/templates/storageclass.yaml
kind: StorageClass
apiVersion: storage.k8s.io/v1
metadata:
  name: efs-sc
  annotations:
      annotation2: foo
    storageclass.kubernetes.io/is-default-class: "true"
provisioner: efs.csi.aws.com
mountOptions:
- tls
parameters:
  basePath: /dynamic_provisioning
  directoryPerms: "700"
  ensureUniqueDirectory: true
  fileSystemId: fs-1122aabb
  gidRangeEnd: "2000"
  gidRangeStart: "1000"
  provisioningMode: efs-ap
  subPathPattern: /subPath
reclaimPolicy: Delete
volumeBindingMode: Immediate
```
With change in this PR, annotations work as expected:
```
---
# Source: aws-efs-csi-driver/templates/storageclass.yaml
kind: StorageClass
apiVersion: storage.k8s.io/v1
metadata:
  name: efs-sc
  annotations:
    annotation2: foo
    storageclass.kubernetes.io/is-default-class: "true"
provisioner: efs.csi.aws.com
mountOptions:
- tls
parameters:
  basePath: /dynamic_provisioning
  directoryPerms: "700"
  ensureUniqueDirectory: true
  fileSystemId: fs-1122aabb
  gidRangeEnd: "2000"
  gidRangeStart: "1000"
  provisioningMode: efs-ap
  subPathPattern: /subPath
reclaimPolicy: Delete
volumeBindingMode: Immediate
```