### PR TITLE
fix: verify startup taint removal after patch to prevent false positives

### DIFF
--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -551,10 +551,19 @@ func removeNotReadyTaint(k8sClient cloud.KubernetesAPIClient) error {
 		return err
 	}
 
-	_, err = clientset.CoreV1().Nodes().Patch(context.Background(), nodeName, k8stypes.JSONPatchType, patch, metav1.PatchOptions{})
+	patchedNode, err := clientset.CoreV1().Nodes().Patch(context.Background(), nodeName, k8stypes.JSONPatchType, patch, metav1.PatchOptions{})
 	if err != nil {
 		return err
 	}
+
+	// Verify taint was actually removed from the patched node
+	for _, taint := range patchedNode.Spec.Taints {
+		if taint.Key == AgentNotReadyNodeTaintKey {
+			klog.V(4).InfoS("Taint still present on node, will retry", "key", taint.Key, "effect", taint.Effect)
+			return fmt.Errorf("taint %s still present after patch", AgentNotReadyNodeTaintKey)
+		}
+	}
+
 	klog.InfoS("Removed taint(s) from local node", "node", nodeName)
 	return nil
 }

--- a/pkg/driver/node_test.go
+++ b/pkg/driver/node_test.go
@@ -976,9 +976,10 @@ func makeDir(path string) error {
 func TestRemoveNotReadyTaint(t *testing.T) {
 	nodeName := "test-node-123"
 	testCases := []struct {
-		name      string
-		setup     func(t *testing.T, mockCtl *gomock.Controller) func() (kubernetes.Interface, error)
-		expResult error
+		name       string
+		setup      func(t *testing.T, mockCtl *gomock.Controller) func() (kubernetes.Interface, error)
+		expResult  error
+		customTest func(t *testing.T, k8sClientGetter func() (kubernetes.Interface, error))
 	}{
 		{
 			name: "missing CSI_NODE_NAME",
@@ -1047,26 +1048,62 @@ func TestRemoveNotReadyTaint(t *testing.T) {
 			expResult: fmt.Errorf("Failed to patch node!"),
 		},
 		{
-			name: "success",
+			name: "successful taint removal",
 			setup: func(t *testing.T, mockCtl *gomock.Controller) func() (kubernetes.Interface, error) {
 				t.Setenv("CSI_NODE_NAME", nodeName)
-				getNodeMock, mockNode := getNodeMock(mockCtl, nodeName, &corev1.Node{
+
+				nodeWithTaint := &corev1.Node{
 					Spec: corev1.NodeSpec{
-						Taints: []corev1.Taint{
-							{
-								Key:    AgentNotReadyNodeTaintKey,
-								Effect: "NoSchedule",
-							},
-						},
+						Taints: []corev1.Taint{{Key: AgentNotReadyNodeTaintKey, Effect: "NoSchedule"}},
 					},
-				}, nil)
-				mockNode.EXPECT().Patch(gomock.Any(), gomock.Eq(nodeName), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
+				}
+				nodeWithoutTaint := &corev1.Node{
+					Spec: corev1.NodeSpec{Taints: []corev1.Taint{}},
+				}
+
+				mockClient := mocks.NewMockKubernetesClient(mockCtl)
+				mockCoreV1 := mocks.NewMockCoreV1Interface(mockCtl)
+				mockNode := mocks.NewMockNodeInterface(mockCtl)
+
+				mockClient.EXPECT().CoreV1().Return(mockCoreV1).MinTimes(1)
+				mockCoreV1.EXPECT().Nodes().Return(mockNode).MinTimes(1)
+
+				mockNode.EXPECT().Get(gomock.Any(), gomock.Eq(nodeName), gomock.Any()).Return(nodeWithTaint, nil)
+				mockNode.EXPECT().Patch(gomock.Any(), gomock.Eq(nodeName), gomock.Any(), gomock.Any(), gomock.Any()).Return(nodeWithoutTaint, nil)
 
 				return func() (kubernetes.Interface, error) {
-					return getNodeMock, nil
+					return mockClient, nil
 				}
 			},
 			expResult: nil,
+		},
+		{
+			name: "patch succeeds with no error but taint still present (verification fails)",
+			setup: func(t *testing.T, mockCtl *gomock.Controller) func() (kubernetes.Interface, error) {
+				t.Setenv("CSI_NODE_NAME", nodeName)
+
+				nodeWithTaint := &corev1.Node{
+					Spec: corev1.NodeSpec{
+						Taints: []corev1.Taint{{Key: AgentNotReadyNodeTaintKey, Effect: "NoSchedule"}},
+					},
+				}
+
+				mockClient := mocks.NewMockKubernetesClient(mockCtl)
+				mockCoreV1 := mocks.NewMockCoreV1Interface(mockCtl)
+				mockNode := mocks.NewMockNodeInterface(mockCtl)
+
+				mockClient.EXPECT().CoreV1().Return(mockCoreV1).MinTimes(1)
+				mockCoreV1.EXPECT().Nodes().Return(mockNode).MinTimes(1)
+
+				mockNode.EXPECT().Get(gomock.Any(), gomock.Eq(nodeName), gomock.Any()).Return(nodeWithTaint, nil)
+				mockNode.EXPECT().Patch(gomock.Any(), gomock.Eq(nodeName), gomock.Any(), gomock.Any(), gomock.Any()).Return(nodeWithTaint, nil)
+
+				return func() (kubernetes.Interface, error) {
+					return mockClient, nil
+				}
+			},
+			// expect verification to show failed startup taint removal
+			expResult: fmt.Errorf("taint %s still present after patch", AgentNotReadyNodeTaintKey),
 		},
 	}
 	for _, tc := range testCases {
@@ -1076,7 +1113,6 @@ func TestRemoveNotReadyTaint(t *testing.T) {
 
 			k8sClientGetter := tc.setup(t, mockCtl)
 			result := removeNotReadyTaint(k8sClientGetter)
-
 			if !reflect.DeepEqual(result, tc.expResult) {
 				t.Fatalf("Expected result `%v`, got result `%v`", tc.expResult, result)
 			}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Bug Fix

**What is this PR about? / Why do we need it?**
Adds verification to ensure startup taint removal succeeds. 

Previously, there were some false positives in the logs claiming the startup taint on nodes were removed. This change checks that if the startup taint persists, the existing retry mechanism is triggered. 

**What testing is done?** 
* Integration Testing
* Unit tests
