### PR TITLE
Update encryptInTransit examples

### DIFF
--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -223,8 +223,6 @@ storageClasses: []
 #   annotations:
 #     # Use that annotation if you want this to your default storageclass
 #     storageclass.kubernetes.io/is-default-class: "true"
-#   mountOptions:
-#   - tls
 #   parameters:
 #     provisioningMode: efs-ap
 #     fileSystemId: fs-1122aabb

--- a/examples/kubernetes/access_points/README.md
+++ b/examples/kubernetes/access_points/README.md
@@ -84,7 +84,6 @@ Also you can verify that data is written into the EFS filesystems:
 ```
 spec:
   mountOptions:
-    - tls
     - accesspoint=fsap-068c22f0246419f75
 ```
 as this could subject you to

--- a/examples/kubernetes/cross_account_mount/README.md
+++ b/examples/kubernetes/cross_account_mount/README.md
@@ -11,8 +11,6 @@ apiVersion: storage.k8s.io/v1
 metadata:
   name: efs-sc
 provisioner: efs.csi.aws.com
-mountOptions:
-  - tls
 parameters:
   provisioningMode: efs-ap
   fileSystemId: fs-1234abcd

--- a/examples/kubernetes/encryption_in_transit/specs/storageclass.yaml
+++ b/examples/kubernetes/encryption_in_transit/specs/storageclass.yaml
@@ -3,5 +3,3 @@ apiVersion: storage.k8s.io/v1
 metadata:
   name: efs-sc
 provisioner: efs.csi.aws.com
-mountOptions:
-  - tls

--- a/examples/kubernetes/volume_path/specs/example.yaml
+++ b/examples/kubernetes/volume_path/specs/example.yaml
@@ -16,8 +16,6 @@ spec:
     - ReadWriteMany
   persistentVolumeReclaimPolicy: Retain
   storageClassName: efs-sc
-  mountOptions:
-    - tls
   csi:
     driver: efs.csi.aws.com
     volumeHandle: fs-e8a95a42:/dir1
@@ -46,8 +44,6 @@ spec:
     - ReadWriteMany
   persistentVolumeReclaimPolicy: Retain
   storageClassName: efs-sc
-  mountOptions:
-    - tls
   csi:
     driver: efs.csi.aws.com
     volumeHandle: fs-e8a95a42:/dir2


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
- Doc enhancement

**What is this PR about? / Why do we need it?**
- The `tls` under mountOptions is deprecated with this driver since tls is enabled by default(https://github.com/kubernetes-sigs/aws-efs-csi-driver/pull/205).  Remove the deprecated `tls` mountOption from example use cases.

