### PR TITLE
feat(helm): add updateStartegy to deamonset and strategy to deployment

### DIFF
--- a/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
+++ b/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
@@ -15,6 +15,12 @@ spec:
   {{- if or (kindIs "float64" .Values.controller.revisionHistoryLimit) (kindIs "int64" .Values.controller.revisionHistoryLimit) }}
   revisionHistoryLimit: {{ .Values.controller.revisionHistoryLimit }}
   {{- end }}
+  {{- if .Values.controller.rollingUpdate }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      {{- toYaml .Values.controller.rollingUpdate | nindent 6 }}
+  {{- end }}
   selector:
     matchLabels:
       app: {{ .Values.controller.name }}

--- a/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
+++ b/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
@@ -13,6 +13,12 @@ spec:
   {{- if or (kindIs "float64" .Values.node.revisionHistoryLimit) (kindIs "int64" .Values.node.revisionHistoryLimit) }}
   revisionHistoryLimit: {{ .Values.node.revisionHistoryLimit }}
   {{- end }}
+  {{- if .Values.node.rollingUpdate }}
+  updateStrategy: 
+    type: RollingUpdate
+    rollingUpdate:
+      {{- toYaml .Values.node.rollingUpdate | nindent 6 }}
+  {{- end }}
   selector:
     matchLabels:
       app: efs-csi-node

--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -146,6 +146,10 @@ controller:
   # Enable reading filesystem IDs from configmap/secret
   fileSystemIdRefs:
     enabled: false
+  # rollingUpdate for controller deployment strategy
+  rollingUpdate: {}
+    #  maxUnavailable: 1
+    #  maxSurge: 1
 
 ## Node daemonset variables
 
@@ -222,6 +226,11 @@ node:
   volumes: []
   volumeMounts: []
   kubeletPath: /var/lib/kubelet
+
+  # rollingUpdate for node deamonset updateStrategy.
+  rollingUpdate: {}
+  #  maxSurge: 0
+  #  maxUnavailable: 20%
 
 storageClasses: []
 # Add StorageClass resources like:


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

This PR adds update strategy cotnrolls that were introduced 3 years ago but disappeared in the mean time.

**What is this PR about? / Why do we need it?**

Allow control for update strategy for both controller and deamonset. It is especially important for Deamonset for bigger clusters. Replacement of 100+ nodes takes really long time.

**What testing is done?** 

`helm template` with different inputs