### PR TITLE
Set PosixUser.Uid correctly in ListAccessPoints

### DIFF
--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -327,7 +327,7 @@ func (c *cloud) ListAccessPoints(ctx context.Context, fileSystemId string) (acce
 		if accessPointDescription.PosixUser != nil {
 			posixUser = &PosixUser{
 				Gid: *accessPointDescription.PosixUser.Gid,
-				Uid: *accessPointDescription.PosixUser.Gid,
+				Uid: *accessPointDescription.PosixUser.Uid,
 			}
 		} else {
 			posixUser = nil

--- a/pkg/cloud/cloud_test.go
+++ b/pkg/cloud/cloud_test.go
@@ -670,7 +670,7 @@ func TestListAccessPoints(t *testing.T) {
 		fsId                = "fs-abcd1234"
 		accessPointId       = "ap-abc123"
 		Gid           int64 = 1000
-		Uid           int64 = 1000
+		Uid           int64 = 2000
 	)
 	testCases := []struct {
 		name     string
@@ -710,6 +710,17 @@ func TestListAccessPoints(t *testing.T) {
 
 				if len(res) != 1 {
 					t.Fatalf("Expected only one AccessPoint in response but got: %v", res)
+				}
+
+				// Verify PosixUser fields are correctly mapped
+				if res[0].PosixUser == nil {
+					t.Fatal("PosixUser should not be nil")
+				}
+				if res[0].PosixUser.Gid != Gid {
+					t.Fatalf("Gid mismatched. Expected: %v, Actual: %v", Gid, res[0].PosixUser.Gid)
+				}
+				if res[0].PosixUser.Uid != Uid {
+					t.Fatalf("Uid mismatched. Expected: %v, Actual: %v", Uid, res[0].PosixUser.Uid)
 				}
 
 				mockctl.Finish()


### PR DESCRIPTION
**Is this a bug fix or adding new feature?** Bug fix

**What is this PR about? / Why do we need it?** `ListAccessPoints` method incorrectly sets `Uid` to be `Gid`. This should not break anything as Uid is not actually used anywhere.

**What testing is done?** Added unit test
