### PR TITLE
fix: add explicit divisor to resourceFieldRef to prevent perpetual diff

### DIFF
--- a/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
+++ b/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
@@ -113,6 +113,7 @@ spec:
               valueFrom:
                 resourceFieldRef:
                   containerName: efs-plugin
+                  divisor: "0"
                   resource: limits.memory
             {{- if .Values.useFIPS }}
             - name: AWS_USE_FIPS_ENDPOINT

--- a/deploy/kubernetes/base/node-daemonset.yaml
+++ b/deploy/kubernetes/base/node-daemonset.yaml
@@ -78,6 +78,7 @@ spec:
               valueFrom:
                 resourceFieldRef:
                   containerName: efs-plugin
+                  divisor: "0"
                   resource: limits.memory
             - name: PORT_RANGE_UPPER_BOUND
               value: "21049"


### PR DESCRIPTION
Fixes #1897

## What

Adds `divisor: "0"` to the `CSI_NODE_MEMORY_LIMIT` env var's `resourceFieldRef` in:
- `charts/aws-efs-csi-driver/templates/node-daemonset.yaml` (Helm)
- `deploy/kubernetes/base/node-daemonset.yaml` (kustomize)

## Why

Kubernetes automatically normalizes an omitted `divisor` field to `"0"`. When the field is absent from the manifest, GitOps tools (Argo CD, Flux) detect a perpetual diff between the desired state and the live cluster state, causing unnecessary sync operations or requiring `ignoreDifferences` workarounds.

## Testing

- `make test` — all unit tests pass
- `make verify` — gofmt, govet, golint pass
- The value `"0"` is the Kubernetes default and has no behavioral impact