### PR TITLE
Fix release workflow to tag the correct commit

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,9 +22,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: ${{ github.event.pull_request.merge_commit_sha }}
-        
+
       - name: Extract version
         id: extract-version
         env:
@@ -49,7 +47,9 @@ jobs:
           major="${major%%.*}"
           changelog="CHANGELOG-${major}.x.md"
           
-          gh release create "$tag" --title "$tag" --notes-file - <<EOF
+          gh release create "$tag" \
+            --target "${{ github.event.pull_request.merge_commit_sha }}" \
+            --title "$tag" --notes-file - <<EOF
           AWS EFS CSI Driver
           
           ## CHANGELOG


### PR DESCRIPTION
gh release create defaults to tagging the repo's default branch. Add --target to ensure the tag is created on the PR merge commit instead of master.

**Is this a bug fix or adding new feature?**
bug fix

**What is this PR about? / Why do we need it?**

**What testing is done?** 
https://github.com/DavidXU12345/aws-efs-csi-driver/actions/runs/24530871652

https://github.com/DavidXU12345/aws-efs-csi-driver/releases/tag/v4.0.2 => points to the commit in post release PR
