### PR TITLE
[POST-RELEASE v2.2.0] Fix release.yaml for auto tag

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,8 +18,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         
-      - name: Extract version and create tag
-        id: tag-version
+      - name: Extract version
+        id: extract-version
         run: |
           PR_TITLE="${{ github.event.pull_request.title }}"
           VERSION=$(echo "$PR_TITLE" | grep -oE '^\[POST-RELEASE v[0-9]+\.[0-9]+\.[0-9]+\]' | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+')
@@ -30,15 +30,12 @@ jobs:
           fi
           
           echo "Extracted VERSION: $VERSION"
-          
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           
-          git config user.name "$GITHUB_ACTOR"
-          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-          git tag $VERSION
-          git push origin $VERSION
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create and push tag
+        uses: rickstaa/action-create-tag@v1
+        with:
+          tag: ${{ steps.extract-version.outputs.version }}
           
       - name: Create Release
         id: create-release
@@ -46,8 +43,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ steps.tag-version.outputs.version }}
-          release_name: ${{ steps.tag-version.outputs.version }}
+          tag_name: ${{ steps.extract-version.outputs.version }}
+          release_name: ${{ steps.extract-version.outputs.version }}
           body: |
             AWS EFS CSI Driver
 


### PR DESCRIPTION
The release.yaml does not work properly due to authentication issue, let's use  rickstaa/action-create-tag which handles the authentication properly.

Tested in my personal repo:
https://github.com/DavidXU12345/aws-efs-csi-driver/actions/runs/20113761366/job/57717900092
