### PR TITLE
Add support for API metrics in the EFS CSI Driver

### DIFF
--- a/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
+++ b/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
@@ -35,8 +35,15 @@ spec:
         {{- with .Values.controller.podLabels }}
         {{ toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.controller.podAnnotations }}
-      annotations: {{- toYaml . | nindent 8 }}
+      {{- if or .Values.controller.podAnnotations (and .Values.controller.enableMetrics .Values.controller.enablePrometheusAnnotations) }}
+      annotations:
+        {{- with .Values.controller.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- if and .Values.controller.enableMetrics .Values.controller.enablePrometheusAnnotations }}
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "3301"
+        {{- end }}
       {{- end }}
     spec:
       {{- if hasKey .Values.controller "hostNetwork" }}
@@ -85,6 +92,9 @@ spec:
             - --v={{ .Values.controller.logLevel }}
             - --delete-access-point-root-dir={{ hasKey .Values.controller "deleteAccessPointRootDir" | ternary .Values.controller.deleteAccessPointRootDir false }}
             - --debug-logs={{ .Values.debugLogs }}
+            {{- if .Values.controller.enableMetrics }}
+            - --http-endpoint=0.0.0.0:3301
+            {{- end }}
           env:
             - name: CSI_ENDPOINT
               value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
@@ -115,6 +125,11 @@ spec:
             - name: healthz
               containerPort: {{ .Values.controller.healthPort }}
               protocol: TCP
+            {{- if .Values.controller.enableMetrics }}
+            - name: metrics
+              containerPort: 3301
+              protocol: TCP
+            {{- end }}
           {{- with .Values.controller.livenessProbe }}
           livenessProbe:
             {{- toYaml . | nindent 12 }}

--- a/charts/aws-efs-csi-driver/templates/metrics.yaml
+++ b/charts/aws-efs-csi-driver/templates/metrics.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.controller.enableMetrics }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: efs-csi-controller
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: efs-csi-controller
+    {{- include "aws-efs-csi-driver.labels" . | nindent 4 }}
+spec:
+  selector:
+    app: efs-csi-controller
+    {{- include "aws-efs-csi-driver.selectorLabels" . | nindent 4 }}
+  ports:
+  - name: metrics
+    port: 3301
+    targetPort: 3301
+    protocol: TCP
+{{- if .Values.controller.serviceMonitor.enabled }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: efs-csi-controller
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: efs-csi-controller
+    {{- include "aws-efs-csi-driver.labels" . | nindent 4 }}
+spec:
+  endpoints:
+  - interval: 15s
+    path: /metrics
+    port: metrics
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      app: efs-csi-controller
+{{- end }}
+{{- end }}

--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -56,6 +56,15 @@ controller:
   name: efs-csi-controller
   # Number of replicas for the CSI controller service deployment
   replicaCount: 2
+  # enableMetrics enables the Prometheus metrics endpoint on the controller.
+  # When true, the driver exposes metrics on port 3301.
+  enableMetrics: false
+  # enablePrometheusAnnotations adds prometheus.io scrape annotations to the controller pod.
+  enablePrometheusAnnotations: true
+  # serviceMonitor controls creation of Prometheus Operator ServiceMonitor resources.
+  # Requires the Prometheus Operator CRDs to be installed.
+  serviceMonitor:
+    enabled: false
   # Number for the log level verbosity
   logLevel: 2
   # If set, add pv/pvc metadata to plugin create requests as parameters.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/klog/v2"
 
 	"github.com/kubernetes-sigs/aws-efs-csi-driver/pkg/driver"
+	"github.com/kubernetes-sigs/aws-efs-csi-driver/pkg/metrics"
 )
 
 // etcAmazonEfs is the non-negotiable directory that the mount.efs will use for config files. We will create a symlink here.
@@ -65,6 +66,12 @@ func main() {
 	if err != nil {
 		klog.Fatalln(err)
 	}
+	if *options.HTTPEndpoint != "" {
+		r := metrics.InitializeRecorder()
+		r.InitializeAPIMetrics()
+		r.InitializeMetricsHandler(*options.HTTPEndpoint, "/metrics", *options.MetricsCertFile, *options.MetricsKeyFile)
+	}
+
 	drv := driver.NewDriver(options, etcAmazonEfs)
 	if err := drv.Run(); err != nil {
 		klog.Fatalln(err)

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,0 +1,31 @@
+# Driver Metrics
+
+## Overview
+
+The EFS CSI Driver supports emitting metrics via an HTTP endpoint from the controller pod in the standard [Prometheus exposition format](https://prometheus.io/docs/instrumenting/exposition_formats/). Most metrics systems support ingesting the Prometheus format, including [Prometheus](https://prometheus.io/), [CloudWatch](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ContainerInsights-Prometheus-metrics.html), [InfluxDB](https://docs.influxdata.com/influxdb/v1/supported_protocols/prometheus/), and many others.
+
+When installing via Helm, metrics can be configured via Helm parameters:
+- Metrics may be enabled by setting `controller.enableMetrics` to `true`.
+  - This deploys a `Service` object for the controller pod.
+  - By default, the controller pod is annotated with `prometheus.io/scrape` and `prometheus.io/port`. This can be controlled via `controller.enablePrometheusAnnotations`.
+  - Prometheus Operator `ServiceMonitor` resources can be enabled by setting `controller.serviceMonitor.enabled` to `true`. This requires the Prometheus Operator CRDs to be installed.
+
+## AWS API Metrics (`efs-csi-controller`)
+
+The EFS CSI Driver emits [AWS EFS API](https://docs.aws.amazon.com/efs/latest/ug/api-reference.html) metrics to `0.0.0.0:3301/metrics` when `controller.enableMetrics: true` is set in the Helm chart.
+
+The following metrics are supported:
+
+| Metric name | Metric type | Description | Labels |
+|-------------|-------------|-------------|--------|
+| `aws_efs_csi_api_request_duration_seconds` | Histogram | AWS SDK API request duration by request type in seconds | `request=<API operation name>`, `service=<efs\|s3files>` |
+| `aws_efs_csi_api_request_errors_total` | Counter | Total number of AWS SDK API errors by error code and request type | `request=<API operation name>`, `service=<efs\|s3files>`, `code=<error code>` |
+| `aws_efs_csi_api_request_throttles_total` | Counter | Total number of throttled AWS SDK API requests per request type | `request=<API operation name>`, `service=<efs\|s3files>` |
+
+Instrumented EFS API operations (`service="efs"`): `CreateAccessPoint`, `DeleteAccessPoint`, `DescribeAccessPoints`, `DescribeFileSystems`, `DescribeMountTargets`.
+
+Instrumented S3Files API operations (`service="s3files"`): `CreateAccessPoint`, `DeleteAccessPoint`, `ListAccessPoints`, `ListFileSystems`.
+
+## TLS
+
+The metrics endpoint can be served over TLS by providing `--metrics-cert-file` and `--metrics-key-file` flags to the driver.

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,9 @@ require (
 	github.com/mitchellh/go-ps v0.0.0-20170309133038-4fdf99ab2936
 	github.com/onsi/ginkgo/v2 v2.21.0
 	github.com/onsi/gomega v1.35.1
+	github.com/prometheus/client_golang v1.22.0
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56
+	golang.org/x/time v0.9.0
 	google.golang.org/grpc v1.80.0
 	k8s.io/api v0.33.2
 	k8s.io/apimachinery v0.33.2
@@ -103,7 +105,6 @@ require (
 	github.com/opencontainers/runtime-spec v1.2.0 // indirect
 	github.com/opencontainers/selinux v1.13.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/prometheus/client_golang v1.22.0 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.62.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
@@ -129,7 +130,6 @@ require (
 	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/term v0.43.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
-	golang.org/x/time v0.9.0 // indirect
 	golang.org/x/tools v0.44.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260401024825-9d38bb4040a9 // indirect

--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -201,12 +201,18 @@ func createEfsClient(awsRoleArn string, externalId string, metadata MetadataServ
 		}
 		cfg.Credentials = aws.NewCredentialsCache(roleProvider)
 	}
-	return efs.NewFromConfig(cfg)
+	efsOptions := func(o *efs.Options) {
+		o.APIOptions = append(o.APIOptions, RecordRequestsMiddleware("efs"), LogServerErrorsMiddleware())
+	}
+	return efs.NewFromConfig(cfg, efsOptions)
 }
 
 func createS3FilesClient(metadata MetadataService) S3Files {
 	cfg, _ := config.LoadDefaultConfig(context.TODO(), config.WithRegion(metadata.GetRegion()))
-	return s3files.NewFromConfig(cfg)
+	s3Options := func(o *s3files.Options) {
+		o.APIOptions = append(o.APIOptions, RecordRequestsMiddleware("s3files"), LogServerErrorsMiddleware())
+	}
+	return s3files.NewFromConfig(cfg, s3Options)
 }
 
 // validateFIPSRegion checks if FIPS endpoints are requested in a non-US/Canada region

--- a/pkg/cloud/handlers.go
+++ b/pkg/cloud/handlers.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloud
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	awsmiddleware "github.com/aws/aws-sdk-go-v2/aws/middleware"
+	"github.com/aws/aws-sdk-go-v2/aws/retry"
+	smithy "github.com/aws/smithy-go"
+	smithymiddleware "github.com/aws/smithy-go/middleware"
+	"github.com/kubernetes-sigs/aws-efs-csi-driver/pkg/metrics"
+	"k8s.io/klog/v2"
+)
+
+// RecordRequestsMiddleware instruments EFS and S3 Files API calls with Prometheus metrics.
+// It is a no-op when the metrics recorder is not initialized.
+func RecordRequestsMiddleware(service string) func(*smithymiddleware.Stack) error {
+	return func(stack *smithymiddleware.Stack) error {
+		return stack.Finalize.Add(smithymiddleware.FinalizeMiddlewareFunc("RecordRequestsMiddleware",
+			func(ctx context.Context, input smithymiddleware.FinalizeInput, next smithymiddleware.FinalizeHandler) (smithymiddleware.FinalizeOutput, smithymiddleware.Metadata, error) {
+				start := time.Now()
+				output, metadata, err := next.HandleFinalize(ctx, input)
+				duration := time.Since(start).Seconds()
+				labels := createLabels(ctx, service)
+				metrics.Recorder().ObserveHistogram(metrics.APIRequestDuration, metrics.APIRequestDurationHelpText, duration, labels, nil)
+				if err != nil {
+					var apiErr smithy.APIError
+					if errors.As(err, &apiErr) {
+						if _, isThrottle := retry.DefaultThrottleErrorCodes[apiErr.ErrorCode()]; isThrottle {
+							metrics.Recorder().IncreaseCount(metrics.APIRequestThrottles, metrics.APIRequestThrottlesHelpText, labels)
+						} else {
+							labels["code"] = apiErr.ErrorCode()
+							metrics.Recorder().IncreaseCount(metrics.APIRequestErrors, metrics.APIRequestErrorsHelpText, labels)
+						}
+					}
+				}
+				return output, metadata, err
+			}), smithymiddleware.After)
+	}
+}
+
+// LogServerErrorsMiddleware logs errors from the EFS and S3 Files APIs.
+// Throttle errors are logged at high verbosity since they are expected under load.
+// This middleware should always be added last so it sees the unmodified error.
+func LogServerErrorsMiddleware() func(*smithymiddleware.Stack) error {
+	return func(stack *smithymiddleware.Stack) error {
+		return stack.Finalize.Add(smithymiddleware.FinalizeMiddlewareFunc("LogServerErrorsMiddleware",
+			func(ctx context.Context, input smithymiddleware.FinalizeInput, next smithymiddleware.FinalizeHandler) (smithymiddleware.FinalizeOutput, smithymiddleware.Metadata, error) {
+				output, metadata, err := next.HandleFinalize(ctx, input)
+				if err != nil {
+					var apiErr smithy.APIError
+					if errors.As(err, &apiErr) {
+						if _, isThrottle := retry.DefaultThrottleErrorCodes[apiErr.ErrorCode()]; isThrottle {
+							klog.V(4).ErrorS(apiErr, "Throttle error from AWS EFS API")
+						} else {
+							klog.ErrorS(apiErr, "Error from AWS EFS API")
+						}
+					} else {
+						klog.ErrorS(err, "Unknown error attempting to contact AWS EFS API")
+					}
+				}
+				return output, metadata, err
+			}), smithymiddleware.After)
+	}
+}
+
+func createLabels(ctx context.Context, service string) map[string]string {
+	op := awsmiddleware.GetOperationName(ctx)
+	if op == "" {
+		op = "Unknown"
+	}
+	return map[string]string{"request": op, "service": service}
+}

--- a/pkg/driver/options.go
+++ b/pkg/driver/options.go
@@ -37,6 +37,9 @@ type Options struct {
 	S3FilesCloudWatchMetricsEnabled *bool
 	EfsUtilsConfOverrides           *string
 	S3FilesUtilsConfOverrides       *string
+	HTTPEndpoint                    *string
+	MetricsCertFile                 *string
+	MetricsKeyFile                  *string
 
 	efsUtilsConfOverridesParsed     []ConfOverride
 	s3filesUtilsConfOverridesParsed []ConfOverride
@@ -68,6 +71,9 @@ func NewOptions() *Options {
 		S3FilesCloudWatchMetricsEnabled: flag.Bool("s3files-cloudwatch-metrics-enabled", true, "Enable CloudWatch metrics emission for S3 files in s3files-utils.conf."),
 		EfsUtilsConfOverrides:           flag.String("efs-utils-conf-overrides", "", "Comma-separated section:key=value overrides applied to efs-utils.conf. These take precedence over other flags that control the same config (e.g., efs-cloudwatch-log-enabled)."),
 		S3FilesUtilsConfOverrides:       flag.String("s3files-utils-conf-overrides", "", "Comma-separated section:key=value overrides applied to s3files-utils.conf. These take precedence over other flags that control the same config (e.g., s3files-cloudwatch-log-enabled, s3files-cloudwatch-metrics-enabled)."),
+		HTTPEndpoint:                    flag.String("http-endpoint", "", "TCP network address for the Prometheus metrics HTTP server (e.g. 0.0.0.0:3301). Disabled when empty."),
+		MetricsCertFile:                 flag.String("metrics-cert-file", "", "Path to the TLS certificate file for the metrics server. Requires --metrics-key-file."),
+		MetricsKeyFile:                  flag.String("metrics-key-file", "", "Path to the TLS private key file for the metrics server. Requires --metrics-cert-file."),
 	}
 }
 

--- a/pkg/metrics/constants.go
+++ b/pkg/metrics/constants.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+const (
+	APIRequestDuration          = "aws_efs_csi_api_request_duration_seconds"
+	APIRequestErrors            = "aws_efs_csi_api_request_errors_total"
+	APIRequestThrottles         = "aws_efs_csi_api_request_throttles_total"
+	APIRequestDurationHelpText  = "AWS SDK API request duration by request type in seconds"
+	APIRequestErrorsHelpText    = "Total number of AWS SDK API errors by error code and request type"
+	APIRequestThrottlesHelpText = "Total number of throttled AWS SDK API requests per request type"
+)

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,0 +1,221 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"net/http"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"golang.org/x/time/rate"
+	"k8s.io/klog/v2"
+)
+
+const (
+	metricsRateLimit = 5  // requests per second
+	metricsRateBurst = 10 // burst capacity
+)
+
+var (
+	r    *MetricRecorder
+	once sync.Once
+
+	efsOperations = []string{
+		"CreateAccessPoint",
+		"DeleteAccessPoint",
+		"DescribeAccessPoints",
+		"DescribeFileSystems",
+		"DescribeMountTargets",
+	}
+	s3FilesOperations = []string{
+		"CreateAccessPoint",
+		"DeleteAccessPoint",
+		"ListAccessPoints",
+		"ListFileSystems",
+	}
+)
+
+type MetricRecorder struct {
+	mu       sync.RWMutex
+	registry *prometheus.Registry
+	metrics  map[string]any
+}
+
+// Recorder returns the singleton MetricRecorder, or nil if not yet initialized.
+func Recorder() *MetricRecorder {
+	return r
+}
+
+// InitializeRecorder creates the singleton MetricRecorder and returns it.
+func InitializeRecorder() *MetricRecorder {
+	once.Do(func() {
+		r = &MetricRecorder{
+			registry: prometheus.NewRegistry(),
+			metrics:  make(map[string]any),
+		}
+	})
+	return r
+}
+
+// InitializeAPIMetrics pre-registers the duration histogram for all known EFS and S3Files
+// operations so that zero-value time series exist before any requests are made.
+func (m *MetricRecorder) InitializeAPIMetrics() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, exists := m.metrics[APIRequestDuration]; !exists {
+		metric := m.registerHistogramVecLocked(APIRequestDuration, APIRequestDurationHelpText, []string{"request", "service"}, nil)
+		for _, op := range efsOperations {
+			metric.WithLabelValues(op, "efs")
+		}
+		for _, op := range s3FilesOperations {
+			metric.WithLabelValues(op, "s3files")
+		}
+	}
+}
+
+// InitializeMetricsHandler starts a rate-limited HTTP server exposing Prometheus metrics.
+func (m *MetricRecorder) InitializeMetricsHandler(address, path, certFile, keyFile string) {
+	if m == nil {
+		klog.InfoS("InitializeMetricsHandler: metric recorder is not initialized")
+		return
+	}
+
+	limiter := rate.NewLimiter(metricsRateLimit, metricsRateBurst)
+	mux := http.NewServeMux()
+	metricsHandler := promhttp.HandlerFor(m.registry, promhttp.HandlerOpts{ErrorHandling: promhttp.ContinueOnError})
+	mux.Handle(path, rateLimitMiddleware(limiter, metricsHandler))
+
+	server := &http.Server{
+		Addr:         address,
+		Handler:      mux,
+		ReadTimeout:  3 * time.Second,
+		WriteTimeout: 5 * time.Second,
+	}
+
+	go func() {
+		var err error
+		klog.InfoS("Metric server listening", "address", address, "path", path)
+		if certFile != "" {
+			err = server.ListenAndServeTLS(certFile, keyFile)
+		} else {
+			err = server.ListenAndServe()
+		}
+		if err != nil && err != http.ErrServerClosed {
+			klog.ErrorS(err, "Failed to start metric server", "address", address, "path", path)
+			klog.FlushAndExit(klog.ExitFlushTimeout, 1)
+		}
+	}()
+}
+
+// IncreaseCount increments the named counter metric by 1.
+func (m *MetricRecorder) IncreaseCount(name, helpText string, labels map[string]string) {
+	if m == nil {
+		return
+	}
+
+	m.mu.RLock()
+	metric, ok := m.metrics[name]
+	m.mu.RUnlock()
+	if !ok {
+		m.mu.Lock()
+		if _, exists := m.metrics[name]; !exists {
+			klog.V(4).InfoS("Metric not found, registering", "name", name, "labels", labels)
+			m.registerCounterVecLocked(name, helpText, getLabelNames(labels))
+		}
+		metric = m.metrics[name]
+		m.mu.Unlock()
+	}
+
+	if cv, ok := metric.(*prometheus.CounterVec); ok {
+		cv.With(labels).Inc()
+	} else {
+		klog.V(4).InfoS("Could not assert metric as CounterVec", "name", name)
+	}
+}
+
+// ObserveHistogram records value in the named histogram metric.
+func (m *MetricRecorder) ObserveHistogram(name, helpText string, value float64, labels map[string]string, buckets []float64) {
+	if m == nil {
+		return
+	}
+
+	m.mu.RLock()
+	metric, ok := m.metrics[name]
+	m.mu.RUnlock()
+	if !ok {
+		m.mu.Lock()
+		if _, exists := m.metrics[name]; !exists {
+			klog.V(4).InfoS("Metric not found, registering", "name", name, "labels", labels)
+			m.registerHistogramVecLocked(name, helpText, getLabelNames(labels), buckets)
+		}
+		metric = m.metrics[name]
+		m.mu.Unlock()
+	}
+
+	if hv, ok := metric.(*prometheus.HistogramVec); ok {
+		hv.With(labels).Observe(value)
+	} else {
+		klog.V(4).InfoS("Could not assert metric as HistogramVec", "name", name)
+	}
+}
+
+func rateLimitMiddleware(limiter *rate.Limiter, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !limiter.Allow() {
+			http.Error(w, "Rate limit exceeded", http.StatusTooManyRequests)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// registerHistogramVecLocked registers a HistogramVec. Callers must hold m.mu.
+func (m *MetricRecorder) registerHistogramVecLocked(name, help string, labels []string, buckets []float64) *prometheus.HistogramVec {
+	if metric, exists := m.metrics[name]; exists {
+		if hv, ok := metric.(*prometheus.HistogramVec); ok {
+			return hv
+		}
+		klog.ErrorS(nil, "Metric exists but is not a HistogramVec", "name", name)
+		return nil
+	}
+	hv := prometheus.NewHistogramVec(prometheus.HistogramOpts{Name: name, Help: help, Buckets: buckets}, labels)
+	m.metrics[name] = hv
+	m.registry.MustRegister(hv)
+	return hv
+}
+
+// registerCounterVecLocked registers a CounterVec. Callers must hold m.mu.
+func (m *MetricRecorder) registerCounterVecLocked(name, help string, labels []string) {
+	if _, exists := m.metrics[name]; exists {
+		return
+	}
+	cv := prometheus.NewCounterVec(prometheus.CounterOpts{Name: name, Help: help}, labels)
+	m.metrics[name] = cv
+	m.registry.MustRegister(cv)
+}
+
+func getLabelNames(labels map[string]string) []string {
+	names := make([]string, 0, len(labels))
+	for k := range labels {
+		names = append(names, k)
+	}
+	sort.Strings(names)
+	return names
+}

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func newTestRecorder() *MetricRecorder {
+	return &MetricRecorder{
+		registry: prometheus.NewRegistry(),
+		metrics:  make(map[string]any),
+	}
+}
+
+func TestMetricRecorder(t *testing.T) {
+	tests := []struct {
+		name     string
+		exec     func(m *MetricRecorder)
+		expected string
+	}{
+		{
+			name: "IncreaseCounterMetric",
+			exec: func(m *MetricRecorder) {
+				m.IncreaseCount("test_total", "help text", map[string]string{"key": "value"})
+			},
+			expected: `
+# HELP test_total help text
+# TYPE test_total counter
+test_total{key="value"} 1
+			`,
+		},
+		{
+			name: "ObserveHistogramMetric",
+			exec: func(m *MetricRecorder) {
+				m.ObserveHistogram("test", "help text", 1.5, map[string]string{"key": "value"}, []float64{1, 2, 3})
+			},
+			expected: `
+# HELP test help text
+# TYPE test histogram
+test_bucket{key="value",le="1"} 0
+test_bucket{key="value",le="2"} 1
+test_bucket{key="value",le="3"} 1
+test_bucket{key="value",le="+Inf"} 1
+test_sum{key="value"} 1.5
+test_count{key="value"} 1
+			`,
+		},
+		{
+			name: "Re-register metric",
+			exec: func(m *MetricRecorder) {
+				m.IncreaseCount("test_re_register_total", "help text", map[string]string{"key": "value1"})
+				m.mu.Lock()
+				m.registerCounterVecLocked("test_re_register_total", "help text", []string{"key"})
+				m.mu.Unlock()
+				m.IncreaseCount("test_re_register_total", "help text", map[string]string{"key": "value1"})
+				m.IncreaseCount("test_re_register_total", "help text", map[string]string{"key": "value2"})
+			},
+			expected: `
+# HELP test_re_register_total help text
+# TYPE test_re_register_total counter
+test_re_register_total{key="value1"} 2
+test_re_register_total{key="value2"} 1
+			`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := newTestRecorder()
+			tt.exec(m)
+			if err := testutil.GatherAndCompare(m.registry, strings.NewReader(tt.expected), getMetricNameFromExpected(tt.expected)); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestNilRecorderIsNoop(t *testing.T) {
+	var rec *MetricRecorder
+	rec.IncreaseCount("anything", "help", map[string]string{"k": "v"})
+	rec.ObserveHistogram("anything", "help", 1.0, map[string]string{"k": "v"}, nil)
+}
+
+func TestRecorderSingleton(t *testing.T) {
+	once = sync.Once{}
+	r = nil
+
+	r1 := InitializeRecorder()
+	r2 := InitializeRecorder()
+
+	if r1 != r2 {
+		t.Error("InitializeRecorder must return the same singleton on repeated calls")
+	}
+}
+
+func getMetricNameFromExpected(expected string) string {
+	for line := range strings.SplitSeq(expected, "\n") {
+		if strings.Contains(line, "{") {
+			return strings.Split(line, "{")[0]
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
I recently left comments about this on https://github.com/kubernetes-sigs/aws-efs-csi-driver/pull/1901 but that PR was closed, so I opened this.

**Is this a bug fix or adding new feature?**

New feature

**What is this PR about? / Why do we need it?**

This PR adds support for EFS API CSI Driver prometheus metrics. This helps driver operators gain better clarity on failure and monitor request latencies. The structure and implementation of this is modeled after the FSx CSI driver PR ([#497](https://github.com/kubernetes-sigs/aws-fsx-csi-driver/pull/497))/issue ([#492](https://github.com/kubernetes-sigs/aws-fsx-csi-driver/issues/492)), which is modeled after the [EBS CSI Driver](https://github.com/kubernetes-sigs/aws-ebs-csi-driver).

This adds the following driver metrics:

| Metric name | Type | Description | Labels |
  |---|---|---|---|
  | `aws_efs_csi_api_request_duration_seconds` | Histogram | AWS SDK API request duration by request type in seconds | `request`, `service` |
  | `aws_efs_csi_api_request_errors_total` | Counter | Total number of AWS SDK API errors by error code and request type | `request`, `service`, `code` |
  | `aws_efs_csi_api_request_throttles_total` | Counter | Total number of throttled AWS SDK API requests per request type | `request`, `service` |

**What testing is done?** 
Tested internally on Netflix's K8s platform.

Here's some output from the metrics endpoint running `grep aws_efs_csi`:

```
# HELP aws_efs_csi_api_request_duration_seconds AWS SDK API request duration by request type in seconds
# TYPE aws_efs_csi_api_request_duration_seconds histogram
aws_efs_csi_api_request_duration_seconds_bucket{request="CreateAccessPoint",service="efs",le="0.005"} 0
aws_efs_csi_api_request_duration_seconds_bucket{request="CreateAccessPoint",service="efs",le="0.01"} 0
aws_efs_csi_api_request_duration_seconds_bucket{request="CreateAccessPoint",service="efs",le="0.025"} 0
aws_efs_csi_api_request_duration_seconds_bucket{request="CreateAccessPoint",service="efs",le="0.05"} 0
aws_efs_csi_api_request_duration_seconds_bucket{request="CreateAccessPoint",service="efs",le="0.1"} 0
aws_efs_csi_api_request_duration_seconds_bucket{request="CreateAccessPoint",service="efs",le="0.25"} 1
aws_efs_csi_api_request_duration_seconds_bucket{request="CreateAccessPoint",service="efs",le="0.5"} 1
aws_efs_csi_api_request_duration_seconds_bucket{request="CreateAccessPoint",service="efs",le="1"} 1
aws_efs_csi_api_request_duration_seconds_bucket{request="CreateAccessPoint",service="efs",le="2.5"} 1
aws_efs_csi_api_request_duration_seconds_bucket{request="CreateAccessPoint",service="efs",le="5"} 1
aws_efs_csi_api_request_duration_seconds_bucket{request="CreateAccessPoint",service="efs",le="10"} 1
aws_efs_csi_api_request_duration_seconds_bucket{request="CreateAccessPoint",service="efs",le="+Inf"} 1
aws_efs_csi_api_request_duration_seconds_sum{request="CreateAccessPoint",service="efs"} 0.117716083
aws_efs_csi_api_request_duration_seconds_count{request="CreateAccessPoint",service="efs"} 1
...
```
