### PR TITLE
feat(e2e): Add crossaccount mode flag for cross-account e2e tests

### DIFF
--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -47,13 +47,21 @@ var (
 
 	// Cross-account parameters — when set, StorageClasses include the provisioner
 	// secret reference and iam mount option for cross-account EFS access.
-	// CrossAccountMountTargetIP is the mount target IP for static PV tests —
-	// static provisioning bypasses the controller, and AZ-specific EFS DNS isn't
-	// resolvable cross-VPC unless extra Route 53 setup is done; the customer
-	// pattern in the AWS docs is to pass mounttargetip directly.
-	CrossAccountSecretName    string
-	CrossAccountAZ            string
-	CrossAccountMountTargetIP string
+	// CrossAccountSecretCrossaccountMode indicates the crossaccount value in the
+	// pre-configured cross-account Secret. When set to "true", the test secret
+	// has crossaccount=true (efs-utils resolves AZ-specific DNS — requires
+	// Route 53 AZ-specific zones in the client VPC). When empty/unset, the
+	// secret omits the crossaccount field (defaults to false), and the
+	// controller injects mount target IP(s) into the PV volumeAttributes.
+	// This flag also controls static PV test behavior:
+	//   - "true": PV has crossaccount=true volumeAttribute (+ tls, iam mount opts)
+	//   - else:   PV has mounttargetip volumeAttribute (+ tls, iam mount opts)
+	// CrossAccountMountTargetIP is the mount target IP used for static PV tests
+	// when CrossAccountSecretCrossaccountMode != "true".
+	CrossAccountSecretName             string
+	CrossAccountAZ                     string
+	CrossAccountMountTargetIP          string
+	CrossAccountSecretCrossaccountMode string
 
 	// CreateFileSystem if set true will create a file system before tests.
 	// Alternatively, provide an existing file system via FileSystemId. If this
@@ -729,14 +737,19 @@ func makeEFSPV(name, path string, volumeAttributes map[string]string, config Fil
 		volumeHandle += ":" + path
 	}
 
-	// Cross-account static PV tests: inject the mount target IP directly via
-	// the mounttargetip mount option. Static provisioning bypasses the CSI
-	// controller, and EFS DNS isn't resolvable cross-VPC without additional
-	// Route 53 setup
+	// Cross-account static PV tests: static provisioning bypasses the CSI
+	// controller, so we must either (a) use the crossaccount mount option
+	// which relies on efs-utils resolving AZ-specific DNS (requires Route 53
+	// private hosted zones in the client VPC), or
+	// (b) inject the mount target IP directly via mounttargetip
 	var mountOptions []string
-	if CrossAccountSecretName != "" && CrossAccountMountTargetIP != "" {
+	if CrossAccountSecretName != "" {
 		mountOptions = []string{"tls", "iam"}
-		volumeAttributes["mounttargetip"] = CrossAccountMountTargetIP
+		if CrossAccountSecretCrossaccountMode == "true" {
+			volumeAttributes["crossaccount"] = "true"
+		} else if CrossAccountMountTargetIP != "" {
+			volumeAttributes["mounttargetip"] = CrossAccountMountTargetIP
+		}
 	}
 
 	return &v1.PersistentVolume{

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -73,8 +73,9 @@ func init() {
 	flag.StringVar(&EfsDriverNamespace, "efs-driver-namespace", "kube-system", "namespace of EFS driver pods")
 	flag.StringVar(&combinedEfsDriverLabelSelectors, "efs-driver-label-selectors", "app=efs-csi-node", "comma-separated label selectors for EFS driver pods, follows the form key1=value1,key2=value2")
 	flag.StringVar(&CrossAccountSecretName, "cross-account-secret-name", "", "name of a pre-existing K8s secret in kube-system with awsRoleArn for cross-account EFS access")
-	flag.StringVar(&CrossAccountAZ, "cross-account-az", "", "availability zone for cross-account mount target selection (used with crossaccount=false)")
-	flag.StringVar(&CrossAccountMountTargetIP, "cross-account-mount-target-ip", "", "mount target IP for static PV tests; used when testing cross-account static provisioning")
+	flag.StringVar(&CrossAccountAZ, "cross-account-az", "", "availability zone for cross-account mount target selection")
+	flag.StringVar(&CrossAccountMountTargetIP, "cross-account-mount-target-ip", "", "mount target IP for static PV tests; used when testing cross-account static provisioning without crossaccount=true")
+	flag.StringVar(&CrossAccountSecretCrossaccountMode, "cross-account-secret-crossaccount-mode", "", "value of the crossaccount field in the pre-configured cross-account secret ('true' or unset). When 'true', static PV tests use crossaccount=true (requires Route 53 AZ-specific zones); otherwise, tests use mounttargetip")
 	flag.Parse()
 
 	var err error
@@ -84,6 +85,16 @@ func init() {
 	}
 	MountTargetSecurityGroupIds = parseCommaSeparatedStrings(combinedMountTargetSecurityGroupIds)
 	MountTargetSubnetIds = parseCommaSeparatedStrings(combinedMountTargetSubnetIds)
+
+	validateFlags()
+}
+
+func validateFlags() {
+	if CrossAccountSecretName != "" && CrossAccountSecretCrossaccountMode != "true" && CrossAccountMountTargetIP == "" {
+		log.Fatalln("--cross-account-mount-target-ip is required when --cross-account-secret-name is set and " +
+			"--cross-account-secret-crossaccount-mode is not 'true', because static provisioning requires " +
+			"mounttargetip when cross-account DNS is not enabled")
+	}
 }
 
 func TestEFSCSI(t *testing.T) {


### PR DESCRIPTION

**Is this a bug fix or adding new feature?**
e2e tests

**What is this PR about? / Why do we need it?**
Add --cross-account-secret-crossaccount-mode flag to control static PV behavior in cross-account tests:
- 'true': sets crossaccount=true in PV volumeAttributes (DNS-based)
- 'false': sets crossaccount=false + mounttargetip (explicit)
- unset: uses mounttargetip only (default behavior)

This enables testing all three cross-account provisioning modes: crossaccount=true, explicit crossaccount=false, and default (unset).


**What testing is done?** 
Tested locally for all scenarios
