### PR TITLE
Enable the Pod Disruption Budget by default

### DIFF
--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -111,7 +111,7 @@ controller:
   regionalStsEndpoints: false
   # Pod Disruption Budget
   podDisruptionBudget: 
-    enabled: false
+    enabled: true
     # maxUnavailable: 1
     minAvailable: 1
     unhealthyPodEvictionPolicy: IfHealthyBudget


### PR DESCRIPTION
Fixes #1799

**Is this a bug fix or adding new feature?**
It's more of a default behaviour change.

**What is this PR about? / Why do we need it?**
Enable the pod disruption budget by default to avoid outages.
The default replica count is 2, so this avoids outages with the default configuration.

**What testing is done?** 
Yes