### PR TITLE
Add maxInflightMountCalls arg with default value based on memory limits

### DIFF
--- a/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
+++ b/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
@@ -86,6 +86,11 @@ spec:
           env:
             - name: CSI_ENDPOINT
               value: unix:/csi/csi.sock
+            - name: CSI_NODE_MEMORY_LIMIT
+              valueFrom:
+                resourceFieldRef:
+                  containerName: efs-plugin
+                  resource: limits.memory
             - name: CSI_NODE_NAME
               valueFrom:
                 fieldRef:

--- a/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
+++ b/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
@@ -81,6 +81,8 @@ spec:
             - --vol-metrics-opt-in={{ hasKey .Values.node "volMetricsOptIn" | ternary .Values.node.volMetricsOptIn false }}
             - --vol-metrics-refresh-period={{ hasKey .Values.node "volMetricsRefreshPeriod" | ternary .Values.node.volMetricsRefreshPeriod 240 }}
             - --vol-metrics-fs-rate-limit={{ hasKey .Values.node "volMetricsFsRateLimit" | ternary .Values.node.volMetricsFsRateLimit 5 }}
+            - --max-inflight-mount-calls-opt-in={{ hasKey .Values.node "maxInflightMountCallsOptIn" | ternary .Values.node.maxInflightMountCallsOptIn false }}
+            - --max-inflight-mount-calls={{ hasKey .Values.node "maxInflightMountCalls" | ternary .Values.node.maxInflightMountCalls 100 }}
           env:
             - name: CSI_ENDPOINT
               value: unix:/csi/csi.sock

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -31,18 +31,20 @@ const etcAmazonEfs = "/etc/amazon/efs"
 
 func main() {
 	var (
-		endpoint                 = flag.String("endpoint", "unix://tmp/csi.sock", "CSI Endpoint")
-		version                  = flag.Bool("version", false, "Print the version and exit")
-		efsUtilsCfgDirPath       = flag.String("efs-utils-config-dir-path", "/var/amazon/efs", "The preferred path for the efs-utils config directory. efs-utils-config-legacy-dir-path will be used if it is not empty, otherwise efs-utils-config-dir-path will be used.")
-		efsUtilsCfgLegacyDirPath = flag.String("efs-utils-config-legacy-dir-path", "/etc/amazon/efs-legacy", "The path to the legacy efs-utils config directory mounted from the host path /etc/amazon/efs")
-		efsUtilsStaticFilesPath  = flag.String("efs-utils-static-files-path", "/etc/amazon/efs-static-files/", "The path to efs-utils static files directory")
-		volMetricsOptIn          = flag.Bool("vol-metrics-opt-in", false, "Opt in to emit volume metrics")
-		volMetricsRefreshPeriod  = flag.Float64("vol-metrics-refresh-period", 240, "Refresh period for volume metrics in minutes")
-		volMetricsFsRateLimit    = flag.Int("vol-metrics-fs-rate-limit", 5, "Volume metrics routines rate limiter per file system")
-		deleteAccessPointRootDir = flag.Bool("delete-access-point-root-dir", false,
+		endpoint                   = flag.String("endpoint", "unix://tmp/csi.sock", "CSI Endpoint")
+		version                    = flag.Bool("version", false, "Print the version and exit")
+		efsUtilsCfgDirPath         = flag.String("efs-utils-config-dir-path", "/var/amazon/efs", "The preferred path for the efs-utils config directory. efs-utils-config-legacy-dir-path will be used if it is not empty, otherwise efs-utils-config-dir-path will be used.")
+		efsUtilsCfgLegacyDirPath   = flag.String("efs-utils-config-legacy-dir-path", "/etc/amazon/efs-legacy", "The path to the legacy efs-utils config directory mounted from the host path /etc/amazon/efs")
+		efsUtilsStaticFilesPath    = flag.String("efs-utils-static-files-path", "/etc/amazon/efs-static-files/", "The path to efs-utils static files directory")
+		volMetricsOptIn            = flag.Bool("vol-metrics-opt-in", false, "Opt in to emit volume metrics")
+		volMetricsRefreshPeriod    = flag.Float64("vol-metrics-refresh-period", 240, "Refresh period for volume metrics in minutes")
+		volMetricsFsRateLimit      = flag.Int("vol-metrics-fs-rate-limit", 5, "Volume metrics routines rate limiter per file system")
+		deleteAccessPointRootDir   = flag.Bool("delete-access-point-root-dir", false,
 			"Opt in to delete access point root directory by DeleteVolume. By default, DeleteVolume will delete the access point behind Persistent Volume and deleting access point will not delete the access point root directory or its contents.")
-		adaptiveRetryMode = flag.Bool("adaptive-retry-mode", true, "Opt out to use standard sdk retry configuration. By default, adaptive retry mode will be used to more heavily client side rate limit EFS API requests.")
-		tags              = flag.String("tags", "", "Space separated key:value pairs which will be added as tags for EFS resources. For example, 'environment:prod region:us-east-1'")
+		adaptiveRetryMode          = flag.Bool("adaptive-retry-mode", true, "Opt out to use standard sdk retry configuration. By default, adaptive retry mode will be used to more heavily client side rate limit EFS API requests.")
+		tags                       = flag.String("tags", "", "Space separated key:value pairs which will be added as tags for EFS resources. For example, 'environment:prod region:us-east-1'")
+		maxInflightMountCallsOptIn = flag.Bool("max-inflight-mount-calls-opt-in", false, "Opt in to use max inflight mount calls limit.")
+		maxInflightMountCalls      = flag.Int64("max-inflight-mount-calls", driver.UnsetMaxInflightMountCounts, "New NodePublishVolume operation will be blocked if maximum number of inflight calls is reached. If it is not specified or set to negative value, the check will be disabled (i.e. no limit).")
 	)
 	klog.InitFlags(nil)
 	flag.Parse()
@@ -61,7 +63,7 @@ func main() {
 	if err != nil {
 		klog.Fatalln(err)
 	}
-	drv := driver.NewDriver(*endpoint, etcAmazonEfs, *efsUtilsStaticFilesPath, *tags, *volMetricsOptIn, *volMetricsRefreshPeriod, *volMetricsFsRateLimit, *deleteAccessPointRootDir, *adaptiveRetryMode)
+	drv := driver.NewDriver(*endpoint, etcAmazonEfs, *efsUtilsStaticFilesPath, *tags, *volMetricsOptIn, *volMetricsRefreshPeriod, *volMetricsFsRateLimit, *deleteAccessPointRootDir, *adaptiveRetryMode, *maxInflightMountCallsOptIn, *maxInflightMountCalls)
 	if err := drv.Run(); err != nil {
 		klog.Fatalln(err)
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -44,7 +44,7 @@ func main() {
 		adaptiveRetryMode          = flag.Bool("adaptive-retry-mode", true, "Opt out to use standard sdk retry configuration. By default, adaptive retry mode will be used to more heavily client side rate limit EFS API requests.")
 		tags                       = flag.String("tags", "", "Space separated key:value pairs which will be added as tags for EFS resources. For example, 'environment:prod region:us-east-1'")
 		maxInflightMountCallsOptIn = flag.Bool("max-inflight-mount-calls-opt-in", false, "Opt in to use max inflight mount calls limit.")
-		maxInflightMountCalls      = flag.Int64("max-inflight-mount-calls", driver.UnsetMaxInflightMountCounts, "New NodePublishVolume operation will be blocked if maximum number of inflight calls is reached. If it is not specified or set to negative value, the check will be disabled (i.e. no limit).")
+		maxInflightMountCalls      = flag.Int64("max-inflight-mount-calls", driver.UnsetMaxInflightMountCounts, "New NodePublishVolume operation will be blocked if maximum number of inflight calls is reached. If maxInflightMountCallsOptIn is true but maxInflightMountCalls is not specified or set to negative value, it will be calculated based on memory limit. If failing to fetch the memory limit, the check will be disabled (i.e. no limit).")
 	)
 	klog.InitFlags(nil)
 	flag.Parse()

--- a/deploy/kubernetes/base/node-daemonset.yaml
+++ b/deploy/kubernetes/base/node-daemonset.yaml
@@ -57,6 +57,8 @@ spec:
             - --vol-metrics-opt-in=false
             - --vol-metrics-refresh-period=240
             - --vol-metrics-fs-rate-limit=5
+            - --max-inflight-mount-calls-opt-in=false
+            - --max-inflight-mount-calls=100
           env:
             - name: CSI_ENDPOINT
               value: unix:/csi/csi.sock

--- a/deploy/kubernetes/base/node-daemonset.yaml
+++ b/deploy/kubernetes/base/node-daemonset.yaml
@@ -62,6 +62,11 @@ spec:
           env:
             - name: CSI_ENDPOINT
               value: unix:/csi/csi.sock
+            - name: CSI_NODE_MEMORY_LIMIT
+              valueFrom:
+                resourceFieldRef:
+                  containerName: efs-plugin
+                  resource: limits.memory
             - name: CSI_NODE_NAME
               valueFrom:
                 fieldRef:

--- a/docs/README.md
+++ b/docs/README.md
@@ -353,6 +353,8 @@ After deploying the driver, you can continue to these sections:
 | vol-metrics-opt-in          |        | false   | true     | Opt in to emit volume metrics.                                                                                                                                                                                                          |
 | vol-metrics-refresh-period  |        | 240     | true     | Refresh period for volume metrics in minutes.                                                                                                                                                                                           |
 | vol-metrics-fs-rate-limit   |        | 5       | true     | Volume metrics routines rate limiter per file system.                                                                                                                                                                                   |
+| max-inflight-mount-calls-opt-in                         |       | false        | true     | Opt in to use max inflight mount calls limit |
+| max-inflight-mount-calls                         |       | -1        | true     | New NodePublishVolume call will be blocked if maximum number of inflight calls is reached. If it is set to negative value, it will be calculated based on memory limit. If failing to fetch the memory limit, the check will be disabled (i.e. no limit). |
 
 
 

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -33,8 +33,11 @@ const (
 	driverName = "efs.csi.aws.com"
 
 	// AgentNotReadyTaintKey contains the key of taints to be removed on driver startup
-	AgentNotReadyNodeTaintKey   = "efs.csi.aws.com/agent-not-ready"
+	AgentNotReadyNodeTaintKey = "efs.csi.aws.com/agent-not-ready"
 	UnsetMaxInflightMountCounts = -1
+
+	bytesInMiB = 1024 * 1024
+	memoryCostPerMount = 30 * bytesInMiB
 )
 
 type Driver struct {

--- a/pkg/driver/inflight_checker.go
+++ b/pkg/driver/inflight_checker.go
@@ -1,0 +1,46 @@
+package driver
+
+import (
+	"sync"
+
+	"k8s.io/klog/v2"
+)
+
+type InFlightChecker struct {
+	mux      sync.Mutex
+	count    int64
+	maxCount int64
+}
+
+func NewInFlightChecker(maxCount int64) *InFlightChecker {
+	if maxCount < 0 {
+		klog.V(4).InfoS("InFlightChecker is disabled")
+		return nil
+	}
+	return &InFlightChecker{
+		maxCount: maxCount,
+	}
+}
+
+func (checker *InFlightChecker) increment() bool {
+	checker.mux.Lock()
+	defer checker.mux.Unlock()
+
+	if checker.count >= checker.maxCount {
+		return false
+	}
+
+	checker.count++
+	return true
+}
+
+func (checker *InFlightChecker) decrement() {
+	checker.mux.Lock()
+	defer checker.mux.Unlock()
+	if checker.count == 0 {
+		klog.Error("InFlightChecker: trying to decrement count when it is already 0")
+		return
+	}
+
+	checker.count--
+}

--- a/pkg/driver/inflight_checker_test.go
+++ b/pkg/driver/inflight_checker_test.go
@@ -1,0 +1,84 @@
+package driver
+
+import (
+	"sync"
+	"testing"
+)
+
+func assertEqual[T comparable](t *testing.T, actual, expected T, description string) {
+	if expected != actual {
+		t.Errorf("%s: expected %v != actual %v", description, expected, actual)
+	}
+}
+
+func TestNewInFlightChecker(t *testing.T) {
+	checker := NewInFlightChecker(5)
+	assertEqual(t, checker.maxCount, 5, "Max inflight count")
+	assertEqual(t, checker.count, 0, "Inflight count")
+
+	checker = NewInFlightChecker(UnsetMaxInflightMountCounts)
+	assertEqual(t, checker, nil, "Nil checker for negative max inflight mount counts")
+}
+
+func TestIncrement(t *testing.T) {
+	maxFlightCount := int64(2)
+	checker := NewInFlightChecker(maxFlightCount)
+
+	if !checker.increment() {
+		t.Errorf("First increment should succeed with max inflight count=%d", maxFlightCount)
+	}
+	assertEqual(t, checker.count, 1, "Inflight count after first increment")
+
+	if !checker.increment() {
+		t.Errorf("Second increment should succeed with max inflight count=%d", maxFlightCount)
+	}
+	assertEqual(t, checker.count, 2, "Inflight count after second increment")
+
+	if checker.increment() {
+		t.Errorf("Third increment should fail with max inflight count=%d", maxFlightCount)
+	}
+	assertEqual(t, checker.count, 2, "Inflight count after third increment")
+}
+
+func TestDecrement(t *testing.T) {
+	maxFlightCount := int64(2)
+	checker := NewInFlightChecker(maxFlightCount)
+	checker.increment()
+	checker.increment()
+
+	checker.decrement()
+	assertEqual(t, checker.count, 1, "Inflight count after first decrement")
+
+	checker.decrement()
+	assertEqual(t, checker.count, 0, "Inflight count after second decrement")
+
+	// Should not decrement further when the count is already zero
+	checker.decrement()
+	assertEqual(t, checker.count, 0, "Inflight count after decrement when count is already zero")
+}
+
+func TestConcurrency(t *testing.T) {
+	maxFlightCount := int64(500)
+	checker := NewInFlightChecker(maxFlightCount)
+	var wg sync.WaitGroup
+
+	numGoRoutinesForIncrement := 400
+	for range numGoRoutinesForIncrement {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			checker.increment()
+		}()
+	}
+
+	numGoRoutinesForDecrement := 350
+	for range numGoRoutinesForDecrement {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			checker.decrement()
+		}()
+	}
+	wg.Wait()
+	assertEqual(t, checker.count, int64(numGoRoutinesForIncrement-numGoRoutinesForDecrement), "inflight count")
+}

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -47,6 +47,10 @@ var (
 	supportedFSTypes = []string{"efs", ""}
 )
 
+const (
+	maxInflightMountCallsReached = "The number of concurrent mount calls is %v, which has reached the limit"
+)
+
 func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRequest) (*csi.NodeStageVolumeResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "")
 }
@@ -75,6 +79,17 @@ func (d *Driver) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolu
 
 	if volCap.GetMount() == nil {
 		return nil, status.Error(codes.InvalidArgument, "Volume capability access type must be mount")
+	}
+
+	if d.inFlightChecker != nil {
+		if ok := d.inFlightChecker.increment(); !ok {
+			return nil, status.Errorf(codes.Aborted, maxInflightMountCallsReached, d.inFlightChecker.maxCount)
+		}
+
+		defer func() {
+			klog.V(4).Infof("NodePublishVolume: volume operation finished for volumeId: %s with %d inflight count before decrementing", req.GetVolumeId(), d.inFlightChecker.count)
+			d.inFlightChecker.decrement()
+		}()
 	}
 
 	// TODO when CreateVolume is implemented, it must use the same key names
@@ -537,4 +552,11 @@ func tryRemoveNotReadyTaintUntilSucceed(interval time.Duration, removeFn func() 
 		klog.ErrorS(err, "Unexpected failure when attempting to remove node taint(s)")
 		time.Sleep(interval)
 	}
+}
+
+func calculateMaxInflightMountCalls(maxInflightMountCallsOptIn bool, maxInflightMountCalls int64) int64 {
+	if !maxInflightMountCallsOptIn {
+		return UnsetMaxInflightMountCounts
+	}
+	return maxInflightMountCalls
 }

--- a/pkg/driver/sanity_test.go
+++ b/pkg/driver/sanity_test.go
@@ -81,6 +81,7 @@ func TestSanityEFSCSI(t *testing.T) {
 		volStatter:      NewVolStatter(),
 		gidAllocator:    NewGidAllocator(),
 		lockManager:     NewLockManagerMap(),
+		inFlightChecker: NewInFlightChecker(UnsetMaxInflightMountCounts),
 	}
 	defer func() {
 		if r := recover(); r != nil {


### PR DESCRIPTION
By default, maxInflightMountCalls will be math.MaxUint64 which will not have limits on concurrent mount calls.

**Is this a bug fix or adding new feature?**
Adding new feature

**What is this PR about? / Why do we need it?**
 Add new `max-inflight-mount-calls` arg to prevent OOM error due to too many concurrent mounting calls

**What testing is done?**
Unit tests are added. Also deployed csi driver manually and tested it using my local cluster.
