### PR TITLE
Move AmazonS3FilesClientFullAccess to efs-csi-node-sa

### DIFF
--- a/hack/eksctl-patch.yaml
+++ b/hack/eksctl-patch.yaml
@@ -6,6 +6,7 @@ iam:
         name: efs-csi-node-sa
         namespace: kube-system
       attachPolicyARNs:
+      - arn:aws:iam::aws:policy/AmazonS3FilesClientFullAccess
       - arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess
       - arn:aws:iam::aws:policy/AmazonElasticFileSystemsUtils
     - metadata:


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
bug fix for E2E test

**What is this PR about? / Why do we need it?**
Move AmazonS3FilesClientFullAccess to efs-csi-node-sa since STS endpoint resolution issue is fixed in efs-utils

**What testing is done?** 
