### PR TITLE
Update docs: Follow semver and support deploy using version tags

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -30,6 +30,11 @@ Since Amazon EFS is an elastic file system, it doesn't really enforce any file s
 For detailed parameter explanations, see the [parameters documentation](parameters.md).
 
 ## Releases
+The EFS CSI Driver follows semantic versioning. The version `MAJOR.MINOR.PATCH` will be bumped following the rules below after `v2.2.0`:
+- Significant breaking changes will be released as a `MAJOR` update.
+- New features will be released as a `MINOR` update.
+- Bug or vulnerability fixes will be released as a `PATCH` update.
+
 ### ECR Image
 | Driver Version | [ECR](https://gallery.ecr.aws/efs-csi-driver/amazon/aws-efs-csi-driver) Image |
 |----------------|-------------------------------------------------------------------------------|

--- a/docs/install.md
+++ b/docs/install.md
@@ -178,19 +178,25 @@ Starting with version 2.X.X, the EFS CSI driver incorporates efs-utils v2.X.X, w
 ### Upgrade to the latest version:
 If you want to update to latest released version:
 ```sh
-kubectl apply -k "github.com/kubernetes-sigs/aws-efs-csi-driver/deploy/kubernetes/overlays/stable/?ref=release-2.0"
+kubectl apply -k "github.com/kubernetes-sigs/aws-efs-csi-driver/deploy/kubernetes/overlays/stable/?ref=release-2.2"
 ```
 
 ### Upgrade to a specific version:
 If you want to update to a specific version, first customize the driver yaml file locally:
 ```sh
-kubectl kustomize "github.com/kubernetes-sigs/aws-efs-csi-driver/deploy/kubernetes/overlays/stable/?ref=release-2.0" > driver.yaml
+kubectl kustomize "github.com/kubernetes-sigs/aws-efs-csi-driver/deploy/kubernetes/overlays/stable/?ref=release-2.2" > driver.yaml
 ```
 
 Then, update all lines referencing `image: amazon/aws-efs-csi-driver` to the desired version (e.g., to `image: amazon/aws-efs-csi-driver:v2.2.0`) in the yaml file, and deploy driver yaml again:
 ```sh
 kubectl apply -f driver.yaml
 ```
+
+Or after `v2.2.0`, we support to deploy using specific version tag:
+```sh
+kubectl apply -k github.com/kubernetes-sigs/aws-efs-csi-driver/deploy/kubernetes/overlays/stable?ref=v2.2.0
+```
+
 -----
 # Uninstalling the Amazon EFS CSI Driver
 


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Docs update

**What is this PR about? / Why do we need it?**
After `v2.2.0`, we will follow semantic versioning and support deploy driver with version tags
