### PR TITLE
Add proper IAM policies for test-e2e-external-eks

### DIFF
--- a/hack/e2e/eksctl.sh
+++ b/hack/e2e/eksctl.sh
@@ -45,6 +45,8 @@ function eksctl_create_cluster() {
       eksctl_patch_cluster_file "$CLUSTER_FILE" "$EKSCTL_PATCH_FILE"
     fi
 
+    loudecho "Final cluster configuration:"
+    cat "$CLUSTER_FILE"
     loudecho "Creating cluster $CLUSTER_NAME with $CLUSTER_FILE"
     ${BIN} create cluster -f "${CLUSTER_FILE}" --kubeconfig "${KUBECONFIG}"
   fi

--- a/hack/eksctl-patch.yaml
+++ b/hack/eksctl-patch.yaml
@@ -7,8 +7,28 @@ iam:
         namespace: kube-system
       wellKnownPolicies:
         efsCSIController: true
+      attachPolicy:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action:
+              - "elasticfilesystem:DescribeMountTargets"
+              - "elasticfilesystem:ClientMount"
+              - "elasticfilesystem:ClientWrite"
+              - "ec2:DescribeAvailabilityZones"
+            Resource: "*"
     - metadata:
         name: efs-csi-controller-sa
         namespace: kube-system
       wellKnownPolicies:
         efsCSIController: true
+      attachPolicy:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action:
+              - "elasticfilesystem:DescribeMountTargets"
+              - "elasticfilesystem:ClientMount"
+              - "elasticfilesystem:ClientWrite"
+              - "ec2:DescribeAvailabilityZones"
+            Resource: "*"

--- a/hack/kops-patch.yaml
+++ b/hack/kops-patch.yaml
@@ -9,7 +9,6 @@ spec:
             "elasticfilesystem:DeleteAccessPoint",
             "elasticfilesystem:DescribeMountTargets",
             "ec2:DescribeAvailabilityZones",
-            "elasticfilesystem:DescribeMountTargets",
             "elasticfilesystem:DescribeAccessPoints",
             "elasticfilesystem:DescribeFileSystems",
             "elasticfilesystem:ClientMount",


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Bug Fix

**What is this PR about? / Why do we need it?**
Add proper IAM policies for test-e2e-external-eks (same policies as test-e2e using `kops-patch.yaml`). The more proper way is to add these policies in `eksctl` [here](https://github.com/eksctl-io/eksctl/blob/efcb7790f8a2393ca6ce95635d96c9ab25d6a2ac/pkg/cfn/builder/statement.go#L443). But as a quick fix, let's merge this PR first.

**What testing is done?**
All checks from k8s-ci-robot pass 

