### PR TITLE
Fix spelling errors and modernize deprecated io/ioutil usage

### DIFF
--- a/pkg/driver/efs_watch_dog.go
+++ b/pkg/driver/efs_watch_dog.go
@@ -16,7 +16,6 @@ package driver
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -224,7 +223,6 @@ func (w *execWatchdog) setup(efsClientSource string) error {
 }
 
 /*
-*
 At image build time, static files installed by efs-utils in the config directory, i.e. CAs file, need
 to be saved in another place so that the other stateful files created at runtime, i.e. private key for
 client certificate, in the same config directory can be persisted to host with a host path volume.
@@ -240,7 +238,7 @@ func copyWithoutOverwriting(srcDir, dstDir string) error {
 		return err
 	}
 
-	entries, err := ioutil.ReadDir(srcDir)
+	entries, err := os.ReadDir(srcDir)
 	if err != nil {
 		return err
 	}
@@ -360,7 +358,7 @@ the newer stunnel binaries will fail to run as this option is no longer supporte
 To avoid any errors, we check for this config and remove it directly on startup.
 */
 func (w *execWatchdog) removeLibwrapOption(stateDir string) error {
-	stunnelFiles, err := ioutil.ReadDir(stateDir)
+	stunnelFiles, err := os.ReadDir(stateDir)
 	if err != nil {
 		return fmt.Errorf("error reading directory %s: %v", efsStateDir, err)
 	}
@@ -369,7 +367,7 @@ func (w *execWatchdog) removeLibwrapOption(stateDir string) error {
 		if strings.HasPrefix(file.Name(), "stunnel-config.") {
 			filePath := filepath.Join(stateDir, file.Name())
 			if err := removeLibwrapFromFile(filePath); err != nil {
-				klog.Warningf("Error proccessing stunnel file %s: %v", filePath, err)
+				klog.Warningf("Error processing stunnel file %s: %v", filePath, err)
 			}
 		}
 	}

--- a/pkg/driver/efs_watch_dog_test.go
+++ b/pkg/driver/efs_watch_dog_test.go
@@ -14,7 +14,6 @@ limitations under the License.
 package driver
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -151,7 +150,7 @@ func TestExecWatchdog(t *testing.T) {
 }
 
 func createTempDir(t *testing.T) string {
-	name, err := ioutil.TempDir("", "")
+	name, err := os.MkdirTemp("", "")
 	checkError(t, err)
 	return name
 }
@@ -259,7 +258,7 @@ func TestSetupWithAdditionalDirectoryInStaticFilesDirectory(t *testing.T) {
 	staticFileDirName := createTempDir(t)
 	defer os.RemoveAll(staticFileDirName)
 
-	_, err := ioutil.TempDir(staticFileDirName, "")
+	_, err := os.MkdirTemp(staticFileDirName, "")
 	checkError(t, err)
 
 	w := newExecWatchdog(configDirName, staticFileDirName, "sleep", "300").(*execWatchdog)
@@ -270,7 +269,7 @@ func TestSetupWithAdditionalDirectoryInStaticFilesDirectory(t *testing.T) {
 }
 
 func TestRemoveLibwrapOption(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "test-stunnel-configs")
+	tempDir, err := os.MkdirTemp("", "test-stunnel-configs")
 	if err != nil {
 		t.Fatalf("Failed to create temp dir: %v", err)
 	}
@@ -285,7 +284,7 @@ connect = fs-123.efs.us-west-2.amazonaws.com:2049
 libwrap = no
 `)
 	testFilePath := filepath.Join(tempDir, "stunnel-config.test")
-	if err := ioutil.WriteFile(testFilePath, testConfig, 0644); err != nil {
+	if err := os.WriteFile(testFilePath, testConfig, 0644); err != nil {
 		t.Fatalf("Failed to write test config: %v", err)
 	}
 
@@ -295,7 +294,7 @@ libwrap = no
 		t.Fatalf("removeLibwrapOption failed: %v", err)
 	}
 
-	content, err := ioutil.ReadFile(testFilePath)
+	content, err := os.ReadFile(testFilePath)
 	if err != nil {
 		t.Fatalf("Failed to read updated config: %v", err)
 	}
@@ -306,7 +305,7 @@ libwrap = no
 }
 
 func verifyFileContent(t *testing.T, fileName string, expectedFileContent string) {
-	fileContent, err := ioutil.ReadFile(fileName)
+	fileContent, err := os.ReadFile(fileName)
 	if err != nil {
 		t.Fatalf("Failed to read file %v, %v", fileName, err)
 	}
@@ -317,7 +316,7 @@ func verifyFileContent(t *testing.T, fileName string, expectedFileContent string
 }
 
 func verifyConfigFile(t *testing.T, configFilePath string) {
-	configFileContent, err := ioutil.ReadFile(configFilePath)
+	configFileContent, err := os.ReadFile(configFilePath)
 	checkError(t, err)
 	actualConfig := string(configFileContent)
 	if actualConfig != expectedEfsUtilsConfig {

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -526,7 +526,7 @@ func removeNotReadyTaint(k8sClient cloud.KubernetesAPIClient) error {
 	return nil
 }
 
-// remove taint may failed, this keep retring until succeed, make sure the taint will eventually being removed
+// remove taint may fail, this keeps retrying until it succeeds, make sure the taint will eventually be removed
 func tryRemoveNotReadyTaintUntilSucceed(interval time.Duration, removeFn func() error) {
 	for {
 		err := removeFn()

--- a/pkg/driver/reaper.go
+++ b/pkg/driver/reaper.go
@@ -18,7 +18,6 @@ package driver
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/signal"
 	"strings"
@@ -88,7 +87,7 @@ func waitIfZombieStunnel(p ps.Process) bool {
 	if !strings.Contains(p.Executable(), "stunnel") && !strings.Contains(p.Executable(), "efs-proxy") {
 		return false
 	}
-	data, err := ioutil.ReadFile(fmt.Sprintf("/proc/%v/status", p.Pid()))
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%v/status", p.Pid()))
 	if err != nil {
 		klog.Warningf("reaper: failed to read process %v's status: %v", p, err)
 		return false


### PR DESCRIPTION
Is this a bug fix or adding new feature?

Bug fix - modernizes deprecated code and fixes spelling errors.

What is this PR about? / Why do we need it?

Replace deprecated io/ioutil functions with modern os package equivalents for Go 1.16+ compatibility
Fix spelling errors: "retring" → "retrying" and "proccessing" → "processing"
What testing is done?

All existing tests pass (go test ). No functional changes - only modernizing deprecated APIs and fixing typos.

Closes #1673