### PR TITLE
feat: Allow setting allowVolumeExpansion to SC in helm chart

### DIFF
--- a/charts/aws-efs-csi-driver/templates/storageclass.yaml
+++ b/charts/aws-efs-csi-driver/templates/storageclass.yaml
@@ -8,6 +8,9 @@ metadata:
   {{ toYaml . | indent 4 }}
   {{- end }}
 provisioner: efs.csi.aws.com
+{{- with .allowVolumeExpansion }}
+allowVolumeExpansion: {{ . }}
+{{- end }}
 {{- with .mountOptions }}
 mountOptions:
 {{ toYaml . }}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
New feature

**What is this PR about? / Why do we need it?**
Allows the `allowVolumeExpansion` key to be added to storage classes managed by the aws-efs-csi-driver helm chart

**What testing is done?** 
- Verified helm template rendered correctly using [example StorageClass](https://github.com/kubernetes-sigs/aws-efs-csi-driver/blob/f82d0dfb61811677c44f6701212ef3adf88feb3f/charts/aws-efs-csi-driver/values.yaml#L221-L238) found in current values file.
- Added `allowVolumeExpansion: true` to current example and verified helm template rendered correctly.