### PR TITLE
Fix release.yaml

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
         
       - name: Extract version
         id: extract-version
@@ -41,10 +43,13 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           tag="${{ steps.extract-version.outputs.version }}"
+          major="${tag#v}"
+          major="${major%%.*}"
+          changelog="CHANGELOG-${major}.x.md"
           
           gh release create "$tag" --title "$tag" --notes-file - <<EOF
           AWS EFS CSI Driver
           
           ## CHANGELOG
-          See [CHANGELOG](https://github.com/kubernetes-sigs/aws-efs-csi-driver/blob/master/CHANGELOG-2.x.md) for full list of changes
+          See [CHANGELOG](https://github.com/kubernetes-sigs/aws-efs-csi-driver/blob/master/${changelog}) for full list of changes
           EOF


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Bug fix

**What is this PR about? / Why do we need it?**
- Currently, the release workflow will checkout master branch and tag the latest commit in master branch which is not correct. It should tag the latest commit in release branch (i.e. the merge commit in the post-release PR)
- Extract major version rather than using hardcoded `CHANGELOG-2.x.md` in release message

**What testing is done?** 
Run the workflow in my personal forked repo: https://github.com/DavidXU12345/aws-efs-csi-driver/actions/runs/24117977710/job/70365781752

- It tags to the latest of merged commit in that PR rather than the latest commit in master branch
- It extracts the major version correctly (i.e. using `CHANGELOG-4.x.md` for `[POST-RELEASE v4.0.0]` PR)