### PR TITLE
fix: Validate access point filesystem ownership in DeleteVolume

### DIFF
--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -388,6 +388,12 @@ func (c *cloud) DescribeAccessPoint(ctx context.Context, accessPointId string, f
 			return nil, fmt.Errorf("DescribeAccessPoint failed. Expected exactly 1 access point in DescribeAccessPoint result. However, received %d access points", len(accessPoints))
 		}
 
+		// Verify the access point belongs to the expected filesystem.
+		if *accessPoints[0].FileSystemId != fileSystemId {
+			return nil, fmt.Errorf("access point %s does not belong to filesystem %s",
+				accessPointId, fileSystemId)
+		}
+
 		return &AccessPoint{
 			AccessPointId:      *accessPoints[0].AccessPointId,
 			FileSystemId:       *accessPoints[0].FileSystemId,

--- a/pkg/cloud/cloud_test.go
+++ b/pkg/cloud/cloud_test.go
@@ -520,6 +520,49 @@ func TestDescribeAccessPoint(t *testing.T) {
 				mockctl.Finish()
 			},
 		},
+		{
+			name: "Fail: Access point belongs to different filesystem",
+			testFunc: func(t *testing.T) {
+				mockctl, c, mockEfs, _ := setupTest(t)
+
+				differentFsId := "fs-differentfs"
+				output := &efs.DescribeAccessPointsOutput{
+					AccessPoints: []types.AccessPointDescription{
+						{
+							AccessPointArn: aws.String(arn),
+							AccessPointId:  aws.String(accessPointId),
+							ClientToken:    aws.String("test"),
+							FileSystemId:   aws.String(fsId),
+							OwnerId:        aws.String("1234567890"),
+							PosixUser: &types.PosixUser{
+								Gid: aws.Int64(gid),
+								Uid: aws.Int64(uid),
+							},
+							RootDirectory: &types.RootDirectory{
+								CreationInfo: &types.CreationInfo{
+									OwnerGid:    aws.Int64(gid),
+									OwnerUid:    aws.Int64(uid),
+									Permissions: aws.String(directoryPerms),
+								},
+								Path: aws.String(directoryPath),
+							},
+						},
+					},
+					NextToken: nil,
+				}
+				ctx := context.Background()
+				mockEfs.EXPECT().DescribeAccessPoints(gomock.Eq(ctx), gomock.Any(), gomock.Any()).Return(output, nil)
+				_, err := c.DescribeAccessPoint(ctx, accessPointId, differentFsId, util.FileSystemTypeEFS)
+				if err == nil {
+					t.Fatalf("DescribeAccessPoint should have failed when access point belongs to a different filesystem")
+				}
+				expectedErrMsg := "access point fsap-abcd1234 does not belong to filesystem fs-differentfs"
+				if err.Error() != expectedErrMsg {
+					t.Fatalf("Unexpected error message. Expected: %v, Actual: %v", expectedErrMsg, err.Error())
+				}
+				mockctl.Finish()
+			},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, tc.testFunc)

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -560,7 +560,13 @@ func (d *Driver) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequest)
 		// Before removing, ensure the removal path exists and is a directory
 		apRootPath := fsRoot + accessPoint.AccessPointRootDir
 		if pathInfo, err := d.mounter.Stat(apRootPath); err == nil && !os.IsNotExist(err) && pathInfo.IsDir() {
+			klog.Infof("DeleteVolume: DELETING root directory for access point %s on filesystem %s", accessPointId, fileSystemId)
 			err = os.RemoveAll(apRootPath)
+			if err != nil {
+				klog.Errorf("DeleteVolume: RemoveAll for access point %s FAILED: %v", accessPointId, err)
+			} else {
+				klog.Infof("DeleteVolume: RemoveAll for access point %s SUCCEEDED - directory deleted from filesystem %s", accessPointId, fileSystemId)
+			}
 		}
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "Could not delete access point root directory %q: %v", accessPoint.AccessPointRootDir, err)


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

**What is this PR about? / Why do we need it?**

**What testing is done?** 
