### PR TITLE
feat: CSI volume health monitoring and failover

### DIFF
--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -100,6 +100,7 @@ func SetNodeCapOptInFeatures(volMetricsOptIn bool) []csi.NodeServiceCapability_R
 	if volMetricsOptIn {
 		klog.V(4).Infof("Enabling Node Service capability for Get Volume Stats")
 		nCaps = append(nCaps, csi.NodeServiceCapability_RPC_GET_VOLUME_STATS)
+		nCaps = append(nCaps, csi.NodeServiceCapability_RPC_VOLUME_CONDITION)
 	} else {
 		klog.V(4).Infof("Node Service capability for Get Volume Stats Not enabled")
 	}

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -67,14 +67,15 @@ func NewDriver(options *Options, efsUtilsCfgPath string) *Driver {
 
 	nodeCaps := SetNodeCapOptInFeatures(*options.VolMetricsOptIn)
 	watchdog := newExecWatchdog(efsUtilsCfgPath, *options.EfsUtilsStaticFilesPath, "amazon-efs-mount-watchdog")
-	return &Driver{
+	vs := NewVolStatter()
+	d := &Driver{
 		endpoint:                 *options.Endpoint,
 		nodeID:                   cloud.GetMetadata().GetInstanceID(),
 		mounter:                  newNodeMounter(),
 		efsWatchdog:              watchdog,
 		cloud:                    cloud,
 		nodeCaps:                 nodeCaps,
-		volStatter:               NewVolStatter(),
+		volStatter:               vs,
 		volMetricsOptIn:          *options.VolMetricsOptIn,
 		volMetricsRefreshPeriod:  *options.VolMetricsRefreshPeriod,
 		volMetricsFsRateLimit:    *options.VolMetricsFsRateLimit,
@@ -88,6 +89,10 @@ func NewDriver(options *Options, efsUtilsCfgPath string) *Driver {
 		forceUnmountAfterTimeout: *options.ForceUnmountAfterTimeout,
 		unmountTimeout:           *options.UnmountTimeout,
 	}
+	if imp, ok := vs.(*VolStatterImpl); ok {
+		imp.SethealthDriver(d)
+	}
+	return d
 }
 
 func SetNodeCapOptInFeatures(volMetricsOptIn bool) []csi.NodeServiceCapability_RPC_Type {

--- a/pkg/driver/mount_health_ha.go
+++ b/pkg/driver/mount_health_ha.go
@@ -1,0 +1,88 @@
+package driver
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"k8s.io/klog/v2"
+)
+
+type MountParams struct {
+	source       string
+	target       string
+	mountOptions []string
+}
+
+func checkMountHealth(ctx context.Context, target string) (bool, error) {
+	osCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	done := make(chan error, 1)
+	mount_health := filepath.Join(target, ".efs_mount_health")
+	writeBytes := []byte(fmt.Sprintf("%s: mount I/O health ping at %v", target, time.Now().UTC()))
+
+	go func() {
+		defer os.Remove(mount_health)
+		err := os.WriteFile(mount_health, writeBytes, 0644)
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			if os.IsNotExist(err) {
+				return false, nil
+			}
+			return false, err
+		}
+		return true, nil
+	case <-osCtx.Done():
+		return false, fmt.Errorf("mount point %s health check timed out", target)
+	}
+}
+
+// High availability and self-heal attempt implementations for unhealthy mount points
+func (d *Driver) AsyncMountHealthRecovery(volId, volPath string) {
+	if !d.lockManager.lockMutex(volId, 1*time.Millisecond) {
+		klog.V(4).Infof("Mount health recovery already in progress for path %s, skipping duplicate attempt", volPath)
+		return
+	}
+	go func() {
+		defer d.lockManager.unlockMutex(volId)
+		params, ok := volumeMountOptions[volId]
+		if !ok {
+			klog.Errorf("Mount parameters not found for volume ID %s during health recovery attempt", volId)
+			return
+		}
+		source := params.source
+		target := params.target
+		mountOptions := params.mountOptions
+
+		klog.Infof("Attempting mount point health recovery for path: %s ", volPath)
+
+		if err := d.mounter.UnmountWithForce(volPath, d.unmountTimeout); err != nil {
+			klog.Errorf("Failed to unmount target %s during health recovery: %v", volPath, err)
+			return
+		}
+
+		// Attempt to remount the target path
+		if err := d.mounter.Mount(source, target, "efs", mountOptions); err != nil {
+			klog.Errorf("Failed to remount target %s during health recovery: %v", volPath, err)
+			return
+		}
+		health, err := checkMountHealth(context.Background(), volPath)
+		if err != nil {
+			klog.Errorf("Mount health check failed for path %s after recovery attempt: %v", volPath, err)
+			return
+		}
+		if !health {
+			klog.Errorf("Mount health recovery attempt did not restore healthy status for vol %s, path %s", volId, volPath)
+			return
+		}
+		klog.Infof("Mount health recovery successful for vol %s", volId)
+		updateVolMetricsWithHealth(volId, health)
+		return
+	}()
+}

--- a/pkg/driver/mount_health_ha.go
+++ b/pkg/driver/mount_health_ha.go
@@ -17,7 +17,7 @@ type MountParams struct {
 }
 
 func checkMountHealth(ctx context.Context, target string) (bool, error) {
-	osCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	osCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 	done := make(chan error, 1)
 	mount_health := filepath.Join(target, ".efs_mount_health")

--- a/pkg/driver/mount_health_ha_test.go
+++ b/pkg/driver/mount_health_ha_test.go
@@ -1,0 +1,153 @@
+package driver
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/kubernetes-sigs/aws-efs-csi-driver/pkg/driver/mocks"
+	"k8s.io/mount-utils"
+)
+
+type FakeMounter struct {
+	mount.FakeMounter
+}
+type MockLockManager struct {
+	locks map[string]bool
+}
+
+func NewMockLockManager() *MockLockManager {
+	return &MockLockManager{
+		locks: make(map[string]bool),
+	}
+}
+
+var (
+	volPath = "/var/lib/kubelet/pods/12345678-1234-1234-1234-123456789012/volumes/efs/test-vol"
+	volId   = "fs-12345678"
+)
+
+func TestAsyncMountHealthRecoveryConcurrency(t *testing.T) {
+
+	mockCtr := gomock.NewController(t)
+	defer mockCtr.Finish()
+	mockMounter := mocks.NewMockMounter(mockCtr)
+
+	d := &Driver{
+		lockManager: NewLockManagerMap(),
+		mounter:     mockMounter,
+	}
+
+	mu.Lock()
+	volumeMountOptions[volId] = MountParams{
+		source: "fs-12345678:/",
+		target: volPath,
+	}
+	mu.Unlock()
+
+	blockThread := make(chan struct{})
+
+	mockMounter.EXPECT().
+		UnmountWithForce(volPath, gomock.Any()).Do(func(interface{}, interface{}) {
+		<-blockThread
+	}).Return(nil).Times(1)
+
+	mockMounter.EXPECT().Mount(gomock.Any(), gomock.Any(), "efs", gomock.Any()).Return(nil).Times(1)
+
+	// Simulate concurrent health recovery attempts
+	for i := 0; i < 3; i++ {
+		go d.AsyncMountHealthRecovery(volId, volPath)
+	}
+
+	time.Sleep(50 * time.Millisecond)
+	close(blockThread)
+	time.Sleep(900 * time.Millisecond)
+}
+
+func TestAsyncMountHealthRecoveryHang(t *testing.T) {
+
+	mockCtr := gomock.NewController(t)
+	defer mockCtr.Finish()
+	mockMounter := mocks.NewMockMounter(mockCtr)
+
+	d := &Driver{
+		lockManager: NewLockManagerMap(),
+		mounter:     mockMounter,
+	}
+
+	mu.Lock()
+	volumeMountOptions[volId] = MountParams{
+		source: "fs-12345678:/",
+		target: volPath,
+	}
+	mu.Unlock()
+
+	blockThread := make(chan struct{})
+
+	mockMounter.EXPECT().
+		UnmountWithForce(volPath, gomock.Any()).Do(func(interface{}, interface{}) {
+		<-blockThread
+	}).Return(nil).Times(1)
+
+	mockMounter.EXPECT().Mount(gomock.Any(), gomock.Any(), "efs", gomock.Any()).Return(nil).Times(1)
+
+	go d.AsyncMountHealthRecovery(volId, volPath)
+
+	time.Sleep(100 * time.Millisecond)
+
+	if d.lockManager.lockMutex(volId, 10*time.Millisecond) {
+		t.Errorf("Expected lock to be held during AsyncMountHealthRecovery long run or hang, but it was acquired")
+	} else {
+		t.Logf("Lock is correctly held during AsyncMountHealthRecovery long run or hang")
+	}
+
+	close(blockThread)
+	time.Sleep(100 * time.Millisecond)
+}
+
+func TestAsyncMountHealthRecoveryRaceDeletion(t *testing.T) {
+
+	mockCtr := gomock.NewController(t)
+	defer mockCtr.Finish()
+	mockMounter := mocks.NewMockMounter(mockCtr)
+
+	d := &Driver{
+		lockManager: NewLockManagerMap(),
+		mounter:     mockMounter,
+	}
+
+	mu.Lock()
+	volumeMountOptions[volId] = MountParams{
+		source: "fs-12345678:/",
+		target: volPath,
+	}
+	mu.Unlock()
+
+	pauseUnmount := make(chan struct{})
+
+	mockMounter.EXPECT().
+		UnmountWithForce(volPath, gomock.Any()).Do(func(interface{}, interface{}) {
+		mu.Lock()
+		delete(volumeMountOptions, volId)
+		mu.Unlock()
+		close(pauseUnmount)
+	}).Return(nil).Times(1)
+
+	mockMounter.EXPECT().Mount("", "", "efs", gomock.Any()).Return(fmt.Errorf("invalid params")).AnyTimes()
+
+	go d.AsyncMountHealthRecovery(volId, volPath)
+
+	select {
+	case <-pauseUnmount:
+		t.Log("Successfully simulated deletion during recovery")
+	case <-time.After(5 * time.Second):
+		t.Error("Test timed out")
+	}
+}
+
+func resetGlobals() {
+	mu.Lock()
+	defer mu.Unlock()
+	volumeMountOptions = make(map[string]MountParams)
+}

--- a/pkg/driver/mount_health_ha_test.go
+++ b/pkg/driver/mount_health_ha_test.go
@@ -1,6 +1,7 @@
 package driver
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -143,6 +144,57 @@ func TestAsyncMountHealthRecoveryRaceDeletion(t *testing.T) {
 		t.Log("Successfully simulated deletion during recovery")
 	case <-time.After(5 * time.Second):
 		t.Error("Test timed out")
+	}
+}
+
+func TestCheckMountHealth_Table(t *testing.T) {
+	// 1. Define the "Table" of test cases
+	tests := []struct {
+		name       string
+		timeout    time.Duration
+		setupPath  func() string // Helper to create temp paths
+		wantHealth bool
+		wantErr    bool
+	}{
+		{
+			name:       "Success Path",
+			timeout:    2 * time.Second,
+			setupPath:  func() string { return t.TempDir() },
+			wantHealth: true,
+			wantErr:    false,
+		},
+		{
+			name:       "Timeout Path",
+			timeout:    1 * time.Millisecond, // Force immediate timeout
+			setupPath:  func() string { return t.TempDir() },
+			wantHealth: false,
+			wantErr:    true,
+		},
+		{
+			name:       "Invalid Path",
+			timeout:    2 * time.Second,
+			setupPath:  func() string { return "/non/existent/path" },
+			wantHealth: false,
+			wantErr:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		// 2. Use t.Run for each row in the table
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), tt.timeout)
+			defer cancel()
+
+			path := tt.setupPath()
+			health, err := checkMountHealth(ctx, path)
+
+			if health != tt.wantHealth {
+				t.Errorf("health = %v, want %v", health, tt.wantHealth)
+			}
+			if (err != nil) != tt.wantErr {
+				t.Errorf("error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
 	}
 }
 

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -337,9 +337,13 @@ func (d *Driver) NodeGetVolumeStats(ctx context.Context, req *csi.NodeGetVolumeS
 			},
 		}, nil
 	}
-
+	klog.V(5).Infof("Compute volume metrics complete for Vol ID: %v, Vol Health: %v", volId, volMetrics.mountHealthy)
 	return &csi.NodeGetVolumeStatsResponse{
 		Usage: volMetrics.volUsage,
+		VolumeCondition: &csi.VolumeCondition{
+			Abnormal: false,
+			Message:  "volume mount is healthy",
+		},
 	}, nil
 }
 

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -337,6 +337,7 @@ func (d *Driver) NodeGetVolumeStats(ctx context.Context, req *csi.NodeGetVolumeS
 			},
 		}, nil
 	}
+
 	klog.V(5).Infof("Compute volume metrics complete for Vol ID: %v, Vol Health: %v", volId, volMetrics.mountHealthy)
 	return &csi.NodeGetVolumeStatsResponse{
 		Usage: volMetrics.volUsage,

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -44,9 +44,10 @@ var (
 		csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
 		csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER,
 	}
-	volumeIdCounter  = make(map[string]int)
-	supportedFSTypes = []string{"efs", ""}
-	hexSuffixRegex   = regexp.MustCompile(`^[0-9a-f]{8,40}$`)
+	volumeIdCounter    = make(map[string]int)
+	volumeMountOptions = make(map[string]MountParams)
+	supportedFSTypes   = []string{"efs", ""}
+	hexSuffixRegex     = regexp.MustCompile(`^[0-9a-f]{8,40}$`)
 )
 
 const (
@@ -229,6 +230,11 @@ func (d *Driver) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolu
 		} else {
 			volumeIdCounter[req.GetVolumeId()] = 1
 		}
+		volumeMountOptions[req.GetVolumeId()] = MountParams{
+			source:       source,
+			target:       target,
+			mountOptions: mountOptions,
+		}
 	}
 
 	return &csi.NodePublishVolumeResponse{}, nil
@@ -288,6 +294,7 @@ func (d *Driver) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpublish
 				volumeIdCounter[req.GetVolumeId()] = value
 			}
 		}
+		delete(volumeMountOptions, req.GetVolumeId())
 	}
 
 	return &csi.NodeUnpublishVolumeResponse{}, nil
@@ -319,6 +326,16 @@ func (d *Driver) NodeGetVolumeStats(ctx context.Context, req *csi.NodeGetVolumeS
 
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not get metrics: %v ", err)
+	}
+
+	if !volMetrics.mountHealthy {
+		return &csi.NodeGetVolumeStatsResponse{
+			Usage: volMetrics.volUsage,
+			VolumeCondition: &csi.VolumeCondition{
+				Abnormal: true,
+				Message:  "volume mount is unhealthy",
+			},
+		}, nil
 	}
 
 	return &csi.NodeGetVolumeStatsResponse{

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -323,27 +323,16 @@ func (d *Driver) NodeGetVolumeStats(ctx context.Context, req *csi.NodeGetVolumeS
 	}
 
 	volMetrics, err := d.volStatter.computeVolumeMetrics(volId, target, d.volMetricsRefreshPeriod, d.volMetricsFsRateLimit)
-
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not get metrics: %v ", err)
-	}
-
-	if !volMetrics.mountHealthy {
-		return &csi.NodeGetVolumeStatsResponse{
-			Usage: volMetrics.volUsage,
-			VolumeCondition: &csi.VolumeCondition{
-				Abnormal: true,
-				Message:  "volume mount is unhealthy",
-			},
-		}, nil
 	}
 
 	klog.V(5).Infof("Compute volume metrics complete for Vol ID: %v, Vol Health: %v", volId, volMetrics.mountHealthy)
 	return &csi.NodeGetVolumeStatsResponse{
 		Usage: volMetrics.volUsage,
 		VolumeCondition: &csi.VolumeCondition{
-			Abnormal: false,
-			Message:  "volume mount is healthy",
+			Abnormal: !volMetrics.mountHealthy,
+			Message:  fmt.Sprintf("volume %v mount is healthy: %v", volId, !volMetrics.mountHealthy),
 		},
 	}, nil
 }

--- a/pkg/driver/vol_statter.go
+++ b/pkg/driver/vol_statter.go
@@ -66,6 +66,10 @@ func NewVolStatter() VolStatter {
 
 func (v VolStatterImpl) computeVolumeMetrics(volId, volPath string, refreshRate float64, fsRateLimit int) (*volMetrics, error) {
 	if value, ok := v.retrieveFromCache(volId); ok {
+		if _, ok := volStatterJobTracker[volId]; ok {
+			klog.V(4).Infof("Volume metrics computation is underway for volume Id : %v. Returning cached metrics for now", volId)
+			return value, nil
+		}
 		if time.Since(value.timeStamp).Minutes() > refreshRate {
 			// Time to refresh volume stats
 			v.launchVolStatsRoutine(volId, volPath, fsRateLimit)
@@ -128,17 +132,29 @@ func (v VolStatterImpl) launchVolStatsRoutine(volId, volPath string, fsRateLimit
 }
 
 func (v VolStatterImpl) computeDiskUsage(fsId, volId, volPath string) {
-	waitTime := wait.Jitter(jitter, 2.0)
+	waitTime := wait.Jitter(jitter, 2.0) //reduce jitter with better thundering herd management
 	var used fs.UsageInfo
 	var err error
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
+	update_time := time.Now().UTC()
+	health := false
 	done := make(chan error, 1)
-	klog.V(5).Infof("Compute Volume Metrics invoked for Vol ID: %v, Sleeping for %v before execution", volId, waitTime)
+	klog.V(5).Infof("Compute volume metrics invoked for Vol ID: %v, Sleeping for %v before execution", volId, waitTime)
+
+	volMetrics := &volMetrics{
+		mountHealthy: health,
+		volPath:      volPath,
+		timeStamp:    update_time,
+		volUsage:     []*csi.VolumeUsage{{Unit: csi.VolumeUsage_UNKNOWN}},
+	}
+	if _, ok := v.retrieveFromCache(volId); !ok {
+		volUsageCache[volId] = volMetrics
+	}
 
 	// ensure fsRateLimiter cleanup for failing execution paths
+	// ToDo: fix kubelet thrundering herd with empty cahce response pending first await volStatter execution completion
 	defer func() {
 		mu.Lock()
+		volUsageCache[volId] = volMetrics
 		delete(volStatterJobTracker, volId)
 		if count, ok := fsRateLimiter[fsId]; ok && count > 0 {
 			fsRateLimiter[fsId] = count - 1
@@ -149,8 +165,11 @@ func (v VolStatterImpl) computeDiskUsage(fsId, volId, volPath string) {
 	//jittered execution
 	time.Sleep(waitTime)
 
-	health, err := checkMountHealth(ctx, volPath)
-	if err != nil {
+	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Second)
+	defer cancel()
+
+	health, err = checkMountHealth(ctx, volPath)
+	if !health {
 		updateVolMetricsWithHealth(volId, health)
 		// attempt a single async recovery to update cached health status back to healthy
 		go v.healthWatchdog.AsyncMountHealthRecovery(volId, volPath)
@@ -196,16 +215,11 @@ func (v VolStatterImpl) computeDiskUsage(fsId, volId, volPath string) {
 		},
 	}
 
-	volMetrics := &volMetrics{
-		mountHealthy: health,
-		volPath:      volPath,
-		timeStamp:    time.Now(),
-		volUsage:     usage}
-
-	// ToDo: initiate an empt cache to stop kubelet thundering herd scenarios?
-	mu.Lock()
-	volUsageCache[volId] = volMetrics
-	mu.Unlock()
+	volMetrics.mountHealthy = health
+	volMetrics.volUsage = usage
+	update_time = time.Now().UTC()
+	volMetrics.timeStamp = update_time
+	klog.V(5).Infof("Compute volume metrics complete for Vol ID: %v, Vol Health: %v, Used: %v, Available: %v, Capacity: %v", volId, health, volUsed, available, capacity)
 	return
 }
 

--- a/pkg/driver/vol_statter.go
+++ b/pkg/driver/vol_statter.go
@@ -15,18 +15,25 @@ limitations under the License.
 package driver
 
 import (
+	"context"
+	"sync"
+	"time"
+
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/volume/util/fs"
-	"sync"
-	"time"
 )
 
 type volMetrics struct {
-	volPath   string
-	timeStamp time.Time
-	volUsage  []*csi.VolumeUsage
+	mountHealthy bool
+	volPath      string
+	timeStamp    time.Time
+	volUsage     []*csi.VolumeUsage
+}
+
+type MountHealth interface {
+	AsyncMountHealthRecovery(volId, volPath string)
 }
 
 var (
@@ -44,6 +51,13 @@ type VolStatter interface {
 }
 
 type VolStatterImpl struct {
+	healthWatchdog MountHealth
+}
+
+func (v *VolStatterImpl) SethealthDriver(r MountHealth) {
+	mu.Lock()
+	defer mu.Unlock()
+	v.healthWatchdog = r
 }
 
 func NewVolStatter() VolStatter {
@@ -66,8 +80,9 @@ func (v VolStatterImpl) computeVolumeMetrics(volId, volPath string, refreshRate 
 	// Return nil as kubelet might timeout waiting for volume stats
 	klog.Warningf("Volume metrics computation is underway for Vol ID: %v and metrics are not available yet.", volId)
 	return &volMetrics{
-		volPath:   volPath,
-		timeStamp: time.Now(),
+		mountHealthy: false,
+		volPath:      volPath,
+		timeStamp:    time.Now(),
 		volUsage: []*csi.VolumeUsage{
 			{
 				Unit: csi.VolumeUsage_UNKNOWN,
@@ -104,7 +119,6 @@ func (v VolStatterImpl) launchVolStatsRoutine(volId, volPath string, fsRateLimit
 		klog.V(5).Infof("Volume stats computation job is underway for volume Id : %v. Awaiting results", volId)
 	} else {
 		if ok := canStatFS(fsId, fsRateLimit); ok {
-			volStatterJobTracker[volId] = true
 			go v.computeDiskUsage(fsId, volId, volPath)
 		} else {
 			klog.V(5).Infof("Too many stat routines are running against FS : %s. Retry stat for volume Id: %s later", fsId, volId)
@@ -115,19 +129,58 @@ func (v VolStatterImpl) launchVolStatsRoutine(volId, volPath string, fsRateLimit
 
 func (v VolStatterImpl) computeDiskUsage(fsId, volId, volPath string) {
 	waitTime := wait.Jitter(jitter, 2.0)
+	var used fs.UsageInfo
+	var err error
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	done := make(chan error, 1)
 	klog.V(5).Infof("Compute Volume Metrics invoked for Vol ID: %v, Sleeping for %v before execution", volId, waitTime)
+
+	// ensure fsRateLimiter cleanup for failing execution paths
+	defer func() {
+		mu.Lock()
+		delete(volStatterJobTracker, volId)
+		if count, ok := fsRateLimiter[fsId]; ok && count > 0 {
+			fsRateLimiter[fsId] = count - 1
+		}
+		mu.Unlock()
+	}()
 
 	//jittered execution
 	time.Sleep(waitTime)
 
-	used, err := fs.DiskUsage(volPath)
+	health, err := checkMountHealth(ctx, volPath)
 	if err != nil {
-		klog.Errorf("Failed to compute volume usage on path %s: %v", volPath, err)
+		updateVolMetricsWithHealth(volId, health)
+		// attempt a single async recovery to update cached health status back to healthy
+		go v.healthWatchdog.AsyncMountHealthRecovery(volId, volPath)
+		klog.Errorf("Failed mount health check for volume path %s: %v", volPath, err)
+		return
+	}
+	// close go routines on dead/inactive mount point that may hang indefinitely
+	go func() {
+		used, err = fs.DiskUsage(volPath)
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		if err != nil {
+			health = false
+			updateVolMetricsWithHealth(volId, health)
+			klog.Errorf("Failed to compute volume usage on path %s: %v", volPath, err)
+			return
+		}
+	case <-ctx.Done():
+		health = false
+		updateVolMetricsWithHealth(volId, health)
+		klog.Errorf("Volume usage computation timed out for path %s", volPath)
 		return
 	}
 
 	volUsed := used.Bytes
 
+	// this Info call can also enter a Ss if the mount point is dead,
+	// so we need should ordinarily put a timeout on it as well
 	available, capacity, _, _, _, _, err := fs.Info(volPath)
 	if err != nil {
 		klog.Errorf("Failed to fetch FsInfo on volume path %s: %v", volPath, err)
@@ -144,16 +197,14 @@ func (v VolStatterImpl) computeDiskUsage(fsId, volId, volPath string) {
 	}
 
 	volMetrics := &volMetrics{
-		volPath:   volPath,
-		timeStamp: time.Now(),
-		volUsage:  usage}
+		mountHealthy: health,
+		volPath:      volPath,
+		timeStamp:    time.Now(),
+		volUsage:     usage}
 
+	// ToDo: initiate an empt cache to stop kubelet thundering herd scenarios?
 	mu.Lock()
 	volUsageCache[volId] = volMetrics
-	delete(volStatterJobTracker, volId)
-	if count, ok := fsRateLimiter[fsId]; ok && count > 0 {
-		fsRateLimiter[fsId] = count - 1
-	}
 	mu.Unlock()
 	return
 }
@@ -170,4 +221,13 @@ func canStatFS(fsId string, fsRateLimit int) bool {
 	}
 
 	return true
+}
+
+func updateVolMetricsWithHealth(volId string, health bool) {
+	mu.Lock()
+	defer mu.Unlock()
+	if value, ok := volUsageCache[volId]; ok {
+		value.mountHealthy = health
+		value.timeStamp = time.Now()
+	}
 }

--- a/pkg/driver/vol_statter.go
+++ b/pkg/driver/vol_statter.go
@@ -41,7 +41,7 @@ var (
 	volStatterJobTracker = make(map[string]bool)
 	fsRateLimiter        = make(map[string]int)
 	mu                   sync.RWMutex
-	jitter               = time.Duration(5 * time.Minute)
+	jitter               = time.Duration(2 * time.Minute)
 )
 
 type VolStatter interface {
@@ -123,6 +123,7 @@ func (v VolStatterImpl) launchVolStatsRoutine(volId, volPath string, fsRateLimit
 		klog.V(5).Infof("Volume stats computation job is underway for volume Id : %v. Awaiting results", volId)
 	} else {
 		if ok := canStatFS(fsId, fsRateLimit); ok {
+			volStatterJobTracker[volId] = true
 			go v.computeDiskUsage(fsId, volId, volPath)
 		} else {
 			klog.V(5).Infof("Too many stat routines are running against FS : %s. Retry stat for volume Id: %s later", fsId, volId)
@@ -135,7 +136,7 @@ func (v VolStatterImpl) computeDiskUsage(fsId, volId, volPath string) {
 	waitTime := wait.Jitter(jitter, 2.0) //reduce jitter with better thundering herd management
 	var used fs.UsageInfo
 	var err error
-	update_time := time.Now().UTC()
+	update_time := time.Now()
 	health := false
 	done := make(chan error, 1)
 	klog.V(5).Infof("Compute volume metrics invoked for Vol ID: %v, Sleeping for %v before execution", volId, waitTime)
@@ -170,7 +171,6 @@ func (v VolStatterImpl) computeDiskUsage(fsId, volId, volPath string) {
 
 	health, err = checkMountHealth(ctx, volPath)
 	if !health {
-		updateVolMetricsWithHealth(volId, health)
 		// attempt a single async recovery to update cached health status back to healthy
 		go v.healthWatchdog.AsyncMountHealthRecovery(volId, volPath)
 		klog.Errorf("Failed mount health check for volume path %s: %v", volPath, err)
@@ -185,13 +185,11 @@ func (v VolStatterImpl) computeDiskUsage(fsId, volId, volPath string) {
 	case err := <-done:
 		if err != nil {
 			health = false
-			updateVolMetricsWithHealth(volId, health)
 			klog.Errorf("Failed to compute volume usage on path %s: %v", volPath, err)
 			return
 		}
 	case <-ctx.Done():
 		health = false
-		updateVolMetricsWithHealth(volId, health)
 		klog.Errorf("Volume usage computation timed out for path %s", volPath)
 		return
 	}
@@ -217,9 +215,9 @@ func (v VolStatterImpl) computeDiskUsage(fsId, volId, volPath string) {
 
 	volMetrics.mountHealthy = health
 	volMetrics.volUsage = usage
-	update_time = time.Now().UTC()
+	update_time = time.Now()
 	volMetrics.timeStamp = update_time
-	klog.V(5).Infof("Compute volume metrics complete for Vol ID: %v, Vol Health: %v, Used: %v, Available: %v, Capacity: %v", volId, health, volUsed, available, capacity)
+	klog.V(5).Infof("Compute volume metrics complete for Vol ID: %v, Vol Healthy: %v, Used: %v, Available: %v, Capacity: %v", volId, health, volUsed, available, capacity)
 	return
 }
 


### PR DESCRIPTION
**Is this a bug fix or adding new feature?** Feature enhancement

**What is this PR about? / Why do we need it?**

This PR should close #1675 #1676 satisfactorily, as well as related request for CSI volume health monitoring, high availability and self-heal

- The CSI should at the minimum be able to monitor health issues on EFS volume mounts and surface volumeCondition status in volume information to kubelet and other operator
- At best, a self recovery of dead volume mount, caused by EFS service AZ failure, network failure, etc. should be possible, and failing that, trigger pod failover (possibly by some separately concerned operator; this behaviour would be out of scope for CSI)

In this PR the minimum use-case, monitor volume mounts an report health and condition along with stat info when they are probed by kubelet, is implemented.
As a stab at the best case scenario, an asyn attempt at volume remount, and failover if EFS server issue or hang is encountered is also implemented.

**What testing is done?** 
unit testing for health check and async recovery attempt flow