### PR TITLE
Fix typo: wether -> whether in helm values comment

### DIFF
--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -257,5 +257,5 @@ storageClasses: []
 #   reclaimPolicy: Delete
 #   volumeBindingMode: Immediate
 
-# Specifies wether to use helm hooks to apply the CSI driver
+# Specifies whether to use helm hooks to apply the CSI driver
 useHelmHooksForCSIDriver: true


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Doc typo fix.

**What is this PR about? / Why do we need it?**
Fixes "wether" -> "whether" in the helm chart values.yaml comment for hook usage.

**What testing is done?**
N/A — comment-only change.