### PR TITLE
Adds the `aws-efs-csi-driver.selectorLabels` template helper

### DIFF
--- a/charts/aws-efs-csi-driver/templates/_helpers.tpl
+++ b/charts/aws-efs-csi-driver/templates/_helpers.tpl
@@ -45,6 +45,16 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
 
 {{/*
+Common selector labels
+*/}}
+{{- define "aws-efs-csi-driver.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "aws-efs-csi-driver.name" . }}
+{{- if ne .Release.Name "kustomize" }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+{{- end -}}
+
+{{/*
 Create a string out of the map for controller tags flag
 */}}
 {{- define "aws-efs-csi-driver.tags" -}}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

New feature

**What is this PR about? / Why do we need it?**

Adding the selectorLabels template helper to align with aws-ebs-csi-driver and aws-fsx-csi-driver. This is needed by the metrics feature (PR #1903).

**What testing is done?** 
```

helm template test ./charts/aws-efs-csi-driver > /dev/null && echo "OK"
OK
```