### PR TITLE
feat(helm): make updateStrategy configurable for node DaemonSet

### DIFF
--- a/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
+++ b/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
@@ -15,11 +15,9 @@ spec:
   {{- if or (kindIs "float64" .Values.controller.revisionHistoryLimit) (kindIs "int64" .Values.controller.revisionHistoryLimit) }}
   revisionHistoryLimit: {{ .Values.controller.revisionHistoryLimit }}
   {{- end }}
-  {{- if .Values.controller.rollingUpdate }}
+  {{- with .Values.controller.strategy }}
   strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      {{- toYaml .Values.controller.rollingUpdate | nindent 6 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   selector:
     matchLabels:

--- a/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
+++ b/charts/aws-efs-csi-driver/templates/node-daemonset.yaml
@@ -13,11 +13,9 @@ spec:
   {{- if or (kindIs "float64" .Values.node.revisionHistoryLimit) (kindIs "int64" .Values.node.revisionHistoryLimit) }}
   revisionHistoryLimit: {{ .Values.node.revisionHistoryLimit }}
   {{- end }}
-  {{- if .Values.node.rollingUpdate }}
-  updateStrategy: 
-    type: RollingUpdate
-    rollingUpdate:
-      {{- toYaml .Values.node.rollingUpdate | nindent 6 }}
+  {{- with .Values.node.updateStrategy }}
+  updateStrategy:
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   selector:
     matchLabels:

--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -146,10 +146,12 @@ controller:
   # Enable reading filesystem IDs from configmap/secret
   fileSystemIdRefs:
     enabled: false
-  # rollingUpdate for controller deployment strategy
-  rollingUpdate: {}
-    #  maxUnavailable: 1
-    #  maxSurge: 1
+  # strategy for controller deployment.
+  strategy:
+    type: RollingUpdate
+  #  rollingUpdate:
+  #    maxUnavailable: 1
+  #    maxSurge: 1
 
 ## Node daemonset variables
 
@@ -227,10 +229,13 @@ node:
   volumeMounts: []
   kubeletPath: /var/lib/kubelet
 
-  # rollingUpdate for node deamonset updateStrategy.
-  rollingUpdate: {}
-  #  maxSurge: 0
-  #  maxUnavailable: 20%
+  # updateStrategy for node daemonset.
+  # Set type to "OnDelete" to control when node pods restart during upgrades.
+  updateStrategy:
+    type: RollingUpdate
+  #  rollingUpdate:
+  #    maxSurge: 0
+  #    maxUnavailable: 20%
 
   # Comma-separated section:key=value overrides for efs-utils.conf.
   # Example: "mount-watchdog:stunnel_health_check_interval_min=1,mount-watchdog:tls_cert_renewal_interval_min=30"

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -9,8 +9,34 @@ Alternatively, if you would prefer not to allocate these resources to your contr
 For most highly concurrent workloads, we recommend increasing the default timeout argument set in the [external-provisioner](https://github.com/kubernetes-csi/external-provisioner) from 15 seconds to 60 seconds. This will avoid provisioning failures due to throttling and resource contention in the controller container. 
 
 ## Update Strategy
-* Amazon EFS CSI driver uses the `RollingUpdate` strategy and only allows you to configure parameters under [rolling update](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#rolling-update-deployment), such as `maxUnavailable` and `maxSurge`.
-* Changing the update strategy (e.g. to `OnDelete`) is not supported.
+The DaemonSet `updateStrategy` and Deployment `strategy` are fully configurable via Helm values. The default strategy is `RollingUpdate`.
+
+To use `OnDelete` strategy for the node DaemonSet:
+```yaml
+node:
+  updateStrategy:
+    type: OnDelete
+```
+
+To use `RollingUpdate` with custom parameters:
+```yaml
+node:
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 20%
+```
+For more details on DaemonSet update strategies, see the [Kubernetes documentation](https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/).
+
+### EFS CSI driver stuck in UPDATING after an update?
+
+If your EFS CSI driver is stuck in `UPDATING` status with an `InsufficientNumberOfReplicas` error after an update, check whether you have `OnDelete` update strategy configured.
+
+With `OnDelete`, pods are only replaced when manually deleted or when nodes are recycled. Any system that waits for all DaemonSet pods to run the updated version will not see the update complete until all old pods are replaced.
+
+**Resolution:**
+* Manually delete the outdated pods to trigger recreation: `kubectl delete pods -n kube-system -l app=efs-csi-node`
+* Or remove the `OnDelete` configuration so future updates roll out automatically
 
 ## Efs-proxy OOMKilled under heavy NFS write workloads
 


### PR DESCRIPTION
Fixes #1898

## Summary

Makes the DaemonSet `updateStrategy` and Deployment `strategy` fully configurable via Helm values, allowing users to set `OnDelete` strategy for the node DaemonSet to control when pods restart during upgrades.

## Changes

- **node-daemonset.yaml**: Replace hardcoded `RollingUpdate` with configurable `node.updateStrategy` object
- **controller-deployment.yaml**: Replace hardcoded `RollingUpdate` with configurable `controller.strategy` object  
- **values.yaml**: New `node.updateStrategy` (replaces `node.rollingUpdate`) and `controller.strategy` (replaces `controller.rollingUpdate`) with `type: RollingUpdate` as default

## Usage

To use `OnDelete` strategy for the node DaemonSet:
```yaml
node:
  updateStrategy:
    type: OnDelete
```

To use `RollingUpdate` with custom parameters:
```yaml
node:
  updateStrategy:
    type: RollingUpdate
    rollingUpdate:
      maxUnavailable: 20%
```

## Breaking Change

`node.rollingUpdate` is now `node.updateStrategy` and `controller.rollingUpdate` is now `controller.strategy`. Users who previously configured these values must migrate to the new structure.

## Testing

- `helm template` renders correctly for all scenarios (default, OnDelete, RollingUpdate with params)
- `make test` passes
- `make verify` passes