### PR TITLE
feat: Add ability to configure emptyDir params (sizeLimit, medium)

### DIFF
--- a/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
+++ b/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
@@ -180,7 +180,11 @@ spec:
           {{- end }}
       volumes:
         - name: socket-dir
+          {{- if .Values.controller.socketDirVolume }}
+          {{- toYaml .Values.controller.socketDirVolume | nindent 10 }}
+          {{- else }}
           emptyDir: {}
+          {{- end }}
         {{- with .Values.controller.volumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -97,6 +97,8 @@ controller:
   env: []
   volumes: []
   volumeMounts: []
+  socketDirVolume:
+    emptyDir: {}
   # Specifies whether a service account should be created
   serviceAccount:
     create: true


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

It adds a new feature

**What is this PR about? / Why do we need it?**

We use both the EBS and the EFS CSI drivers. The EBS driver offers this capability already:
- https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/1840
- https://github.com/kubernetes-sigs/aws-ebs-csi-driver/commit/3cc74df677e6ae7ac4a0c105b58cba7edb191b8f#diff-38890fc178a6bb362418969605e8650e75296dedaf1eef29dc3b21400ff36676L220

**What testing is done?** 

```bash
$ helm template aws-efs-csi-driver .
(..)
          securityContext:
            allowPrivilegeEscalation: false
            readOnlyRootFilesystem: true
      volumes:
        - name: socket-dir
          emptyDir: {}     # <-- see here
---
# Source: aws-efs-csi-driver/templates/csidriver.yaml
apiVersion: storage.k8s.io/v1
(..)
```

And with customized emptyDir:

```bash
$ helm template aws-efs-csi-driver . --set controller.socketDirVolume.emptyDir.sizeLimit=100Mi
(..)
          securityContext:
            allowPrivilegeEscalation: false
            readOnlyRootFilesystem: true
      volumes:
        - name: socket-dir
          emptyDir:           # <-- see here
            sizeLimit: 100Mi  # 
---
# Source: aws-efs-csi-driver/templates/csidriver.yaml
apiVersion: storage.k8s.io/v1
(..)
```