### PR TITLE
Add SA option for automounting tokens

### DIFF
--- a/charts/aws-efs-csi-driver/templates/controller-serviceaccount.yaml
+++ b/charts/aws-efs-csi-driver/templates/controller-serviceaccount.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.controller.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: {{ .Values.controller.serviceAccount.automountServiceAccountToken }}
 metadata:
   name: {{ .Values.controller.serviceAccount.name }}
   namespace: {{ .Release.Namespace }}

--- a/charts/aws-efs-csi-driver/templates/node-serviceaccount.yaml
+++ b/charts/aws-efs-csi-driver/templates/node-serviceaccount.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.node.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: {{ .Values.node.serviceAccount.automountServiceAccountToken }}
 metadata:
   name: {{ .Values.node.serviceAccount.name }}
   namespace: {{ .Release.Namespace }}

--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -100,6 +100,8 @@ controller:
   # Specifies whether a service account should be created
   serviceAccount:
     create: true
+    # Automount API credentials for a Service Account.
+    automountServiceAccountToken: true
     name: efs-csi-controller-sa
     annotations: {}
     ## Enable if EKS IAM for SA is used
@@ -200,6 +202,8 @@ node:
   # Specifies whether a service account should be created
   serviceAccount:
     create: true
+    # Automount API credentials for a Service Account.
+    automountServiceAccountToken: true
     name: efs-csi-node-sa
     annotations: {}
     ## Enable if EKS IAM for SA is used


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Fix and quality of life imptovement (backport from aws-loadbalancer-controller helmchart)

**What is this PR about? / Why do we need it?**
Since modern k8s releases do not automount tokens one wishing to use IRSA must also create dedicated serviceaccounts outside of this helmchart. Considering the fact that values.yaml has hints covering irsa annotations lack of this parameter makes whole thing more than incoherent.

**What testing is done?** 
- template rendered and sa objects compared with sa generated by the aws loadbalancer controller and object definitions