### PR TITLE
Add AmazonS3FilesClientFullAccess to efs-csi-node-sa

### DIFF
--- a/hack/eksctl-patch.yaml
+++ b/hack/eksctl-patch.yaml
@@ -14,3 +14,13 @@ iam:
       attachPolicyARNs:
       - arn:aws:iam::aws:policy/service-role/AmazonS3FilesCSIDriverPolicy
       - arn:aws:iam::aws:policy/service-role/AmazonEFSCSIDriverPolicy
+
+managedNodeGroups:
+  - name: ng-default
+    iam:
+      attachPolicyARNs:
+      - arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy
+      - arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy
+      - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly
+      - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
+      - arn:aws:iam::aws:policy/AmazonS3FilesClientFullAccess

--- a/hack/kops-patch.yaml
+++ b/hack/kops-patch.yaml
@@ -5,6 +5,7 @@ spec:
       - arn:aws:iam::aws:policy/service-role/AmazonEFSCSIDriverPolicy
       - arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess
       - arn:aws:iam::aws:policy/AmazonElasticFileSystemsUtils
+      - arn:aws:iam::aws:policy/AmazonS3FilesClientFullAccess
   cloudConfig:
     awsEBSCSIDriver:
       managed: true


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
bug fix

**What is this PR about? / Why do we need it?**
Add `AmazonS3FilesClientFullAccess` to node instance so that e2e tests can be passed.

**What testing is done?** 
Local testing using my personal EKS cluster.
