### PR TITLE
fix(e2e): validate encryptInTransit via efs-proxy --tls flag

### DIFF
--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
 
 	ginkgo "github.com/onsi/ginkgo/v2"
 	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/kubernetes/test/e2e/framework/kubectl"
 
 	v1 "k8s.io/api/core/v1"
@@ -18,7 +20,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
@@ -82,6 +83,9 @@ var (
 	// unstable version of the driver to be tested.
 	DeployDriver  bool
 	destroyDriver bool
+
+	// tlsFlagRe matches the --tls flag in efs-proxy command-line arguments.
+	tlsFlagRe = regexp.MustCompile(`(^|\s)--tls(\s|$)`)
 )
 
 // FileSystemTestConfig holds test configuration for a specific filesystem type
@@ -383,10 +387,11 @@ var _ = ginkgo.Describe("[efs-csi]", func() {
 				})
 
 				testEncryptInTransit := func(f *framework.Framework, encryptInTransit *bool) {
-					// TODO [RyanStan 4-15-24]
-					// Now that non-tls mounts are re-directed to efs-proxy (efs-utils v2),
-					// we need a new method of determining whether encrypt in transit is correctly working.
-					// One way to do this could be to parse the arguments passed to efs-proxy and look for the '--tls' flag.
+					// With efs-utils v2+, both TLS and non-TLS mounts go through efs-proxy on 127.0.0.1.
+					// To distinguish them, we check the efs-proxy process args on the driver pod:
+					// TLS mounts have the '--tls' flag, non-TLS mounts do not.
+
+					expectTLS := encryptInTransit == nil || *encryptInTransit // default (nil) and true both expect TLS
 
 					ginkgo.By("Creating efs pvc & pv")
 					volumeAttributes := map[string]string{}
@@ -402,27 +407,77 @@ var _ = ginkgo.Describe("[efs-csi]", func() {
 					defer func() {
 						_ = f.ClientSet.CoreV1().PersistentVolumes().Delete(context.TODO(), pv.Name, metav1.DeleteOptions{})
 					}()
+					defer func() {
+						_ = f.ClientSet.CoreV1().PersistentVolumeClaims(f.Namespace.Name).Delete(context.TODO(), pvc.Name, metav1.DeleteOptions{})
+					}()
 
-					// mount.efs connects the local NFS client to efs-proxy which listens on localhost and forwards NFS operations to EFS.
-					// This occurs for both non-tls and tls mounts.
-					// Therefore, the mount table entry should be
-					// 127.0.0.1:/ on /mnt/volume1 type nfs4 (rw,relatime,vers=4.1,rsize=1048576,wsize=1048576,namlen=255,hard,noresvport,proto=tcp,port=20052,timeo=600,retrans=2,sec=sys,clientaddr=127.0.0.1,local_lock=none,addr=127.0.0.1)
-					// (stunnel proxy running on localhost)
-					// instead of the EFS DNS name
-					// (file-system-id.efs.aws-region.amazonaws.com).
-					// Call `mount` alone first to print it for debugging.
-
-					command := "mount && mount | grep /mnt/volume1 | grep 127.0.0.1"
-					ginkgo.By(fmt.Sprintf("Creating pod to mount pvc %q and run %q", pvc.Name, command))
-					pod := e2epod.MakePod(f.Namespace.Name, nil, []*v1.PersistentVolumeClaim{pvc}, admissionapi.LevelBaseline, command)
-					pod.Spec.RestartPolicy = v1.RestartPolicyNever
+					ginkgo.By("Creating a long-running pod to mount the volume")
+					pod := e2epod.MakePod(f.Namespace.Name, nil, []*v1.PersistentVolumeClaim{pvc}, admissionapi.LevelBaseline, "while true; do echo $(date -u); sleep 5; done")
 					pod, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(context.TODO(), pod, metav1.CreateOptions{})
 					framework.ExpectNoError(err, "creating pod")
+					framework.ExpectNoError(e2epod.WaitForPodNameRunningInNamespace(context.TODO(), f.ClientSet, pod.Name, f.Namespace.Name), "waiting for pod running")
+					defer func() {
+						_ = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(context.TODO(), pod.Name, metav1.DeleteOptions{})
+					}()
 
-					err = e2epod.WaitForPodSuccessInNamespace(context.TODO(), f.ClientSet, pod.Name, f.Namespace.Name)
-					logs, _ := e2epod.GetPodLogs(context.TODO(), f.ClientSet, f.Namespace.Name, pod.Name, "write-pod")
-					framework.Logf("pod %q logs:\n %v", pod.Name, logs)
-					framework.ExpectNoError(err, "waiting for pod success")
+					ginkgo.By("Verifying mount goes through efs-proxy on 127.0.0.1")
+					mountOutput := kubectl.RunKubectlOrDie(f.Namespace.Name, "exec", pod.Name, "--", "/bin/sh", "-c", "mount | grep /mnt/volume1")
+					framework.Logf("mount output: %s", mountOutput)
+					if !strings.Contains(mountOutput, "127.0.0.1") {
+						ginkgo.Fail(fmt.Sprintf("Expected mount through efs-proxy (127.0.0.1), got: %s", mountOutput))
+					}
+
+					ginkgo.By("Finding the efs-csi-node driver pod on the same node")
+					pod, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(context.TODO(), pod.Name, metav1.GetOptions{})
+					framework.ExpectNoError(err, "getting pod to determine node")
+					nodeName := pod.Spec.NodeName
+
+					labelSelector := buildLabelSelector(EfsDriverLabelSelectors)
+					driverPods, err := f.ClientSet.CoreV1().Pods(EfsDriverNamespace).List(context.TODO(), metav1.ListOptions{
+						LabelSelector: labelSelector,
+						FieldSelector: "spec.nodeName=" + nodeName,
+					})
+					framework.ExpectNoError(err, "listing efs-csi-node pods on node")
+					if len(driverPods.Items) == 0 {
+						ginkgo.Fail(fmt.Sprintf("No efs-csi-node pod found on node %q", nodeName))
+					}
+					driverPod := driverPods.Items[0]
+					framework.Logf("Found efs-csi-node pod %q on node %q", driverPod.Name, nodeName)
+
+					ginkgo.By("Checking efs-proxy process args for --tls flag")
+					fsID := config.GetFSID()
+					// Match on PVC name to identify the exact efs-proxy process for this test's mount,
+					// avoiding false matches from other tests sharing the same filesystem.
+					pvcName := pvc.Name
+
+					// Retry: efs-proxy may still be starting when the pod first reaches Running.
+					var matchingLine, psOutput string
+					waitCtx, waitCancel := context.WithTimeout(context.Background(), 60*time.Second)
+					defer waitCancel()
+					waitErr := wait.PollUntilContextTimeout(waitCtx, 5*time.Second, 60*time.Second, true, func(ctx context.Context) (bool, error) {
+						psOutput = strings.TrimSpace(kubectl.RunKubectlOrDie(EfsDriverNamespace, "exec", driverPod.Name, "-c", "efs-plugin", "--", "python3", "-c", "import glob\nfor f in sorted(glob.glob('/proc/[0-9]*/cmdline')):\n try:\n  c=open(f).read().replace('\\x00',' ').strip()\n  if 'efs-proxy' in c: print(c)\n except: pass"))
+						framework.Logf("efs-proxy processes:\n%s", psOutput)
+						for _, line := range strings.Split(psOutput, "\n") {
+							if strings.Contains(line, fsID) && strings.Contains(line, pvcName) {
+								matchingLine = line
+								return true, nil
+							}
+						}
+						return false, nil
+					})
+					if waitErr != nil {
+						ginkgo.Fail(fmt.Sprintf("Timed out waiting for efs-proxy process for filesystem %q with PVC %q; last ps output:\n%s", fsID, pvcName, psOutput))
+					}
+					framework.Logf("Matched efs-proxy line: %s", matchingLine)
+
+					hasTLS := tlsFlagRe.MatchString(matchingLine)
+					if expectTLS && !hasTLS {
+						ginkgo.Fail(fmt.Sprintf("Expected efs-proxy --tls flag for filesystem %q but not found: %s", fsID, matchingLine))
+					}
+					if !expectTLS && hasTLS {
+						ginkgo.Fail(fmt.Sprintf("Expected efs-proxy to NOT have --tls flag for filesystem %q but found: %s", fsID, matchingLine))
+					}
+					framework.Logf("TLS validation passed: expectTLS=%v, hasTLS=%v, fs=%s", expectTLS, hasTLS, fsID)
 				}
 
 				ginkgo.It("should mount with option tls when encryptInTransit unset", func() {


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
bug fix
**What is this PR about? / Why do we need it?**
With efs-utils v2, both TLS and non-TLS mounts route through efs-proxy on 127.0.0.1, so the mount-table check in testEncryptInTransit cannot distinguish encrypted from unencrypted mounts.

Replace mount table inspection with direct efs-proxy process argument checking: exec into the efs-csi-node driver pod, find the efs-proxy process for the target filesystem, and assert --tls flag presence/absence.

 
**What testing is done?** 
locally