### PR TITLE
feat: add Prometheus metrics for controller provisioning operations

### DIFF
--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -88,11 +88,12 @@ var (
 	}
 )
 
-func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest) (*csi.CreateVolumeResponse, error) {
+func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest) (resp *csi.CreateVolumeResponse, err error) {
+	start := time.Now()
+	defer func() { recordOperationMetrics("CreateVolume", start, err) }()
 	klog.V(4).Infof("CreateVolume: called with args %+v", util.SanitizeRequest(*req))
 
 	var reuseAccessPoint bool
-	var err error
 	volumeParams := req.GetParameters()
 	volName := req.GetName()
 	clientToken := volName
@@ -480,12 +481,13 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 	}, nil
 }
 
-func (d *Driver) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequest) (*csi.DeleteVolumeResponse, error) {
+func (d *Driver) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequest) (_ *csi.DeleteVolumeResponse, err error) {
+	start := time.Now()
+	defer func() { recordOperationMetrics("DeleteVolume", start, err) }()
 	var (
 		localCloud             cloud.Cloud
 		roleArn                string
 		crossAccountDNSEnabled bool
-		err                    error
 	)
 
 	localCloud, roleArn, crossAccountDNSEnabled, err = getCloud(req.GetSecrets(), d)

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -57,6 +57,7 @@ type Driver struct {
 	volumeAttachLimit        int64
 	forceUnmountAfterTimeout bool
 	unmountTimeout           time.Duration
+	metricsAddr              string
 }
 
 func NewDriver(options *Options, efsUtilsCfgPath string) *Driver {
@@ -87,6 +88,7 @@ func NewDriver(options *Options, efsUtilsCfgPath string) *Driver {
 		volumeAttachLimit:        getVolumeAttachLimit(*options.VolumeAttachLimitOptIn, *options.VolumeAttachLimit),
 		forceUnmountAfterTimeout: *options.ForceUnmountAfterTimeout,
 		unmountTimeout:           *options.UnmountTimeout,
+		metricsAddr:              *options.MetricsAddr,
 	}
 }
 
@@ -138,6 +140,10 @@ func (d *Driver) Run() error {
 	reaper := newReaper()
 	klog.Info("Starting reaper")
 	reaper.start()
+
+	if d.metricsAddr != "" {
+		StartMetricsServer(d.metricsAddr)
+	}
 
 	// Remove taint from node to indicate driver startup success
 	// This is done at the last possible moment to prevent race conditions or false positive removals

--- a/pkg/driver/metrics.go
+++ b/pkg/driver/metrics.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package driver
+
+import (
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"k8s.io/klog/v2"
+)
+
+const (
+	metricsSubsystem = "efs_csi_controller"
+)
+
+var (
+	operationTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: metricsSubsystem,
+			Name:      "operations_total",
+			Help:      "Total number of CSI controller operations.",
+		},
+		[]string{"operation", "status"},
+	)
+
+	operationDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Subsystem: metricsSubsystem,
+			Name:      "operation_duration_seconds",
+			Help:      "Latency of CSI controller operations in seconds.",
+			Buckets:   prometheus.ExponentialBuckets(0.1, 2, 10),
+		},
+		[]string{"operation"},
+	)
+)
+
+func init() {
+	prometheus.MustRegister(operationTotal, operationDuration)
+}
+
+// recordOperationMetrics records the result and duration of a controller operation.
+func recordOperationMetrics(operation string, start time.Time, err error) {
+	duration := time.Since(start).Seconds()
+	operationDuration.WithLabelValues(operation).Observe(duration)
+	status := "success"
+	if err != nil {
+		status = "error"
+	}
+	operationTotal.WithLabelValues(operation, status).Inc()
+}
+
+// StartMetricsServer starts an HTTP server to expose Prometheus metrics.
+func StartMetricsServer(addr string) {
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.Handler())
+	server := &http.Server{Addr: addr, Handler: mux}
+	klog.Infof("Starting metrics server on %s", addr)
+	go func() {
+		if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			klog.Errorf("Metrics server failed: %v", err)
+		}
+	}()
+}

--- a/pkg/driver/metrics_test.go
+++ b/pkg/driver/metrics_test.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package driver
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func TestRecordOperationMetrics(t *testing.T) {
+	tests := []struct {
+		name      string
+		operation string
+		err       error
+		wantLabel string
+	}{
+		{
+			name:      "success",
+			operation: "CreateVolume",
+			err:       nil,
+			wantLabel: "success",
+		},
+		{
+			name:      "error",
+			operation: "DeleteVolume",
+			err:       errors.New("some error"),
+			wantLabel: "error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			operationTotal.Reset()
+			operationDuration.Reset()
+
+			start := time.Now().Add(-100 * time.Millisecond)
+			recordOperationMetrics(tt.operation, start, tt.err)
+
+			counter := operationTotal.WithLabelValues(tt.operation, tt.wantLabel)
+			if got := testutil.ToFloat64(counter); got != 1 {
+				t.Errorf("expected counter to be 1, got %f", got)
+			}
+		})
+	}
+}

--- a/pkg/driver/options.go
+++ b/pkg/driver/options.go
@@ -37,6 +37,7 @@ type Options struct {
 	S3FilesCloudWatchMetricsEnabled *bool
 	EfsUtilsConfOverrides           *string
 	S3FilesUtilsConfOverrides       *string
+	MetricsAddr                     *string
 
 	efsUtilsConfOverridesParsed     []ConfOverride
 	s3filesUtilsConfOverridesParsed []ConfOverride
@@ -68,6 +69,7 @@ func NewOptions() *Options {
 		S3FilesCloudWatchMetricsEnabled: flag.Bool("s3files-cloudwatch-metrics-enabled", true, "Enable CloudWatch metrics emission for S3 files in s3files-utils.conf."),
 		EfsUtilsConfOverrides:           flag.String("efs-utils-conf-overrides", "", "Comma-separated section:key=value overrides applied to efs-utils.conf. These take precedence over other flags that control the same config (e.g., efs-cloudwatch-log-enabled)."),
 		S3FilesUtilsConfOverrides:       flag.String("s3files-utils-conf-overrides", "", "Comma-separated section:key=value overrides applied to s3files-utils.conf. These take precedence over other flags that control the same config (e.g., s3files-cloudwatch-log-enabled, s3files-cloudwatch-metrics-enabled)."),
+		MetricsAddr:                     flag.String("metrics-addr", "", "Address to serve Prometheus metrics on (e.g. :8080). Disabled if empty."),
 	}
 }
 


### PR DESCRIPTION
Fixes #1787

## Summary

Adds Prometheus metrics to the EFS CSI controller for `CreateVolume` and `DeleteVolume` operations, enabling observability for provisioning performance and failures.

## Metrics

| Metric | Type | Labels | Description |
|--------|------|--------|-------------|
| `efs_csi_controller_operations_total` | Counter | operation, status | Total provisioning operations (success/error) |
| `efs_csi_controller_operation_duration_seconds` | Histogram | operation | Latency of provisioning operations |

## Configuration

New flag: `--metrics-addr` (default: empty/disabled)

When set (e.g. `--metrics-addr=:8080`), starts an HTTP server exposing metrics at `/metrics`. When empty, no server is started — fully backwards compatible.

## Testing

- Added unit test for `recordOperationMetrics` (table-driven, covers success and error paths)
- `make test` passes
- `make verify` passes (gofmt, govet, golint)