### PR TITLE
Pin commit SHA for GitHub workflow actions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -40,11 +40,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3.0.0
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@7fc6561ed893d15cec696e062df840b21db27eb0 # v4.35.2
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -55,7 +55,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
+      uses: github/codeql-action/autobuild@7fc6561ed893d15cec696e062df840b21db27eb0 # v4.35.2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -69,4 +69,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@7fc6561ed893d15cec696e062df840b21db27eb0 # v4.35.2

--- a/.github/workflows/helm-chart-release.yaml
+++ b/.github/workflows/helm-chart-release.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
       - name: Configure Git
@@ -24,7 +24,7 @@ jobs:
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.1.0
+        uses: helm/chart-releaser-action@a0d2dc62c5e491af8ef6ba64a2e02bcf3fb33aa1 # v1.7.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:

--- a/.github/workflows/notify-slack.yaml
+++ b/.github/workflows/notify-slack.yaml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Send issue notification to Slack
         if: github.event_name == 'issues'
-        uses: slackapi/slack-github-action@v2.1.1
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook
@@ -33,7 +33,7 @@ jobs:
 
       - name: Send pull request notification to Slack
         if: github.event_name == 'pull_request_target'
-        uses: slackapi/slack-github-action@v2.1.1
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook
@@ -49,7 +49,7 @@ jobs:
 
       - name: Send issue comments notification to Slack
         if: github.event_name == 'issue_comment' && !github.event.issue.pull_request 
-        uses: slackapi/slack-github-action@v2.1.1
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ jobs:
       startsWith(github.event.pull_request.title, '[POST-RELEASE')
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.pull_request.merge_commit_sha }}
         

--- a/.github/workflows/trivy-scan.yaml
+++ b/.github/workflows/trivy-scan.yaml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Extract images from kustomization
         id: images
@@ -40,7 +40,7 @@ jobs:
           echo "csi-provisioner=${imgs[3]}" >> "$GITHUB_OUTPUT"
 
       - name: Scan aws-efs-csi-driver
-        uses: aquasecurity/trivy-action@v0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         env:
           TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
         with:
@@ -53,7 +53,7 @@ jobs:
         run: sleep 60
 
       - name: Scan livenessprobe
-        uses: aquasecurity/trivy-action@v0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         env:
           TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
         with:
@@ -66,7 +66,7 @@ jobs:
         run: sleep 60
 
       - name: Scan csi-node-driver-registrar
-        uses: aquasecurity/trivy-action@v0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         env:
           TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
         with:
@@ -79,7 +79,7 @@ jobs:
         run: sleep 60
 
       - name: Scan csi-provisioner
-        uses: aquasecurity/trivy-action@v0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         env:
           TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
         with:
@@ -89,25 +89,25 @@ jobs:
           ignore-unfixed: true
 
       - name: Upload results - aws-efs-csi-driver
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@7fc6561ed893d15cec696e062df840b21db27eb0 # v4.35.2
         with:
           sarif_file: 'results-efs-csi-driver.sarif'
           category: aws-efs-csi-driver
 
       - name: Upload results - livenessprobe
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@7fc6561ed893d15cec696e062df840b21db27eb0 # v4.35.2
         with:
           sarif_file: 'results-livenessprobe.sarif'
           category: livenessprobe
 
       - name: Upload results - csi-node-driver-registrar
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@7fc6561ed893d15cec696e062df840b21db27eb0 # v4.35.2
         with:
           sarif_file: 'results-node-driver-registrar.sarif'
           category: csi-node-driver-registrar
 
       - name: Upload results - csi-provisioner
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@7fc6561ed893d15cec696e062df840b21db27eb0 # v4.35.2
         with:
           sarif_file: 'results-csi-provisioner.sarif'
           category: csi-provisioner
@@ -132,7 +132,7 @@ jobs:
           echo "affected=$affected" >> "$GITHUB_OUTPUT"
 
       - name: Notify Slack
-        uses: slackapi/slack-github-action@v2
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -12,10 +12,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version-file: 'go.mod'
 


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

**What is this PR about? / Why do we need it?**
Have to pin commit SHA rather than mutable versions / tags for workflow actions to make it work

**What testing is done?** 

Received an email:
Hello Everyone,

The  [GitHub Actions Security Policy](https://github.com/kubernetes/community/blob/main/github-management/github-actions-policy.md) [1] is now enforced at the Kubernetes Enterprise Level.

As a result, any GitHub Actions workflows under Kubernetes GitHub orgs that use mutable references such as `latest`, tags, or branches (like `master`, `main`), will now fail to run.

If your workflows are affected, please update them to pin all actions to 40-character commit SHA hashes (e.g., uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1).

For full details, please refer to the[ policy documentation](https://github.com/kubernetes/community/blob/main/github-management/github-actions-policy.md)[1].

If you have questions, please reach out on the #github-management [2] Slack channel.
Regards,
Kubernetes GitHub Admin Team