### PR TITLE
Add maxInflightMountCalls and volumeAttachLimit args

### DIFF
--- a/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
+++ b/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
@@ -81,6 +81,10 @@ spec:
             - --vol-metrics-opt-in={{ hasKey .Values.node "volMetricsOptIn" | ternary .Values.node.volMetricsOptIn false }}
             - --vol-metrics-refresh-period={{ hasKey .Values.node "volMetricsRefreshPeriod" | ternary .Values.node.volMetricsRefreshPeriod 240 }}
             - --vol-metrics-fs-rate-limit={{ hasKey .Values.node "volMetricsFsRateLimit" | ternary .Values.node.volMetricsFsRateLimit 5 }}
+            - --max-inflight-mount-calls-opt-in={{ hasKey .Values.node "maxInflightMountCallsOptIn" | ternary .Values.node.maxInflightMountCallsOptIn false }}
+            - --max-inflight-mount-calls={{ hasKey .Values.node "maxInflightMountCalls" | ternary .Values.node.maxInflightMountCalls 10 }}
+            - --volume-attach-limit-opt-in={{ hasKey .Values.node "volumeAttachLimitOptIn" | ternary .Values.node.volumeAttachLimitOptIn false }}
+            - --volume-attach-limit={{ hasKey .Values.node "volumeAttachLimit" | ternary .Values.node.volumeAttachLimit 20 }}
           env:
             - name: CSI_ENDPOINT
               value: unix:/csi/csi.sock

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -41,8 +41,12 @@ func main() {
 		volMetricsFsRateLimit    = flag.Int("vol-metrics-fs-rate-limit", 5, "Volume metrics routines rate limiter per file system")
 		deleteAccessPointRootDir = flag.Bool("delete-access-point-root-dir", false,
 			"Opt in to delete access point root directory by DeleteVolume. By default, DeleteVolume will delete the access point behind Persistent Volume and deleting access point will not delete the access point root directory or its contents.")
-		adaptiveRetryMode = flag.Bool("adaptive-retry-mode", true, "Opt out to use standard sdk retry configuration. By default, adaptive retry mode will be used to more heavily client side rate limit EFS API requests.")
-		tags              = flag.String("tags", "", "Space separated key:value pairs which will be added as tags for EFS resources. For example, 'environment:prod region:us-east-1'")
+		adaptiveRetryMode          = flag.Bool("adaptive-retry-mode", true, "Opt out to use standard sdk retry configuration. By default, adaptive retry mode will be used to more heavily client side rate limit EFS API requests.")
+		tags                       = flag.String("tags", "", "Space separated key:value pairs which will be added as tags for EFS resources. For example, 'environment:prod region:us-east-1'")
+		maxInflightMountCallsOptIn = flag.Bool("max-inflight-mount-calls-opt-in", false, "Opt in to use max inflight mount calls limit.")
+		maxInflightMountCalls      = flag.Int64("max-inflight-mount-calls", driver.UnsetMaxInflightMountCounts, "New NodePublishVolume operation will be blocked if maximum number of inflight calls is reached. If maxInflightMountCallsOptIn is true, it has to be set to a positive value.")
+		volumeAttachLimitOptIn     = flag.Bool("volume-attach-limit-opt-in", false, "Opt in to use volume attach limit.")
+		volumeAttachLimit          = flag.Int64("volume-attach-limit", driver.UnsetVolumeAttachLimit, "Maximum number of volumes that can be attached to a node. If volumeAttachLimitOptIn is true, it has to be set to a positive value.")
 	)
 	klog.InitFlags(nil)
 	flag.Parse()
@@ -61,7 +65,7 @@ func main() {
 	if err != nil {
 		klog.Fatalln(err)
 	}
-	drv := driver.NewDriver(*endpoint, etcAmazonEfs, *efsUtilsStaticFilesPath, *tags, *volMetricsOptIn, *volMetricsRefreshPeriod, *volMetricsFsRateLimit, *deleteAccessPointRootDir, *adaptiveRetryMode)
+	drv := driver.NewDriver(*endpoint, etcAmazonEfs, *efsUtilsStaticFilesPath, *tags, *volMetricsOptIn, *volMetricsRefreshPeriod, *volMetricsFsRateLimit, *deleteAccessPointRootDir, *adaptiveRetryMode, *maxInflightMountCallsOptIn, *maxInflightMountCalls, *volumeAttachLimitOptIn, *volumeAttachLimit)
 	if err := drv.Run(); err != nil {
 		klog.Fatalln(err)
 	}

--- a/deploy/kubernetes/base/node-daemonset.yaml
+++ b/deploy/kubernetes/base/node-daemonset.yaml
@@ -57,6 +57,10 @@ spec:
             - --vol-metrics-opt-in=false
             - --vol-metrics-refresh-period=240
             - --vol-metrics-fs-rate-limit=5
+            - --max-inflight-mount-calls-opt-in=false
+            - --max-inflight-mount-calls=10
+            - --volume-attach-limit-opt-in=false
+            - --volume-attach-limit=20
           env:
             - name: CSI_ENDPOINT
               value: unix:/csi/csi.sock

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -33,7 +33,9 @@ const (
 	driverName = "efs.csi.aws.com"
 
 	// AgentNotReadyTaintKey contains the key of taints to be removed on driver startup
-	AgentNotReadyNodeTaintKey = "efs.csi.aws.com/agent-not-ready"
+	AgentNotReadyNodeTaintKey   = "efs.csi.aws.com/agent-not-ready"
+	UnsetMaxInflightMountCounts = -1
+	UnsetVolumeAttachLimit      = -1
 )
 
 type Driver struct {
@@ -53,9 +55,11 @@ type Driver struct {
 	adaptiveRetryMode        bool
 	tags                     map[string]string
 	lockManager              LockManagerMap
+	inFlightMountTracker     *InFlightMountTracker
+	volumeAttachLimit        int64
 }
 
-func NewDriver(endpoint, efsUtilsCfgPath, efsUtilsStaticFilesPath, tags string, volMetricsOptIn bool, volMetricsRefreshPeriod float64, volMetricsFsRateLimit int, deleteAccessPointRootDir bool, adaptiveRetryMode bool) *Driver {
+func NewDriver(endpoint, efsUtilsCfgPath, efsUtilsStaticFilesPath, tags string, volMetricsOptIn bool, volMetricsRefreshPeriod float64, volMetricsFsRateLimit int, deleteAccessPointRootDir bool, adaptiveRetryMode bool, maxInflightMountCallsOptIn bool, maxInflightMountCalls int64, volumeAttachLimitOptIn bool, volumeAttachLimit int64) *Driver {
 	cloud, err := cloud.NewCloud(adaptiveRetryMode)
 	if err != nil {
 		klog.Fatalln(err)
@@ -79,6 +83,8 @@ func NewDriver(endpoint, efsUtilsCfgPath, efsUtilsStaticFilesPath, tags string, 
 		adaptiveRetryMode:        adaptiveRetryMode,
 		tags:                     parseTagsFromStr(strings.TrimSpace(tags)),
 		lockManager:              NewLockManagerMap(),
+		inFlightMountTracker:     NewInFlightMountTracker(getMaxInflightMountCalls(maxInflightMountCallsOptIn, maxInflightMountCalls)),
+		volumeAttachLimit:        getVolumeAttachLimit(volumeAttachLimitOptIn, volumeAttachLimit),
 	}
 }
 

--- a/pkg/driver/inflight_mount_tracker.go
+++ b/pkg/driver/inflight_mount_tracker.go
@@ -1,0 +1,47 @@
+package driver
+
+import (
+	"sync"
+
+	"k8s.io/klog/v2"
+)
+
+type InFlightMountTracker struct {
+	mux      sync.Mutex
+	count    int64
+	maxCount int64
+}
+
+func NewInFlightMountTracker(maxCount int64) *InFlightMountTracker {
+	if maxCount <= 0 {
+		klog.V(4).InfoS("InFlightMountTracker is disabled")
+		return nil
+	}
+	return &InFlightMountTracker{
+		maxCount: maxCount,
+	}
+}
+
+func (checker *InFlightMountTracker) increment() bool {
+	checker.mux.Lock()
+	defer checker.mux.Unlock()
+
+	if checker.count >= checker.maxCount {
+		return false
+	}
+
+	checker.count++
+	return true
+}
+
+func (checker *InFlightMountTracker) decrement() bool {
+	checker.mux.Lock()
+	defer checker.mux.Unlock()
+	if checker.count == 0 {
+		klog.Error("InFlightMountTracker: trying to decrement count when it is already 0")
+		return false
+	}
+
+	checker.count--
+	return true
+}

--- a/pkg/driver/inflight_mount_tracker_test.go
+++ b/pkg/driver/inflight_mount_tracker_test.go
@@ -1,0 +1,97 @@
+package driver
+
+import (
+	"sync"
+	"testing"
+)
+
+func assertEqual[T comparable](t *testing.T, actual, expected T, description string) {
+	if expected != actual {
+		t.Errorf("%s: expected %v != actual %v", description, expected, actual)
+	}
+}
+
+func TestNewInFlightMountTracker(t *testing.T) {
+	checker := NewInFlightMountTracker(5)
+	assertEqual(t, checker.maxCount, 5, "Max inflight count")
+	assertEqual(t, checker.count, 0, "Inflight count")
+
+	checker = NewInFlightMountTracker(UnsetMaxInflightMountCounts)
+	assertEqual(t, checker, nil, "Nil checker for negative max inflight mount counts")
+
+	checker = NewInFlightMountTracker(0)
+	assertEqual(t, checker, nil, "Nil checker for zero max inflight mount counts")
+}
+
+func TestIncrement(t *testing.T) {
+	maxFlightCount := int64(2)
+	checker := NewInFlightMountTracker(maxFlightCount)
+
+	if !checker.increment() {
+		t.Errorf("First increment should succeed with max inflight count=%d", maxFlightCount)
+	}
+	assertEqual(t, checker.count, 1, "Inflight count after first increment")
+
+	if !checker.increment() {
+		t.Errorf("Second increment should succeed with max inflight count=%d", maxFlightCount)
+	}
+	assertEqual(t, checker.count, 2, "Inflight count after second increment")
+
+	if checker.increment() {
+		t.Errorf("Third increment should fail with max inflight count=%d", maxFlightCount)
+	}
+	assertEqual(t, checker.count, 2, "Inflight count after third increment")
+}
+
+func TestDecrement(t *testing.T) {
+	maxFlightCount := int64(2)
+	checker := NewInFlightMountTracker(maxFlightCount)
+	checker.increment()
+	checker.increment()
+
+	checker.decrement()
+	assertEqual(t, checker.count, 1, "Inflight count after first decrement")
+
+	checker.decrement()
+	assertEqual(t, checker.count, 0, "Inflight count after second decrement")
+
+	// Should not decrement further when the count is already zero
+	checker.decrement()
+	assertEqual(t, checker.count, 0, "Inflight count after decrement when count is already zero")
+}
+
+func TestConcurrency(t *testing.T) {
+	// Run multiple iterations to increase chance of catching race conditions
+	for i := 0; i < 100; i++ {
+		maxFlightCount := int64(500)
+		checker := NewInFlightMountTracker(maxFlightCount)
+		var wg sync.WaitGroup
+		var mu sync.Mutex
+
+		numGoRoutinesForIncrement := 400
+		for range numGoRoutinesForIncrement {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				checker.increment()
+			}()
+		}
+
+		numGoRoutinesForDecrement := 350
+		actualDecrements := 0
+		for range numGoRoutinesForDecrement {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				if checker.decrement() {
+					mu.Lock()
+					actualDecrements++
+					mu.Unlock()
+				}
+			}()
+		}
+
+		wg.Wait()
+		assertEqual(t, checker.count, int64(numGoRoutinesForIncrement-actualDecrements), "inflight count")
+	}
+}

--- a/pkg/driver/sanity_test.go
+++ b/pkg/driver/sanity_test.go
@@ -71,16 +71,17 @@ func TestSanityEFSCSI(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	mockCloud := cloud.NewFakeCloudProvider()
 	drv := Driver{
-		endpoint:        endpoint,
-		nodeID:          "sanity",
-		mounter:         NewFakeMounter(),
-		efsWatchdog:     &mockWatchdog{},
-		cloud:           mockCloud,
-		nodeCaps:        nodeCaps,
-		volMetricsOptIn: true,
-		volStatter:      NewVolStatter(),
-		gidAllocator:    NewGidAllocator(),
-		lockManager:     NewLockManagerMap(),
+		endpoint:             endpoint,
+		nodeID:               "sanity",
+		mounter:              NewFakeMounter(),
+		efsWatchdog:          &mockWatchdog{},
+		cloud:                mockCloud,
+		nodeCaps:             nodeCaps,
+		volMetricsOptIn:      true,
+		volStatter:           NewVolStatter(),
+		gidAllocator:         NewGidAllocator(),
+		lockManager:          NewLockManagerMap(),
+		inFlightMountTracker: NewInFlightMountTracker(UnsetMaxInflightMountCounts),
 	}
 	defer func() {
 		if r := recover(); r != nil {


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Adding new feature.

**What is this PR about? / Why do we need it?**
Add maxInflightMountCalls and volumeAttachLimit args. We need them to prevent OOM killed issue for efs-plugin container since it takes 30MiB for mounting operation and 12MiB for each EFS volume due to efs-proxy process.

**What testing is done?** 
- Unit tests
- e2e test
- Manually deploy csi driver with this change locally to verify OOM issue can be solved with `maxInflightMountCalls` and `volumeAttachLimit` being set