### PR TITLE
feat: add slack notification for issues and PRs

### DIFF
--- a/.github/workflows/notify-slack.yaml
+++ b/.github/workflows/notify-slack.yaml
@@ -1,0 +1,65 @@
+name: Slack Notifications
+
+on:
+  issues:
+    types: [opened, reopened, edited]
+  issue_comment:
+    types: [created, edited]
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send issue notification to Slack
+        if: github.event_name == 'issues'
+        uses: slackapi/slack-github-action@v2.1.1
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "type": "issue_update",
+              "action": "${{ github.event.action }}",
+              "number": ${{ github.event.issue.number }},
+              "title": "${{ github.event.issue.title }}",
+              "url": "${{ github.event.issue.html_url }}",
+              "user": "${{ github.event.issue.user.login }}"
+            }
+
+      - name: Send pull request notification to Slack
+        if: github.event_name == 'pull_request_target'
+        uses: slackapi/slack-github-action@v2.1.1
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "type": "pr_update",
+              "action": "${{ github.event.action }}",
+              "number": ${{ github.event.pull_request.number }},
+              "title": "${{ github.event.pull_request.title }}",
+              "url": "${{ github.event.pull_request.html_url }}",
+              "user": "${{ github.event.pull_request.user.login }}"
+            }
+
+      - name: Send issue comments notification to Slack
+        if: github.event_name == 'issue_comment' && !github.event.issue.pull_request 
+        uses: slackapi/slack-github-action@v2.1.1
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "type": "issue_comment",
+              "action": "${{ github.event.action }}",
+              "number": ${{ github.event.issue.number }},
+              "title": "${{ github.event.issue.title }}",
+              "url": "${{ github.event.comment.html_url }}",
+              "body": "${{ github.event.comment.body }}",
+              "user": "${{ github.event.comment.user.login }}"
+            }


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
New feature

**What is this PR about? / Why do we need it?**
Add slack notification for open issue and PR updates.

**What testing is done?** 
Tested in my personal repo. In slack, it will show something like:

```
#PR-18
URL: https://github.com/DavidXU12345/aws-efs-csi-driver/pull/18
Action: reopened
Title: Add slack notification for issues and PRs
Author: DavidXU12345
```
