### PR TITLE
Update cross-account mount documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -19,7 +19,7 @@ Amazon EFS CSI driver supports dynamic provisioning and static provisioning.
 * Dynamic provisioning - Uses a persistent volume claim (PVC) to dynamically provision a persistent volume (PV). On creating a PVC, Kubernetes requests an Amazon EFS or Amazon S3 file system to create an access point in a file system which will be used to mount the PV.
 * Mount options - Mount options can be specified in the persistent volume (PV) or storage class for dynamic provisioning to define how the volume should be mounted.
 * Encryption of data in transit - Amazon EFS and Amazon S3 file systems are mounted with encryption in transit enabled by default in the master branch version of the driver.
-* Cross account mount (Amazon EFS only) - Amazon EFS file systems from different AWS accounts can be mounted from an Amazon EKS cluster.
+* Cross account mount (Amazon EFS only) - Amazon EFS file systems from different AWS accounts can be mounted from an Amazon EKS cluster, with three provisioning modes: efs-utils DNS resolution (`crossaccount=true`), pinned-AZ mount target (`az` parameter), and a per-node AZ→IP map for AZ resilience without DNS prerequisites. See the [cross-account mount example](../examples/kubernetes/efs/cross_account_mount/README.md) and [parameters reference](parameters.md#cross-account-provisioning).
 * Multiarch - Amazon EFS CSI driver image is now multiarch on ECR
 
 The following CSI interfaces are implemented:

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -70,5 +70,15 @@ This configuration uses standard (non-FIPS) endpoints for control plane API call
 - Security policy restricting TLS handshake negotiation to FIPS-approved algorithms only
 - FIPS-validated cryptography module: AWS-LC-FIPS (CSI driver v2.1.15+) or OpenSSL compiled with FIPS-validated libcrypto and FIPS enabled at OS level (CSI driver v2.1.14 or lower versions); runtime switch between FIPS and non-FIPS is not supported for cryptograhy module. 
 
+## Cross-account: what happens if a mount target's AZ goes down?
+
+It depends on which provisioning mode you used (see the [cross-account mount example](../examples/kubernetes/efs/cross_account_mount/README.md) and [parameters reference](parameters.md#cross-account-provisioning)):
+
+- **DNS mode** (`crossaccount=true` in the secret) — each node resolves a mount target via DNS at mount time, so pods on healthy AZs keep working. Existing pods on the failed AZ lose connectivity until they are rescheduled.
+- **Default per-node AZ selection** (no `az`, no `crossaccount`) — the controller resolves all available mount targets at provisioning time. Each node selects its own AZ's mount target; if a node's AZ has no mount target, it falls back to any available one (logged as a warning). Pods running on healthy AZs keep working.
+- **Pinned AZ** (StorageClass `az=<zone>`) — every pod uses the mount target in `<zone>`. If that AZ goes down, all pods using this StorageClass lose connectivity.
+
+If you are still on a driver version that baked a single random mount target IP into every PV, upgrade to `v3.1.0` or newer to get the default per-node AZ selection feature.
+
 ## Tenant Isolation
 Refer to the [EKS Best Practices Guide on Tenant Isolation](https://docs.aws.amazon.com/eks/latest/best-practices/tenant-isolation.html).

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -13,7 +13,7 @@
 | basePath              |        |                 | true     | Path under which access points for dynamic provisioning is created. If this parameter is not specified, access points are created under the root directory of the file system                                                                                                                                                                                                                 |
 | subPathPattern        |        | `/${.PV.name}`  | true     | The template used to construct the subPath under which each of the access points created under Dynamic Provisioning. Can be made up of fixed strings and limited variables, is akin to the 'subPathPattern' variable on the [nfs-subdir-external-provisioner](https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner) chart. Supports `.PVC.name`,`.PVC.namespace` and `.PV.name` |
 | ensureUniqueDirectory |        | true            | true     | **NOTE: Only set this to false if you're sure this is the behaviour you want**.<br/> Used when dynamic provisioning is enabled, if set to true, appends the a UID to the pattern specified in `subPathPattern` to ensure that access points will not accidentally point at the same directory.                                                                                                |
-| az                    |        | ""              | true     | Used for cross-account mount. If specified, the mount target in the given AZ is used. If not specified, the driver passes all available mount target IPs to each node, which selects the mount target matching its own AZ. If no mount target is available in the node's AZ, a random available mount target is selected.  |
+| az                    |        | ""              | true     | Used for cross-account dynamic provisioning. When set, the controller prefers the mount target in this Availability Zone; if none exists in that AZ, it falls back to a random available mount target. When unset, the controller resolves all available mount targets and each CSI node selects the mount target in its own AZ at mount time, with fallback to any available mount target if the node's AZ has none. See [Cross-account provisioning](#cross-account-provisioning) for the full behavior matrix. |
 | enforceZoneAffinity | true/false | false       | true     | When set to `true`, queries the availability zone of the EFS filesystem and returns CSI topology constraints. For One Zone EFS filesystems, this ensures pods are scheduled only in the zone where the filesystem is located. Regional EFS filesystems (multi-AZ) will have no topology constraints. Supports both `volumeBindingMode` values: `Immediate` and `WaitForFirstConsumer`. |
 | reuseAccessPoint      |        | false           | true     | When set to true, it creates the Access Point client-token from the provided PVC name. So that the AccessPoint can be replicated from a different cluster if same PVC name and storageclass configuration are used. This feature is currently only supported for a single filesystem per account/region. If attempting to reuse access points across multiple clusters and filesystems within the same region, volume provisioning will fail. If you wish to use the same EFS accesspoint across different clusters for multiple filesystems in a single region, we recommend manually creating the access points and [statically provisioning](https://github.com/kubernetes-sigs/aws-efs-csi-driver/tree/master/examples/kubernetes/access_points) those volumes.                                                                                                                                                                            |
 
@@ -21,11 +21,43 @@
 * **Filesystem ID Source (marked with \*)**: Exactly one of `fileSystemId`, `fileSystemIdConfigRef`, or `fileSystemIdSecretRef` must be specified to provide the EFS filesystem ID. For detailed usage guide, see the [ConfigMap and Secret Resolution Guide](./filesystem-id-resolution.md).
 * Custom Posix group Id range for Access Point root directory must include both `gidRangeStart` and `gidRangeEnd` parameters. These parameters are optional only if both are omitted. If you specify one, the other becomes mandatory.
 * When using a custom Posix group ID range, there is a possibility for the driver to run out of available POSIX group Ids. We suggest ensuring custom group ID range is large enough or create a new storage class with a new file system to provision additional volumes. 
-* `az` under storage class parameter is not to be confused with efs-utils mount option `az`. The `az` mount option is used for cross-AZ mount or EFS one-zone file system mount within the same AWS account as the cluster.
+* The StorageClass `az` parameter (cross-account dynamic provisioning) is distinct from the efs-utils `az` mount option. The mount option is consumed by efs-utils on the node for cross-AZ or EFS One Zone mounts and can be passed via `mountOptions` on the PV/StorageClass; the StorageClass `az` parameter only influences which mount target the controller selects at provisioning time when the secret carries `awsRoleArn`.
 * Using dynamic provisioning, [user identity enforcement]((https://docs.aws.amazon.com/efs/latest/ug/efs-access-points.html#enforce-identity-access-points)) is always applied.
  * When user enforcement is enabled, Amazon EFS replaces the NFS client's user and group IDs with the identity configured on the access point for all file system operations.
  * The uid/gid configured on the access point is either the uid/gid specified in the storage class, a value in the gidRangeStart-gidRangeEnd (used as both uid/gid) specified in the storage class, or is a value selected by the driver is no uid/gid or gidRange is specified.
  * We suggest using [static provisioning](https://github.com/kubernetes-sigs/aws-efs-csi-driver/blob/master/examples/kubernetes/static_provisioning/README.md) if you do not wish to use user identity enforcement.
+
+### Cross-account provisioning
+
+Cross-account provisioning lets an EKS cluster in account `A` mount EFS file systems owned by another account `B`. Drive it through the provisioner secret keys below; for the IAM/VPC peering prerequisites and full walk-through, see [examples/kubernetes/efs/cross_account_mount/README.md](../examples/kubernetes/efs/cross_account_mount/README.md).
+
+**Provisioner secret keys**
+
+| Key | Required | Description |
+|-----|----------|-------------|
+| `awsRoleArn` | yes (for cross-account) | IAM role in account `B` that the controller assumes via STS to call EFS APIs. |
+| `externalId` | no | External ID required by the role's trust policy, if configured. |
+| `crossaccount` | no | Set to `"true"` to use efs-utils DNS-based cross-account resolution at the node and skip baking a mount target IP into the PV. Defaults to `false`. Has [efs-utils prerequisites](https://github.com/aws/efs-utils?tab=readme-ov-file#crossaccount-option-prerequisites). |
+
+**Dynamic provisioning behavior** (when the provisioner secret has `awsRoleArn`)
+
+| Trigger | PV `volumeAttributes` written | Mount-time behavior |
+|---------|-------------------------------|---------------------|
+| Secret has `crossaccount=true` | `crossaccount: "true"` | Each node uses efs-utils DNS to resolve a mount target in its own AZ. No mount target IP is baked into the PV. |
+| StorageClass has `az=<zone>` (and `crossaccount` is unset/`false`) | `mounttargetip: <ip>` | Every node uses the single mount target IP baked into the PV. If no mount target exists in the specified AZ, the controller falls back to a random available mount target. |
+| Neither set (default) | (internal AZ→IP mapping) | Each node selects the mount target in its own AZ; if absent, falls back to any available mount target (with a warning). |
+
+**Static provisioning `volumeAttributes` accepted on the PV** (see [`pkg/driver/node.go`](../pkg/driver/node.go))
+
+| Key | Description |
+|-----|-------------|
+| `encryptInTransit` | `"true"` (default) or `"false"` to disable TLS. |
+| `mounttargetip` | Explicit mount target IPv4/IPv6 address. Use when you have already chosen the target — for example a same-VPC peer or a single-AZ workload. |
+| `crossaccount` | `"true"` to mount via efs-utils DNS resolution (cross-account). Requires the [efs-utils crossaccount prerequisites](https://github.com/aws/efs-utils?tab=readme-ov-file#crossaccount-option-prerequisites) on each node. Not supported for S3 Files file systems. |
+
+The static PV does not accept an `az` key — to pin a static cross-account PV to a specific AZ, set `mounttargetip` directly.
+
+**Cleanup behavior** — When `delete-access-point-root-dir=true`, `DeleteVolume` mounts the file system from the controller to remove the access point's root directory. For cross-account PVs without `crossaccount=true`, the cleanup mount selects the mount target in the controller node's own AZ when one exists, falling back to any available target.
 
 ---
 If you want to pass any other mountOptions to Amazon EFS CSI driver while mounting, they can be passed in through the Persistent Volume or the Storage Class objects, depending on whether static or dynamic provisioning is used. The following are examples of some mountOptions that can be passed:

--- a/examples/kubernetes/efs/cross_account_mount/README.md
+++ b/examples/kubernetes/efs/cross_account_mount/README.md
@@ -1,94 +1,117 @@
-## Dynamic Provisioning
-This example shows how to create a dynamically provisioned volume created through [EFS access points](https://docs.aws.amazon.com/efs/latest/ug/efs-access-points.html) and Persistent Volume Claim (PVC) and consume it from a pod.
+# Cross-account EFS mount
 
-**Note**: this example requires Kubernetes v1.17+ and driver version >= 1.8.0.
+This example shows how an EKS cluster in AWS account `A` can mount an EFS file system that lives in account `B`. It covers both **dynamic provisioning** and **static provisioning**, driven by a small set of provisioner-secret keys, StorageClass parameters, and PV `volumeAttributes`.
 
-### Edit [StorageClass](./specs/storageclass.yaml)
+**Note**: requires Kubernetes v1.17+ and driver version >= 1.8.0.
 
-```
-kind: StorageClass
-apiVersion: storage.k8s.io/v1
-metadata:
-  name: efs-sc
-provisioner: efs.csi.aws.com
-parameters:
-  provisioningMode: efs-ap
-  fileSystemId: fs-1234abcd
-  directoryPerms: "700"
-  gidRangeStart: "1000"
-  gidRangeEnd: "2000"
-  basePath: "/dynamic_provisioning"
-  az: us-east-1a
-  csi.storage.k8s.io/provisioner-secret-name: x-account
-  csi.storage.k8s.io/provisioner-secret-namespace: kube-system
-```
+## How the driver picks a mount target
 
-### Prerequisite setup
-Lets say you have an EKS cluster in aws account `A` & you wish to mount your file system in another aws account `B` using aws-efs-csi-driver, you'll need to perform the following steps before you proceed with cross account mount between accounts `A` & `B` 
-1. Perform [vpc-peering](https://docs.aws.amazon.com/vpc/latest/peering/working-with-vpc-peering.html) between EKS cluster `vpc` in aws account `A` and EFS `vpc` in another aws account `B`.
-2. Create an IAM role, say `EFSCrossAccountAccessRole` in Account `B` which has a [trust relationship](./iam-policy-examples/trust-relationship-example.json) with Account `A` and add an inline EFS policy with [permissions](./iam-policy-examples/describe-mount-target-example.json) to call `DescribeMountTargets`. This role will be used by CSI-Driver's Controller service running on EKS cluster in account `A` to determine the mount targets for your file system in account `B`. 
-3. In aws account `A`, attach an inline policy to IAM role of efs-csi-driver's controller service account with necessary [permissions](./iam-policy-examples/cross-account-assume-policy-example.json) to perform `sts assume role` on the IAM role created in step 2.  
-4. Create a kubernetes secret with `awsRoleArn` as the key and the role from step 2 as the value. For example, `kubectl create secret generic x-account --namespace=default --from-literal=awsRoleArn='arn:aws:iam::123456789012:role/EFSCrossAccountAccessRole'`. If your IAM role ARN requires externalId as validation, include `externalId` key with the value. For example, `kubectl create secret generic x-account --namespace=kube-system --from-literal=awsRoleArn='arn:aws:iam::123456789012:role/EFSCrossAccountAccessRole --from-literal=externalId="external-id"`. If you would like to ensure that your EFS Mount Target is in the same availability zone as your EKS Node, then ensure you have completed the [prerequisites for cross-account DNS resolution](https://github.com/aws/efs-utils?tab=readme-ov-file#crossaccount-option-prerequisites) and include the `crossaccount` key with value `true`. For example, `kubectl create secret generic x-account --namespace=kube-system --from-literal=awsRoleArn='arn:aws:iam::123456789012:role/EFSCrossAccountAccessRole' --from-literal=crossaccount='true'` instead.
-5. Create an IAM role for service accounts for EKS cluster in account `A` with required [permissions](./iam-policy-examples/node-deamonset-iam-policy-example.json) for EFS client mount. Alternatively, you can find this policy under AWS managed policy as `AmazonElasticFileSystemClientFullAccess`.  
-6. Attach the service account from step 5 to node daemonset.
-7. Create a [file system policy](https://docs.aws.amazon.com/efs/latest/ug/iam-access-control-nfs-efs.html#file-sys-policy-examples) for file system in account `B` which allows account `A` to perform mount on it.
+When the provisioner secret carries `awsRoleArn`, `CreateVolume` chooses one of three branches based on the secret's `crossaccount` key and the StorageClass `az` parameter:
 
-#### Note: 
-In dynamic provisioning, if you wish to enable delete access points root directory by setting `delete-access-point-root-dir=true`, you must attach the IAM policy from step 5 above to controller service account's IAM role. 
+| Trigger | PV `volumeAttributes` written | Mount-time behavior |
+|---------|-------------------------------|---------------------|
+| Secret has `crossaccount=true` | `crossaccount: "true"` | Each node uses [efs-utils DNS resolution](https://github.com/aws/efs-utils?tab=readme-ov-file#crossaccount-option-prerequisites) to mount a mount target in its own AZ. No mount target IP is baked into the PV. |
+| StorageClass has `az=<zone>` (and `crossaccount` unset/`false`) | `mounttargetip: <ip>` | Every node uses the single mount target IP baked into the PV. If no mount target exists in the specified AZ, the controller falls back to a random available mount target. |
+| Neither set (default) | (internal AZ→IP mapping) | Each node selects the mount target in its own AZ; if absent, falls back to any available mount target (with a warning logged). |
 
-### Deploy the Example
-Create storage class, persistent volume claim (PVC) and the pod which consumes PV:
+For static provisioning, use `crossaccount: "true"` or `mounttargetip: <ip>` in the PV's `volumeAttributes`.
+
+> Older driver versions baked a single random mount-target IP into the PV regardless of the node's AZ, which made every workload depend on one AZ even in a multi-AZ deployment. Mode A (`crossaccount=true`) and Mode C (default) avoid that.
+
+## Shared prerequisites
+
+Perform these once before using any mode below. EKS cluster lives in account `A`, EFS file system in account `B`.
+
+1. Set up [VPC peering](https://docs.aws.amazon.com/vpc/latest/peering/working-with-vpc-peering.html) between the EKS VPC in account `A` and the EFS VPC in account `B`.
+2. In account `B`, create an IAM role (e.g. `EFSCrossAccountAccessRole`) with a [trust relationship](./iam-policy-examples/trust-relationship-example.json) to account `A` and an inline EFS policy granting [`DescribeMountTargets`](./iam-policy-examples/describe-mount-target-example.json). The controller in account `A` assumes this role to discover mount targets in account `B`.
+3. In account `A`, attach a policy to the controller's service-account IAM role granting [`sts:AssumeRole`](./iam-policy-examples/cross-account-assume-policy-example.json) on the role from step 2.
+4. In account `A`, attach the [EFS client policy](./iam-policy-examples/node-deamonset-iam-policy-example.json) (or the AWS-managed `AmazonElasticFileSystemClientFullAccess`) to the node DaemonSet's service account.
+5. In account `B`, attach a [file system policy](https://docs.aws.amazon.com/efs/latest/ug/iam-access-control-nfs-efs.html#file-sys-policy-examples) on the file system that allows account `A` to mount it.
+6. Create the Kubernetes secret with the cross-account role ARN. Add `externalId` if the trust policy requires it; add `crossaccount=true` only for **Mode A** below.
+
+   ```sh
+   # Mode B and Mode C — secret with role ARN only
+   kubectl create secret generic x-account \
+     --namespace=kube-system \
+     --from-literal=awsRoleArn='arn:aws:iam::123456789012:role/EFSCrossAccountAccessRole'
+
+   # Mode A — DNS-based; add crossaccount=true
+   kubectl create secret generic x-account \
+     --namespace=kube-system \
+     --from-literal=awsRoleArn='arn:aws:iam::123456789012:role/EFSCrossAccountAccessRole' \
+     --from-literal=crossaccount='true'
+
+   # Optional externalId
+   kubectl create secret generic x-account \
+     --namespace=kube-system \
+     --from-literal=awsRoleArn='arn:aws:iam::123456789012:role/EFSCrossAccountAccessRole' \
+     --from-literal=externalId='external-id'
+   ```
+
+> If you enable `delete-access-point-root-dir=true` on the controller, the controller mounts the file system itself during `DeleteVolume`. Make sure the EFS client policy from step 4 is also attached to the controller's service account, not just the node DaemonSet's.
+
+## Dynamic provisioning
+
+Each mode below uses the same Pod and PVC; only the StorageClass and the secret differ. The example pod and PVC live at [`./specs/pod.yaml`](./specs/pod.yaml) and they reference `storageClassName: efs-sc`.
+
+### Mode A — DNS-based (recommended for AZ resilience)
+
+Use when every node can meet the efs-utils [crossaccount option prerequisites](https://github.com/aws/efs-utils?tab=readme-ov-file#crossaccount-option-prerequisites). No mount target IP is baked into the PV; each node resolves a mount target in its own AZ at mount time.
+
+Secret: include `crossaccount=true` (see the Mode A `kubectl create secret` command above).
+
+StorageClass: [`./specs/storageclass-dns.yaml`](./specs/storageclass-dns.yaml) — no `az` parameter.
+
 ```sh
->> kubectl apply -f examples/kubernetes/efs/dynamic_provisioning/specs/storageclass.yaml
->> kubectl apply -f examples/kubernetes/efs/dynamic_provisioning/specs/pod.yaml
+>> kubectl apply -f examples/kubernetes/efs/cross_account_mount/specs/storageclass-dns.yaml
+>> kubectl apply -f examples/kubernetes/efs/cross_account_mount/specs/pod.yaml
 ```
 
-### Check EFS filesystem is used
-After the objects are created, verify that pod is running:
+### Mode B — Pinned AZ
+
+Use when you want every pod for this StorageClass to mount a specific AZ's mount target. If no mount target exists in the named AZ, the controller falls back to a random available mount target.
+
+Secret: omit `crossaccount` (use the Mode B/C secret command above).
+
+StorageClass: [`./specs/storageclass.yaml`](./specs/storageclass.yaml) — sets `az` to the AZ where the desired mount target lives (replace the example value with your AZ).
+
+```sh
+>> kubectl apply -f examples/kubernetes/efs/cross_account_mount/specs/storageclass.yaml
+>> kubectl apply -f examples/kubernetes/efs/cross_account_mount/specs/pod.yaml
+```
+
+### Mode C — Per-node AZ selection (default)
+
+Use when you cannot meet the DNS prerequisites but still want to survive a single-AZ mount target outage. The controller resolves all available mount targets at provisioning time and each node selects the mount target in its own AZ. If no mount target exists in the node's AZ, it falls back to any available target (logged as a warning).
+
+Secret: omit `crossaccount` (use the Mode B/C secret command above).
+
+StorageClass: [`./specs/storageclass-default.yaml`](./specs/storageclass-default.yaml) — no `az`, no `crossaccount` in the secret.
+
+```sh
+>> kubectl apply -f examples/kubernetes/efs/cross_account_mount/specs/storageclass-default.yaml
+>> kubectl apply -f examples/kubernetes/efs/cross_account_mount/specs/pod.yaml
+```
+
+### Verify
 
 ```sh
 >> kubectl get pods
-```
-
-Also you can verify that data is written onto EFS filesystem:
-
-```sh
 >> kubectl exec -ti efs-app -- tail -f /data/out
 ```
 
-## Static Provisioning
-This example shows how to perform cross-account static provisioning.
+## Static provisioning
 
-**Note**: this example requires Kubernetes v1.17+ and driver version >= 1.8.0.
+For static provisioning, the PV's `volumeAttributes` selects the mount behavior directly — there is no controller secret involved. The supported keys are `crossaccount` and `mounttargetip`. The PV does **not** accept an `az` key; to pin a static cross-account PV to a specific AZ, use `mounttargetip` with that AZ's mount target IP.
 
-### Edit [PersistentVolume](./specs/pv.yaml) config file volumeAttributes
+Both variants share the StorageClass at [`./specs/storageclass-static-prov.yaml`](./specs/storageclass-static-prov.yaml), the PVC at [`./specs/claim.yaml`](./specs/claim.yaml), and the pod at [`./specs/pod-static-prov.yaml`](./specs/pod-static-prov.yaml). Replace `[Filesystem ID]` and `[MOUNT TARGET IP ADDRESS]` placeholders before applying.
 
-```
-apiVersion: v1
-kind: PersistentVolume
-metadata:
-  name: efs-pv
-spec:
-  capacity:
-    storage: 5Gi
-  volumeMode: Filesystem
-  accessModes:
-    - ReadWriteOnce
-  storageClassName: efs-sc
-  persistentVolumeReclaimPolicy: Retain
-  csi:
-    driver: efs.csi.aws.com
-    volumeHandle: [Filesystem ID]
-    volumeAttributes:
-      crossaccount: "true"
-```
-Replace [Filesystem ID] with the corresponding EFS filesystem ID.
+### DNS mode
 
-### Prerequisite setup
-Complete the [efs-utils crossaccount mount option setup](https://github.com/aws/efs-utils?tab=readme-ov-file#crossaccount-option-prerequisites).
+Use when every node meets the [efs-utils crossaccount prerequisites](https://github.com/aws/efs-utils?tab=readme-ov-file#crossaccount-option-prerequisites).
 
-### Deploy the Example Application
-Create PV and persistent volume claim (PVC):
+PV: [`./specs/pv.yaml`](./specs/pv.yaml) — `volumeAttributes.crossaccount: "true"`.
+
 ```sh
 >> kubectl apply -f examples/kubernetes/efs/cross_account_mount/specs/storageclass-static-prov.yaml
 >> kubectl apply -f examples/kubernetes/efs/cross_account_mount/specs/pv.yaml
@@ -96,15 +119,29 @@ Create PV and persistent volume claim (PVC):
 >> kubectl apply -f examples/kubernetes/efs/cross_account_mount/specs/pod-static-prov.yaml
 ```
 
-### Check EFS filesystem is used
-After the objects are created, verify that pod is running:
+### Explicit mount target IP
+
+Use when you want to pin to a specific mount target — for example, a single-AZ workload, or when DNS prerequisites are not met.
+
+PV: [`./specs/pv-mounttargetip.yaml`](./specs/pv-mounttargetip.yaml) — `volumeAttributes.mounttargetip: <ip>`.
+
+```sh
+>> kubectl apply -f examples/kubernetes/efs/cross_account_mount/specs/storageclass-static-prov.yaml
+>> kubectl apply -f examples/kubernetes/efs/cross_account_mount/specs/pv-mounttargetip.yaml
+>> kubectl apply -f examples/kubernetes/efs/cross_account_mount/specs/claim.yaml
+>> kubectl apply -f examples/kubernetes/efs/cross_account_mount/specs/pod-static-prov.yaml
+```
+
+### Verify
 
 ```sh
 >> kubectl get pods
-```
-
-Also you can verify that data is written onto EFS filesystem:
-
-```sh
 >> kubectl exec -ti efs-app -- tail -f /data/out.txt
 ```
+
+## How DeleteVolume cleans up
+
+When `delete-access-point-root-dir=true`, the controller mounts the file system in its own pod to remove the access point's root directory. For cross-account PVs:
+
+- If the PV has `crossaccount=true`, the cleanup mount uses efs-utils DNS resolution.
+- Otherwise, the controller calls `DescribeAvailableMountTargets` and prefers the mount target in **the controller node's own AZ**, falling back to any available target. This means cleanup traffic is sourced from the controller's AZ rather than a random AZ.

--- a/examples/kubernetes/efs/cross_account_mount/specs/pv-mounttargetip.yaml
+++ b/examples/kubernetes/efs/cross_account_mount/specs/pv-mounttargetip.yaml
@@ -1,0 +1,23 @@
+# Cross-account static provisioning — explicit mount target IP.
+# Use when you want to pin the PV to a specific mount target (for example a
+# single-AZ workload, or when you cannot meet the efs-utils crossaccount DNS
+# prerequisites). The node honors `mounttargetip` directly. The PV does not
+# accept an `az` key — to target a particular AZ, supply that AZ's mount
+# target IP here.
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: efs-pv
+spec:
+  capacity:
+    storage: 5Gi
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: efs-sc
+  persistentVolumeReclaimPolicy: Retain
+  csi:
+    driver: efs.csi.aws.com
+    volumeHandle: efs:[Filesystem ID]
+    volumeAttributes:
+      mounttargetip: "[MOUNT TARGET IP ADDRESS]"

--- a/examples/kubernetes/efs/cross_account_mount/specs/pv.yaml
+++ b/examples/kubernetes/efs/cross_account_mount/specs/pv.yaml
@@ -1,3 +1,8 @@
+# Cross-account static provisioning — DNS mode.
+# The node uses efs-utils DNS resolution to find a mount target in its own AZ
+# at mount time. Requires the efs-utils crossaccount prerequisites on every
+# node: https://github.com/aws/efs-utils?tab=readme-ov-file#crossaccount-option-prerequisites
+# See pv-mounttargetip.yaml for the explicit-IP variant.
 apiVersion: v1
 kind: PersistentVolume
 metadata:

--- a/examples/kubernetes/efs/cross_account_mount/specs/storageclass-default.yaml
+++ b/examples/kubernetes/efs/cross_account_mount/specs/storageclass-default.yaml
@@ -1,0 +1,20 @@
+# Cross-account dynamic provisioning — Mode C (per-node AZ selection, default).
+# Provisioner secret carries only `awsRoleArn` (no `crossaccount` key) and the
+# StorageClass omits `az`. The controller resolves all available mount targets
+# and each node selects the target in its own AZ at mount time; if none exists,
+# it falls back to any available target (with a warning logged).
+# Use when you want AZ resilience without DNS prerequisites.
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: efs-sc
+provisioner: efs.csi.aws.com
+parameters:
+  provisioningMode: efs-ap
+  fileSystemId: fs-1234abcd
+  directoryPerms: "700"
+  gidRangeStart: "1000" # optional
+  gidRangeEnd: "2000" # optional
+  basePath: "/dynamic_provisioning" # optional
+  csi.storage.k8s.io/provisioner-secret-name: x-account
+  csi.storage.k8s.io/provisioner-secret-namespace: kube-system

--- a/examples/kubernetes/efs/cross_account_mount/specs/storageclass-dns.yaml
+++ b/examples/kubernetes/efs/cross_account_mount/specs/storageclass-dns.yaml
@@ -1,0 +1,21 @@
+# Cross-account dynamic provisioning — Mode A (DNS-based).
+# Provisioner secret carries `crossaccount=true`, so the controller writes
+# `crossaccount: "true"` into the PV's volumeAttributes and does NOT bake a
+# mount target IP. Each node uses efs-utils DNS resolution to mount the
+# target in its own AZ at NodePublishVolume time. Requires the efs-utils
+# crossaccount prerequisites on every node:
+# https://github.com/aws/efs-utils?tab=readme-ov-file#crossaccount-option-prerequisites
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: efs-sc
+provisioner: efs.csi.aws.com
+parameters:
+  provisioningMode: efs-ap
+  fileSystemId: fs-1234abcd
+  directoryPerms: "700"
+  gidRangeStart: "1000" # optional
+  gidRangeEnd: "2000" # optional
+  basePath: "/dynamic_provisioning" # optional
+  csi.storage.k8s.io/provisioner-secret-name: x-account
+  csi.storage.k8s.io/provisioner-secret-namespace: kube-system

--- a/examples/kubernetes/efs/cross_account_mount/specs/storageclass.yaml
+++ b/examples/kubernetes/efs/cross_account_mount/specs/storageclass.yaml
@@ -1,3 +1,9 @@
+# Cross-account dynamic provisioning — Mode B (pinned AZ).
+# The controller resolves the mount target in the AZ given by `az` and writes
+# `mounttargetip` into the PV's volumeAttributes. Every node mounts the same
+# target. Provisioner secret should contain only `awsRoleArn` (do NOT set
+# `crossaccount=true` for this mode). See storageclass-dns.yaml and
+# storageclass-default.yaml for the other two modes.
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
@@ -5,11 +11,11 @@ metadata:
 provisioner: efs.csi.aws.com
 parameters:
   provisioningMode: efs-ap
-  fileSystemId: fs-92107410
+  fileSystemId: fs-1234abcd
   directoryPerms: "700"
   gidRangeStart: "1000" # optional
   gidRangeEnd: "2000" # optional
   basePath: "/dynamic_provisioning" # optional
-  az: us-east-1a
+  az: us-east-1a # replace with your target AZ
   csi.storage.k8s.io/provisioner-secret-name: x-account
   csi.storage.k8s.io/provisioner-secret-namespace: kube-system


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Documentation

**What is this PR about? / Why do we need it?**
- Rewrites the cross-account mount example README to clearly document all three dynamic provisioning modes (DNS-based, pinned-AZ, per-node AZ selection) and the two static provisioning options (crossaccount, mounttargetip).
- Adds a cross-account provisioning section to `docs/parameters.md` with a behavior matrix and provisioner secret key reference.
- Adds a FAQ entry explaining AZ failure behavior for each mode.
- Adds separate StorageClass examples for each dynamic mode (`storageclass-dns.yaml`, `storageclass-default.yaml`) and a static PV example for explicit mount target IP (`pv-mounttargetip.yaml`).

**What testing is done?** 
N/A