### PR TITLE
reuseAccessPoint precheck must validate the existing access point against the requested StorageClass constraints instead of binding to it unconditionally

### DIFF
--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -142,12 +142,14 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 		azName                 string
 		basePath               string
 		gid                    int64
+		gidSpecified           bool
 		gidMin                 int64
 		gidMax                 int64
 		localCloud             cloud.Cloud
 		provisioningMode       string
 		roleArn                string
 		uid                    int64
+		uidSpecified           bool
 		crossAccountDNSEnabled bool
 		fsType                 util.FileSystemType
 	)
@@ -202,6 +204,13 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 		return nil, err
 	}
 
+	// Parse the StorageClass-driven access point constraints (base path, POSIX
+	// uid/gid and gid range).
+	basePath, uid, uidSpecified, gid, gidSpecified, gidMin, gidMax, err = parseAccessPointConstraints(volumeParams)
+	if err != nil {
+		return nil, err
+	}
+
 	var accessPoint *cloud.AccessPoint
 	//if reuseAccessPoint is true, check for AP with same Root Directory exists in efs
 	// if found reuse that AP
@@ -213,6 +222,12 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 		if existingAP != nil {
 			//AP path already exists
 			klog.V(2).Infof("Existing AccessPoint found : %+v", existingAP)
+
+			// Enforce the same validation that the CreateAccessPoint ErrAlreadyExists path applies before reusing it.
+			if err = validateExistingAccessPoint(existingAP, basePath, gid, gidSpecified, uid, uidSpecified, gidMin, gidMax); err != nil {
+				return nil, status.Errorf(codes.AlreadyExists, "Invalid existing access point: %v", err)
+			}
+
 			accessPoint = &cloud.AccessPoint{
 				AccessPointId: existingAP.AccessPointId,
 				FileSystemId:  existingAP.FileSystemId,
@@ -242,67 +257,6 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 		}
 
 		accessPointsOptions.Tags = tags
-
-		uid = -1
-		var uidSpecified = false
-		if value, ok := volumeParams[Uid]; ok {
-			uid, err = strconv.ParseInt(value, 10, 64)
-			if err != nil {
-				return nil, status.Errorf(codes.InvalidArgument, "Failed to parse invalid %v: %v", Uid, err)
-			}
-			if uid < 0 {
-				return nil, status.Errorf(codes.InvalidArgument, "%v must be greater or equal than 0", Uid)
-			}
-			uidSpecified = true
-		}
-
-		gid = -1
-		var gidSpecified = false
-		if value, ok := volumeParams[Gid]; ok {
-			gid, err = strconv.ParseInt(value, 10, 64)
-			if err != nil {
-				return nil, status.Errorf(codes.InvalidArgument, "Failed to parse invalid %v: %v", Gid, err)
-			}
-			if gid < 0 {
-				return nil, status.Errorf(codes.InvalidArgument, "%v must be greater or equal than 0", Gid)
-			}
-			gidSpecified = true
-		}
-
-		if value, ok := volumeParams[GidMin]; ok {
-			gidMin, err = strconv.ParseInt(value, 10, 64)
-			if err != nil {
-				return nil, status.Errorf(codes.InvalidArgument, "Failed to parse invalid %v: %v", GidMin, err)
-			}
-			if gidMin <= 0 {
-				return nil, status.Errorf(codes.InvalidArgument, "%v must be greater than 0", GidMin)
-			}
-		}
-
-		if value, ok := volumeParams[GidMax]; ok {
-			// Ensure GID min is provided with GID max
-			if gidMin == 0 {
-				return nil, status.Errorf(codes.InvalidArgument, "Missing %v parameter", GidMin)
-			}
-			gidMax, err = strconv.ParseInt(value, 10, 64)
-			if err != nil {
-				return nil, status.Errorf(codes.InvalidArgument, "Failed to parse invalid %v: %v", GidMax, err)
-			}
-			if gidMax <= gidMin {
-				return nil, status.Errorf(codes.InvalidArgument, "%v must be greater than %v", GidMax, GidMin)
-			}
-		} else {
-			// Ensure GID max is provided with GID min
-			if gidMin != 0 {
-				return nil, status.Errorf(codes.InvalidArgument, "Missing %v parameter", GidMax)
-			}
-		}
-
-		// Assign default GID ranges if not provided
-		if gidMin == 0 && gidMax == 0 {
-			gidMin = DefaultGidMin
-			gidMax = DefaultGidMax
-		}
 
 		if value, ok := volumeParams[DirectoryPerms]; ok {
 			accessPointsOptions.DirectoryPerms = value
@@ -343,10 +297,6 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 		}
 		if gid == -1 {
 			gid = allocatedGid
-		}
-
-		if value, ok := volumeParams[BasePath]; ok {
-			basePath = value
 		}
 
 		rootDirName := volName
@@ -831,6 +781,75 @@ func validatePathRequirements(proposedPath string) (bool, error) {
 	} else {
 		return true, nil
 	}
+}
+
+// parseAccessPointConstraints parses the StorageClass parameters that define
+// the requested access point's base path and POSIX identity.
+func parseAccessPointConstraints(volumeParams map[string]string) (basePath string, uid int64, uidSpecified bool, gid int64, gidSpecified bool, gidMin int64, gidMax int64, err error) {
+	uid = -1
+	if value, ok := volumeParams[Uid]; ok {
+		uid, err = strconv.ParseInt(value, 10, 64)
+		if err != nil {
+			return "", 0, false, 0, false, 0, 0, status.Errorf(codes.InvalidArgument, "Failed to parse invalid %v: %v", Uid, err)
+		}
+		if uid < 0 {
+			return "", 0, false, 0, false, 0, 0, status.Errorf(codes.InvalidArgument, "%v must be greater or equal than 0", Uid)
+		}
+		uidSpecified = true
+	}
+
+	gid = -1
+	if value, ok := volumeParams[Gid]; ok {
+		gid, err = strconv.ParseInt(value, 10, 64)
+		if err != nil {
+			return "", 0, false, 0, false, 0, 0, status.Errorf(codes.InvalidArgument, "Failed to parse invalid %v: %v", Gid, err)
+		}
+		if gid < 0 {
+			return "", 0, false, 0, false, 0, 0, status.Errorf(codes.InvalidArgument, "%v must be greater or equal than 0", Gid)
+		}
+		gidSpecified = true
+	}
+
+	if value, ok := volumeParams[GidMin]; ok {
+		gidMin, err = strconv.ParseInt(value, 10, 64)
+		if err != nil {
+			return "", 0, false, 0, false, 0, 0, status.Errorf(codes.InvalidArgument, "Failed to parse invalid %v: %v", GidMin, err)
+		}
+		if gidMin <= 0 {
+			return "", 0, false, 0, false, 0, 0, status.Errorf(codes.InvalidArgument, "%v must be greater than 0", GidMin)
+		}
+	}
+
+	if value, ok := volumeParams[GidMax]; ok {
+		// Ensure GID min is provided with GID max
+		if gidMin == 0 {
+			return "", 0, false, 0, false, 0, 0, status.Errorf(codes.InvalidArgument, "Missing %v parameter", GidMin)
+		}
+		gidMax, err = strconv.ParseInt(value, 10, 64)
+		if err != nil {
+			return "", 0, false, 0, false, 0, 0, status.Errorf(codes.InvalidArgument, "Failed to parse invalid %v: %v", GidMax, err)
+		}
+		if gidMax <= gidMin {
+			return "", 0, false, 0, false, 0, 0, status.Errorf(codes.InvalidArgument, "%v must be greater than %v", GidMax, GidMin)
+		}
+	} else {
+		// Ensure GID max is provided with GID min
+		if gidMin != 0 {
+			return "", 0, false, 0, false, 0, 0, status.Errorf(codes.InvalidArgument, "Missing %v parameter", GidMax)
+		}
+	}
+
+	// Assign default GID ranges if not provided
+	if gidMin == 0 && gidMax == 0 {
+		gidMin = DefaultGidMin
+		gidMax = DefaultGidMax
+	}
+
+	if value, ok := volumeParams[BasePath]; ok {
+		basePath = value
+	}
+
+	return basePath, uid, uidSpecified, gid, gidSpecified, gidMin, gidMax, nil
 }
 
 func get64LenHash(text string) string {

--- a/pkg/driver/controller_test.go
+++ b/pkg/driver/controller_test.go
@@ -972,6 +972,73 @@ func TestCreateVolume(t *testing.T) {
 			},
 		},
 		{
+			name: "Fail: reuseAccessPoint precheck rejects existing access point that violates requested StorageClass basePath and UID/GID",
+			testFunc: func(t *testing.T) {
+				// reuseAccessPoint precheck must validate the existing access
+				// point against the requested StorageClass constraints instead
+				// of binding to it unconditionally. A requester who can choose
+				// the PVC name (which derives the reuse client token) must not
+				// be able to bind to an access point rooted under a different
+				// base path or with a different POSIX identity.
+				mockCtl := gomock.NewController(t)
+				mockCloud := mocks.NewMockCloud(mockCtl)
+
+				driver := &Driver{
+					endpoint:     endpoint,
+					cloud:        mockCloud,
+					gidAllocator: NewGidAllocator(),
+					lockManager:  NewLockManagerMap(),
+					tags:         parseTagsFromStr(""),
+				}
+				pvcNameVal := "shared-claim"
+
+				req := &csi.CreateVolumeRequest{
+					Name: volumeName,
+					VolumeCapabilities: []*csi.VolumeCapability{
+						stdVolCap,
+					},
+					CapacityRange: &csi.CapacityRange{
+						RequiredBytes: capacityRange,
+					},
+					Parameters: map[string]string{
+						ProvisioningMode:    "efs-ap",
+						FsId:                fsId,
+						BasePath:            "/tenant-a",
+						Uid:                 "1000",
+						Gid:                 "1000",
+						DirectoryPerms:      "777",
+						ReuseAccessPointKey: "true",
+						PvcNameKey:          pvcNameVal,
+					},
+				}
+
+				ctx := context.Background()
+
+				// Existing access point belonging to a different tenant: rooted
+				// under /tenant-b and owned by uid/gid 2000.
+				existingAP := &cloud.AccessPoint{
+					AccessPointId:      apId,
+					FileSystemId:       fsId,
+					AccessPointRootDir: "/tenant-b/shared-claim",
+					PosixUser: &cloud.PosixUser{
+						Gid: 2000,
+						Uid: 2000,
+					},
+				}
+				mockCloud.EXPECT().FindAccessPointByClientToken(gomock.Eq(ctx), gomock.Any(), gomock.Eq(fsId), gomock.Eq(util.FileSystemTypeEFS)).Return(existingAP, nil)
+
+				_, err := driver.CreateVolume(ctx, req)
+				if err == nil {
+					t.Fatal("CreateVolume should have rejected the mismatched existing access point")
+				}
+				if status.Code(err) != codes.AlreadyExists {
+					t.Fatalf("Expected error code %v, got %v (err: %v)", codes.AlreadyExists, status.Code(err), err)
+				}
+
+				mockCtl.Finish()
+			},
+		},
+		{
 			name: "Success: reuseAccessPointName is true with existing access point not found",
 			testFunc: func(t *testing.T) {
 				mockCtl := gomock.NewController(t)


### PR DESCRIPTION
reuseAccessPoint precheck must validate the existing access point against the requested StorageClass constraints instead of binding to it unconditionally

**Is this a bug fix or adding new feature?**

**What is this PR about? / Why do we need it?**

**What testing is done?** 
