### PR TITLE
Add opt-in parameter to disable node mutation permissions

### DIFF
--- a/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
+++ b/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
@@ -96,6 +96,10 @@ spec:
             - name: AWS_USE_FIPS_ENDPOINT
               value: "true"
             {{- end }}
+            {{- if .Values.node.serviceAccount.disableMutation }}
+            - name: DISABLE_TAINT_WATCHER
+              value: "true"
+            {{- end }}
             - name: PORT_RANGE_UPPER_BOUND
               value: "{{ .Values.portRangeUpperBound }}"
             {{- with .Values.node.env }}

--- a/charts/aws-efs-csi-driver/templates/node-serviceaccount.yaml
+++ b/charts/aws-efs-csi-driver/templates/node-serviceaccount.yaml
@@ -21,7 +21,12 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["nodes"]
-    verbs: ["get", "list", "watch", "patch"]
+    verbs: ["get", "list", "watch"]
+  {{- if not .Values.node.serviceAccount.disableMutation }}
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["patch"]
+  {{- end }}
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -204,6 +204,10 @@ node:
     annotations: {}
     ## Enable if EKS IAM for SA is used
     #  eks.amazonaws.com/role-arn: arn:aws:iam::111122223333:role/efs-csi-role
+    # Disable mutating permissions for the node service account.
+    # When disableMutation is true, some features of the EFS CSI Driver node pods will not function, such as taint removal.
+    # Primarily useful in particularly security-sensitive environments, or on multi-tenant clusters that isolate tenants by node.
+    disableMutation: false
   healthPort: 9809
   # securityContext on the node pod
   securityContext:

--- a/deploy/kubernetes/base/node-serviceaccount.yaml
+++ b/deploy/kubernetes/base/node-serviceaccount.yaml
@@ -16,7 +16,10 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["nodes"]
-    verbs: ["get", "list", "watch", "patch"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["patch"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -488,6 +488,11 @@ type JSONPatch struct {
 // This taint can be optionally applied by users to prevent startup race conditions such as
 // https://github.com/kubernetes/kubernetes/issues/95911
 func removeNotReadyTaint(k8sClient cloud.KubernetesAPIClient) error {
+	if os.Getenv("DISABLE_TAINT_WATCHER") != "" {
+		klog.V(4).InfoS("DISABLE_TAINT_WATCHER set, skipping taint removal")
+		return nil
+	}
+
 	nodeName := os.Getenv("CSI_NODE_NAME")
 	if nodeName == "" {
 		klog.V(4).InfoS("CSI_NODE_NAME missing, skipping taint removal")


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
feauture

**What is this PR about? / Why do we need it?**

Adds a parameter node.serviceAccount.disableMutation to disable mutating permissions on the node SA. Also updates the node code to detect and gracefully handle this case rather than attempting and failing to patch the node.

**What testing is done?** 

```
helm template test-release . > /tmp/default.yaml
grep -A 15 "kind: ClusterRole" /tmp/default.yaml | grep "efs-csi-node-role"
apiVersion: rbac.authorization.k8s.io/v1
metadata:
  name: efs-csi-node-role
  labels:
    app.kubernetes.io/name: aws-efs-csi-driver
rules:
  - apiGroups: [""]
    resources: ["nodes"]
    verbs: ["get", "list", "watch"]
  - apiGroups: [""]
    resources: ["nodes"]
    verbs: ["patch"]


helm template test-release . --set node.serviceAccount.disableMutation=true > /tmp/secure.yaml
grep -A 15 "kind: ClusterRole" /tmp/secure.yaml | grep  "efs-csi-node-role"
apiVersion: rbac.authorization.k8s.io/v1
metadata:
  name: efs-csi-node-role
  labels:
    app.kubernetes.io/name: aws-efs-csi-driver
rules:
  - apiGroups: [""]
    resources: ["nodes"]
    verbs: ["get", "list", "watch"]
---
```
