### PR TITLE
Add revisionHistoryLimit support in charts

### DIFF
--- a/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
+++ b/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
@@ -12,6 +12,9 @@ metadata:
     {{- end }}
 spec:
   replicas: {{ .Values.controller.replicaCount }}
+  {{- if or (kindIs "float64" .Values.controller.revisionHistoryLimit) (kindIs "int64" .Values.controller.revisionHistoryLimit) }}
+  revisionHistoryLimit: {{ .Values.controller.revisionHistoryLimit }}
+  {{- end }}
   selector:
     matchLabels:
       app: {{ .Values.controller.name }}

--- a/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
+++ b/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
@@ -10,6 +10,9 @@ metadata:
     {{ toYaml . | nindent 4 }}
     {{- end }}
 spec:
+  {{- if or (kindIs "float64" .Values.node.revisionHistoryLimit) (kindIs "int64" .Values.node.revisionHistoryLimit) }}
+  revisionHistoryLimit: {{ .Values.node.revisionHistoryLimit }}
+  {{- end }}
   selector:
     matchLabels:
       app: efs-csi-node

--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -86,6 +86,7 @@ controller:
     # requests:
     #   cpu: 100m
     #   memory: 128Mi
+  revisionHistoryLimit: 10
   nodeSelector: {}
   updateStrategy: {}
   tolerations:
@@ -182,6 +183,7 @@ node:
     # requests:
     #   cpu: 100m
     #   memory: 128Mi
+  revisionHistoryLimit: 10
   nodeSelector: {}
   updateStrategy:
     {}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
new feature

**What is this PR about? / Why do we need it?**
Original PR: https://github.com/kubernetes-sigs/aws-efs-csi-driver/pull/1380
Would like to merge this small feature in for next release

**What testing is done?** 
```
helm template aws-efs-csi-driver . | grep revisionHistoryLimit
  revisionHistoryLimit: 10
  revisionHistoryLimit: 10
```

Similar to this [commit](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/commit/3cc74df677e6ae7ac4a0c105b58cba7edb191b8f#diff-d8e5a62ff0b157f20a21d31a249171c3f82c3217f13f93fedc3e05cd8f7a5186) in EBS