### PR TITLE
Change stop watchdog log to verbose info

### DIFF
--- a/pkg/driver/efs_watch_dog.go
+++ b/pkg/driver/efs_watch_dog.go
@@ -322,7 +322,7 @@ func (w *execWatchdog) runLoop(stopCh <-chan struct{}) {
 	for {
 		select {
 		case <-stopCh:
-			klog.Info("stopping...")
+			klog.V(4).Infof("stopping...")
 			break
 		default:
 			err := w.exec()


### PR DESCRIPTION
When running test, stopping log for watchdog spams the test log, let's make it verbose level 4 so that it won't show during test.

**Is this a bug fix or adding new feature?**
Minor change

**What is this PR about? / Why do we need it?**
 the watchdog `stopping...` log makes it difficult to read the test log, let's make it `klog.V(4).Info` so that it won't be printed out during test

**What testing is done?** 
N/A