### PR TITLE
Support whitespace in tag keys and values

### DIFF
--- a/pkg/driver/controller_test.go
+++ b/pkg/driver/controller_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
+	"reflect"
 	"regexp"
 	"strconv"
 	"sync"
@@ -800,7 +801,7 @@ func TestCreateVolume(t *testing.T) {
 				}
 
 				if driver.tags["cluster"] != "efs" || driver.tags["tag2:name2"] != "tag2:val2" {
-					t.Fatalf("Incorrect tags")
+					t.Fatalf("Incorrect tags %v", driver.tags)
 				}
 
 				req := &csi.CreateVolumeRequest{
@@ -860,7 +861,7 @@ func TestCreateVolume(t *testing.T) {
 					cloud:        mockCloud,
 					gidAllocator: NewGidAllocator(),
 					lockManager:  NewLockManagerMap(),
-					tags:         parseTagsFromStr("cluster-efs"),
+					tags:         parseTagsFromStr("cluster-efs:value1:value2"),
 				}
 
 				req := &csi.CreateVolumeRequest{
@@ -4607,6 +4608,90 @@ func TestControllerGetCapabilities(t *testing.T) {
 	_, err := driver.ControllerGetCapabilities(ctx, &csi.ControllerGetCapabilitiesRequest{})
 	if err != nil {
 		t.Fatalf("ControllerGetCapabilities failed: %v", err)
+	}
+}
+
+func TestTaggingCapabilitites(t *testing.T) {
+	testCases := []struct {
+		name     string
+		testFunc func(t *testing.T)
+	}{
+		{
+			name: "Success: complex split key value colon with backslash",
+			testFunc: func(t *testing.T) {
+				given := "aa\\:bb cc\\\\dd:ee\\:ff gg\\\\hh"
+				expected := []string{"aa:bb cc\\dd", "ee:ff gg\\hh"}
+				result := splitToList(given, byte(':'))
+				if !reflect.DeepEqual(result, expected) {
+					t.Fatalf("Incorrect tags: %v vs. %v", result, expected)
+				}
+			},
+		},
+		{
+			name: "Success: complex split key only colon with backslash",
+			testFunc: func(t *testing.T) {
+				given := "aa\\:bb cc\\\\dd\\\\"
+				expected := []string{"aa:bb cc\\dd\\"}
+				result := splitToList(given, byte(':'))
+				if !reflect.DeepEqual(result, expected) {
+					t.Fatalf("Incorrect tags: %v vs. %v", result, expected)
+				}
+			},
+		},
+		{
+			name: "Success: simple split whitespace",
+			testFunc: func(t *testing.T) {
+				given := "aa:bb cc:dd ee:ff"
+				expected := []string{"aa:bb", "cc:dd", "ee:ff"}
+				result := splitToList(given, byte(' '))
+				if !reflect.DeepEqual(result, expected) {
+					t.Fatalf("Incorrect tags: %v vs. %v", result, expected)
+				}
+			},
+		},
+		{
+			name: "Success: simple single tag",
+			testFunc: func(t *testing.T) {
+				expected := map[string]string{"happy": "case"}
+				result := parseTagsFromStr("happy:case")
+				if !reflect.DeepEqual(result, expected) {
+					t.Fatalf("Incorrect tags: %v vs. %v", result, expected)
+				}
+			},
+		},
+		{
+			name: "Success: simple multiple tags",
+			testFunc: func(t *testing.T) {
+				expected := map[string]string{"firstkey": "firstvalue", "secondkey": "secondvalue"}
+				result := parseTagsFromStr("firstkey:firstvalue secondkey:secondvalue")
+				if !reflect.DeepEqual(result, expected) {
+					t.Fatalf("Incorrect tags: %v vs. %v", result, expected)
+				}
+			},
+		},
+		{
+			name: "Success: complex key escaping",
+			testFunc: func(t *testing.T) {
+				expected := map[string]string{"first:key": "first value", "second key": "second:value"}
+				result := parseTagsFromStr("first\\:key:first\\ value second\\ key:second\\:value")
+				if !reflect.DeepEqual(result, expected) {
+					t.Fatalf("Incorrect tags: %v vs. %v", result, expected)
+				}
+			},
+		},
+		{
+			name: "Success: complex key escaping maintain backslash",
+			testFunc: func(t *testing.T) {
+				expected := map[string]string{"first:key": "first\\value", "second key": "second:value"}
+				result := parseTagsFromStr("first\\:key:first\\\\value second\\ key:second\\:value")
+				if !reflect.DeepEqual(result, expected) {
+					t.Fatalf("Incorrect tags: %v vs. %v", result, expected)
+				}
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, tc.testFunc)
 	}
 }
 

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -147,6 +147,50 @@ func (d *Driver) Run() error {
 	return d.srv.Serve(listener)
 }
 
+func splitToList(tagsStr string, splitter byte) []string {
+	defer func() {
+		if r := recover(); r != nil {
+			klog.Errorf("Failed to parse input string: %v", tagsStr)
+		}
+	}()
+
+	l := []string{}
+	if tagsStr == "" {
+		klog.Infof("Did not find any input tags.")
+		return l
+	}
+	var tagBuilder strings.Builder
+	var jump_to_index int = 0
+	for index, runeValue := range tagsStr {
+		if jump_to_index > index {
+			continue
+		}
+		jump_to_index++
+		if byte(runeValue) == splitter {
+			l = append(l, tagBuilder.String())
+			tagBuilder.Reset()
+			continue
+		}
+
+		// Handle escape character
+		if runeValue == '\\' && tagsStr[index+1] == byte('\\') {
+			tagBuilder.WriteRune('\\')
+			jump_to_index++
+			continue
+		}
+
+		if runeValue == '\\' && tagsStr[index+1] == splitter {
+			tagBuilder.WriteByte(splitter)
+			jump_to_index++
+			continue
+		}
+
+		tagBuilder.WriteRune(runeValue)
+	}
+	l = append(l, tagBuilder.String())
+	return l
+}
+
 func parseTagsFromStr(tagStr string) map[string]string {
 	defer func() {
 		if r := recover(); r != nil {
@@ -154,37 +198,22 @@ func parseTagsFromStr(tagStr string) map[string]string {
 		}
 	}()
 
-	m := make(map[string]string)
+	m := map[string]string{}
 	if tagStr == "" {
 		klog.Infof("Did not find any input tags.")
 		return m
 	}
-	tagsSplit := strings.Split(tagStr, " ")
+	tagsSplit := splitToList(tagStr, byte(' '))
 	for _, currTag := range tagsSplit {
-		var nameBuilder strings.Builder
-		var valBuilder strings.Builder
-		var currBuilder *strings.Builder = &nameBuilder
-
-		for i := 0; i < len(currTag); i++ {
-			if currTag[i] == ':' {
-				if currBuilder == &valBuilder {
-					break
-				} else {
-					currBuilder = &valBuilder
-					continue
-				}
-			}
-
-			// Handle escape character
-			if currTag[i] == byte('\\') && currTag[i+1] == byte(':') {
-				currBuilder.WriteRune(':')
-				i++ // Skip an extra character
-				continue
-			}
-
-			currBuilder.WriteByte(currTag[i])
+		var tagList = splitToList(currTag, byte(':'))
+		switch len(tagList) {
+		case 1:
+			m[tagList[0]] = ""
+		case 2:
+			m[tagList[0]] = tagList[1]
+		default:
+			klog.Errorf("Failed to parse input tag: %v", tagList)
 		}
-		m[nameBuilder.String()] = valBuilder.String()
 	}
 	return m
 }


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

This PR adds a feature.

**What is this PR about? / Why do we need it?**

The current EFS Driver implementation does not support whitespace in tagging keys and values while the EFS API itself does support that. 

The proposed implementation adds escaping support for the whitespace, allowing to configure the tags accordingly so the Driver implementation can handle it and causes fancy potentially undesirable tag values being written in case this is not known. 

I chose to implement this via escape sequence. Namely a backslash as this was chosen recently via PR #1693 

Existing behavior is mainly kept. The only difference I propose to implement is that empty tag values are supported. Before the changes this raised an error, after the changes a missing colon separator leads to an empty value. 

**What testing is done?** 

Additional unit tests have been added. 
