### PR TITLE
Remove inactive GitHub users from OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,15 +1,12 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- d-nishi
-- leakingtapan
-- justinsb
-- jsafrane
-- wongma7
-- nckturner
-- jqmichael
-- Ashley-wenyizha
-- mskanth972
-- dankova22
 - DavidXU12345
 - samuhale
+
+reviewers:
+- DavidXU12345
+- samuhale
+
+emeritus_approvers:
+- dankova22


### PR DESCRIPTION
Reviewers are automatically selected from OWNERS file. Let's keep OWNERS file updated.

**Is this a bug fix or adding new feature?**

**What is this PR about? / Why do we need it?**
Refer to https://www.kubernetes.dev/docs/guide/owners/

**What testing is done?** 
