### PR TITLE
CHANGELOG 3.x update

### DIFF
--- a/CHANGELOG-3.x.md
+++ b/CHANGELOG-3.x.md
@@ -1,3 +1,8 @@
 # V3.0.0
 * Add support for Amazon S3 Files ([#1828](https://github.com/kubernetes-sigs/aws-efs-csi-driver/pull/1828), [@DavidXU12345](https://github.com/DavidXU12345))
+* Add debugLogs param to increase verbose level and enable debug logging in efs-utils
+* Disallow crossaccount to be manually configured in mountOptions
+* Remove updateStrategy configuration
+* Deprecate path as volume attribute
 * Honor stderrthreshold when logtostderr is enabled ([#1822](https://github.com/kubernetes-sigs/aws-efs-csi-driver/pull/1822), [@pierluigilenoci](https://github.com/pierluigilenoci))
+* Add stricter filtering for filesystem accesspoint([#1796](https://github.com/kubernetes-sigs/aws-efs-csi-driver/pull/1796), [@DavidXU12345](https://github.com/DavidXU12345))

--- a/docs/iam-policy-create.md
+++ b/docs/iam-policy-create.md
@@ -321,10 +321,7 @@ You can create the roles using `eksctl` or the AWS CLI.
 >         },
 >         {
 >             "Effect": "Allow",
->             "Action": [
->                 "s3:ListBucket",
->                 "s3:GetBucketLocation"
->             ],
+>             "Action": "s3:ListBucket",
 >             "Resource": "arn:aws:s3:::*",
 >             "Condition": {
 >                 "StringEquals": {


### PR DESCRIPTION
- Include more detailed and customer impact commits which were squashed into S3 Files commit.
- s3:GetBucketLocation is not required to enable direct s3 read access

**Is this a bug fix or adding new feature?**

**What is this PR about? / Why do we need it?**

**What testing is done?** 
