### PR TITLE
Upgrade golang to 1.25.5 to fix high CVE

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -156,4 +156,4 @@ replace k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.33.2
 
 go 1.25.0
 
-toolchain go1.25.3
+toolchain go1.25.5


### PR DESCRIPTION
There is a new CVEs related to go package. Upgrade it to 1.25.5 to fix them.

```
NAME          INSTALLED                FIXED IN              TYPE       VULNERABILITY       SEVERITY  EPSS          RISK
openssl       1:3.0.8-1.amzn2023.0.19  3.2.2-1.amzn2023.0.2  rpm        ALAS2023-2025-1225  Medium    < 0.1% (6th)  < 0.1
openssl-libs  1:3.0.8-1.amzn2023.0.19  3.2.2-1.amzn2023.0.2  rpm        ALAS2023-2025-1225  Medium    < 0.1% (6th)  < 0.1
stdlib        go1.25.3                 1.24.11, 1.25.5       go-module  CVE-2025-61729      High      < 0.1% (2nd)  < 0.1
stdlib        go1.25.3                 1.24.11, 1.25.5       go-module  CVE-2025-61727      Medium    < 0.1% (2nd)  < 0.1
```
