### PR TITLE
add e2e test for cross account setup

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -28,6 +28,10 @@ go test -v -timeout 0 ./... -report-dir=$ARTIFACTS -ginkgo.focus="\[efs-csi\]" -
 The E2E flags that you can pass to `go test` are defined in [e2e_test.go](https://github.com/kubernetes-sigs/aws-efs-csi-driver/blob/master/test/e2e/e2e_test.go#L66-L75).
 
 
+### Running Cross-Account E2E Tests
+Cross-account tests verify EFS behaviors when the filesystem is in a different AWS account than the EKS cluster. The same standard e2e test suite runs against a cluster pre-configured with cross-account Secret and StorageClass.
+
+
 ### Running Upgrade Test
 In order to test upgrades from previous releases to the current development version of the driver, the following steps can be followed:
 

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -45,6 +45,16 @@ var (
 	S3FilesFileSystemName string
 	s3FilesResources      *S3FilesResources // Store complete S3Files resources for cleanup
 
+	// Cross-account parameters — when set, StorageClasses include the provisioner
+	// secret reference and iam mount option for cross-account EFS access.
+	// CrossAccountMountTargetIP is the mount target IP for static PV tests —
+	// static provisioning bypasses the controller, and AZ-specific EFS DNS isn't
+	// resolvable cross-VPC unless extra Route 53 setup is done; the customer
+	// pattern in the AWS docs is to pass mounttargetip directly.
+	CrossAccountSecretName    string
+	CrossAccountAZ            string
+	CrossAccountMountTargetIP string
+
 	// CreateFileSystem if set true will create a file system before tests.
 	// Alternatively, provide an existing file system via FileSystemId. If this
 	// is true, ClusterName and Region must be set. For CI it should be true
@@ -158,6 +168,8 @@ func (e *efsDriver) GetDynamicProvisionStorageClass(ctx context.Context, config 
 		"directoryPerms":   "777",
 	}
 
+	mountOptions := applyCrossAccountConfig(parameters)
+
 	generateName := fmt.Sprintf("efs-csi-dynamic-sc-test1234-")
 
 	defaultBindingMode := storagev1.VolumeBindingImmediate
@@ -167,6 +179,7 @@ func (e *efsDriver) GetDynamicProvisionStorageClass(ctx context.Context, config 
 		},
 		Provisioner:       "efs.csi.aws.com",
 		Parameters:        parameters,
+		MountOptions:      mountOptions,
 		VolumeBindingMode: &defaultBindingMode,
 	}
 }
@@ -635,8 +648,23 @@ func makeEFSPVCDynamicProvisioning(namespace, name string, storageClassName stri
 	}
 }
 
+// applyCrossAccountConfig adds cross-account secret reference, mount options,
+// and az parameter to StorageClass parameters when cross-account testing is enabled.
+func applyCrossAccountConfig(parameters map[string]string) []string {
+	if CrossAccountSecretName == "" {
+		return nil
+	}
+	parameters["csi.storage.k8s.io/provisioner-secret-name"] = CrossAccountSecretName
+	parameters["csi.storage.k8s.io/provisioner-secret-namespace"] = "kube-system"
+	if CrossAccountAZ != "" {
+		parameters["az"] = CrossAccountAZ
+	}
+	return []string{"tls", "iam"}
+}
+
 func GetStorageClass(params map[string]string) *storagev1.StorageClass {
 	parameters := params
+	mountOptions := applyCrossAccountConfig(parameters)
 
 	generateName := fmt.Sprintf("efs-csi-dynamic-sc-test1234-")
 
@@ -647,6 +675,7 @@ func GetStorageClass(params map[string]string) *storagev1.StorageClass {
 		},
 		Provisioner:       "efs.csi.aws.com",
 		Parameters:        parameters,
+		MountOptions:      mountOptions,
 		VolumeBindingMode: &defaultBindingMode,
 	}
 }
@@ -699,6 +728,17 @@ func makeEFSPV(name, path string, volumeAttributes map[string]string, config Fil
 	if path != "" {
 		volumeHandle += ":" + path
 	}
+
+	// Cross-account static PV tests: inject the mount target IP directly via
+	// the mounttargetip mount option. Static provisioning bypasses the CSI
+	// controller, and EFS DNS isn't resolvable cross-VPC without additional
+	// Route 53 setup
+	var mountOptions []string
+	if CrossAccountSecretName != "" && CrossAccountMountTargetIP != "" {
+		mountOptions = []string{"tls", "iam"}
+		volumeAttributes["mounttargetip"] = CrossAccountMountTargetIP
+	}
+
 	return &v1.PersistentVolume{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
@@ -715,7 +755,8 @@ func makeEFSPV(name, path string, volumeAttributes map[string]string, config Fil
 					VolumeAttributes: volumeAttributes,
 				},
 			},
-			AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteMany},
+			MountOptions: mountOptions,
+			AccessModes:  []v1.PersistentVolumeAccessMode{v1.ReadWriteMany},
 		},
 	}
 }

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -72,7 +72,9 @@ func init() {
 	flag.StringVar(&combinedMountTargetSubnetIds, "mount-target-subnet-ids", "", "comma-separated list of subnet IDs to use for mount targets of provisioned EFS file system, only used if -file-system-id is not set")
 	flag.StringVar(&EfsDriverNamespace, "efs-driver-namespace", "kube-system", "namespace of EFS driver pods")
 	flag.StringVar(&combinedEfsDriverLabelSelectors, "efs-driver-label-selectors", "app=efs-csi-node", "comma-separated label selectors for EFS driver pods, follows the form key1=value1,key2=value2")
-
+	flag.StringVar(&CrossAccountSecretName, "cross-account-secret-name", "", "name of a pre-existing K8s secret in kube-system with awsRoleArn for cross-account EFS access")
+	flag.StringVar(&CrossAccountAZ, "cross-account-az", "", "availability zone for cross-account mount target selection (used with crossaccount=false)")
+	flag.StringVar(&CrossAccountMountTargetIP, "cross-account-mount-target-ip", "", "mount target IP for static PV tests; used when testing cross-account static provisioning")
 	flag.Parse()
 
 	var err error


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
new test

**What is this PR about? / Why do we need it?**
Adding e2e test to cover crossaccount setup scenarios

**What testing is done?** 
Locally tests were run successfully. 

 ## │ Test                                                                                           │ Time │ Result                               │
  
  │ 1   │ crossaccount not set, no `az` → `mounttargetipmap`        │ ~15s │ ✅ PASS                              │
  │ 2   │ `crossaccount=false` + `az` → single mount target           │ ~15s │ ✅ PASS                              │
  │ 3   │ crossaccount not set + `az` → single mount target            │ ~15s │ ✅ PASS                              │
  │ 4   │ `crossaccount=false`, no `az` → `mounttargetipmap`      │ ~15s │ ✅ PASS                              │
  │ 5   │ Multi-AZ simultaneous mount                                               │ ~15s │ ✅ PASS                              │
  │ 6   │ Pod rescheduling across AZs                                               │ ~15s │ ✅ PASS                              │
  │ 7   │ `mounttargetipmap` multi-AZ + per-node mount               │ ~15s │ ✅ PASS                              │
  │ 8   │ PVC deletion cleanup                                                            │ ~20s │ ✅ PASS                              │
  