### PR TITLE
Cherry-pick "Update private registry tag to the correct one" to release-3.0 branch

### DIFF
--- a/deploy/kubernetes/overlays/stable/ecr/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/ecr/kustomization.yaml
@@ -5,7 +5,7 @@ bases:
 images:
   - name: public.ecr.aws/efs-csi-driver/amazon/aws-efs-csi-driver
     newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/aws-efs-csi-driver
-    newTag: v3.0.0
+    newTag: v3.0.0-2
   - name: public.ecr.aws/csi-components/livenessprobe
     newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/livenessprobe
     newTag: v2.17.0-eksbuild.3


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
bugfix

**What is this PR about? / Why do we need it?**
v3.0.0 tag in private registry is pointing to an older image version. We fixed it by pushing a new tag to the correct image.

Cherry-pick it to release branch so that 
```
kubectl kustomize \
    "github.com/kubernetes-sigs/aws-efs-csi-driver/deploy/kubernetes/overlays/stable/ecr/?ref=release-3.0" > private-ecr-driver.yaml
```
works correctly

**What testing is done?** 
NA