### PR TITLE
Upgrade Go to 1.25.6 to fix high CVE

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -156,4 +156,4 @@ replace k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.33.2
 
 go 1.25.0
 
-toolchain go1.25.5
+toolchain go1.25.6


### PR DESCRIPTION
Upgrade go to 1.25.6 to address CVEs

| Resource | Current Version | Fixed Version | Vulnerabilities |
|----------|----------------|---------------|-----------------|
| go/stdlib | 1.25.5 | 1.25.6 | CVE-2025-61726, CVE-2025-61728, CVE-2025-61730 |