### PR TITLE
Closes #1609: Ipv4 private link in ipv6 network env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM public.ecr.aws/eks-distro-build-tooling/golang:1.25.5 as go-builder
+FROM public.ecr.aws/eks-distro-build-tooling/golang:1.25.6-gcc-al23 as go-builder
 WORKDIR /go/src/github.com/kubernetes-sigs/aws-efs-csi-driver
 
 ARG TARGETOS
@@ -89,6 +89,9 @@ RUN clean_install amazon-efs-utils true && \
 # Otherwise creating a host path volume for that directory will clean up everything inside at the first time.
 # Those static files need to be copied back to the config directory when the driver starts up.
 RUN mv /newroot/etc/amazon/efs /newroot/etc/amazon/efs-static-files
+
+# Workaround to ensure IPv4/IPv6 dual stack net with IPv4 only Private link endpoint prioritizes IPv4 over IPv6, which is a common setup for Private link endpoint. This is required for stunnel to work properly in that setup. More details can be found in
+RUN echo "precedence ::ffff:0:0/96  100" >> /newroot/etc/gai.conf
 
 FROM public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-python:3.11-al23 AS linux-amazon
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM public.ecr.aws/eks-distro-build-tooling/golang:1.25.6-gcc-al23 as go-builder
+FROM public.ecr.aws/eks-distro-build-tooling/golang:1.25.5 as go-builder
 WORKDIR /go/src/github.com/kubernetes-sigs/aws-efs-csi-driver
 
 ARG TARGETOS


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
adds a feature

**What is this PR about? / Why do we need it?**
This PR address the issue reported in #1609 
in a dual stack environment with EFS service private link (VPC endpoint_ configured for connection, pod connection to EFS timeout because IPv6 source address is not allowed;
- NAT translation and other workaround fails because the EFS VPC endpoint does not allow IPv6 connection yet. 

This suggestion implements a low level change in the container env with a `gai.conf` file to prioritize IPv4 A responses, without exposing any unnecessary user knobs. As eventually, the expectations is EFS will not only supports IPv4 but IPv6 will be enabled as on all services - avoiding deprecation requirements for any user exposed configurations.

**What testing is done?** 
build and function testing