### PR TITLE
Fix the link to the kubernetes example about accessing a file system from multiple pods

### DIFF
--- a/examples/kubernetes/README.md
+++ b/examples/kubernetes/README.md
@@ -8,7 +8,7 @@ Before following the examples, you need to:
 * [Static provisioning](static_provisioning/README.md)
 * [Dynamic provisioning](dynamic_provisioning/README.md)
 * [Encryption in transit](encryption_in_transit/README.md)
-* [Accessing the file system from multiple pods](kubernetes/multiple_pods/README.md)
+* [Accessing the file system from multiple pods](multiple_pods/README.md)
 * [Consume Amazon EFS in StatefulSets](statefulset/README.md)
 * [Mount subpath](volume_path/README.md)
 * [Use Access Points](access_points/README.md)


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
bug fix

**What is this PR about? / Why do we need it?**
just fixes a broken link at https://github.com/kubernetes-sigs/aws-efs-csi-driver/blob/master/examples/kubernetes/README.md : the link for "Accessing the file system from multiple pods" should not have 'kubernetes/' in its relative path.

**What testing is done?** 
I removed 'kubernetes/' from the path in my browser and it worked :-)
