### PR TITLE
Add ability to configure node container securityContext

### DIFF
--- a/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
+++ b/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
@@ -70,8 +70,10 @@ spec:
       {{- end }}
       containers:
         - name: efs-plugin
+          {{- with .Values.node.containerSecurityContext }}
           securityContext:
-            privileged: true
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           image: {{ printf "%s:%s" .Values.image.repository (default (printf "v%s" .Chart.AppVersion) (toString .Values.image.tag)) }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:

--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -219,6 +219,9 @@ node:
     runAsUser: 0
     runAsGroup: 0
     fsGroup: 0
+  # securityContext on the node container
+  containerSecurityContext:
+    privileged: true
   env: []
   volumes: []
   volumeMounts: []


### PR DESCRIPTION
Is this a bug fix or adding new feature?
Add ability to pass node container security contexts

What is this PR about? / Why do we need it?
Since modern k8s platforms comes with security webhooks that mutates container securityContexts if they are not passed explicitly.
the existing node daemonSet templates consists hardcoded value for container security

```
containers:
        - name: efs-plugin
          securityContext:
            privileged: true
```
This PR allowes users to pass the container security contexts via the values.yaml file.

What testing is done?

template rendered and could able to see the values being reflected in the rendred template 