### PR TITLE
Upgrade sidecar image versions to latest version to fix CVEs

### DIFF
--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -19,7 +19,7 @@ sidecars:
   livenessProbe:
     image:
       repository: public.ecr.aws/csi-components/livenessprobe
-      tag: v2.19.0-eksbuild.3
+      tag: v2.19.0-eksbuild.4
       pullPolicy: IfNotPresent
     resources: {}
     securityContext:
@@ -28,7 +28,7 @@ sidecars:
   nodeDriverRegistrar:
     image:
       repository: public.ecr.aws/csi-components/csi-node-driver-registrar
-      tag: v2.17.0-eksbuild.3
+      tag: v2.17.0-eksbuild.4
       pullPolicy: IfNotPresent
     resources: {}
     securityContext:
@@ -37,7 +37,7 @@ sidecars:
   csiProvisioner:
     image:
       repository: public.ecr.aws/csi-components/csi-provisioner
-      tag: v6.3.0-eksbuild.2
+      tag: v6.3.0-eksbuild.3
       pullPolicy: IfNotPresent
     resources: {}
     securityContext:

--- a/deploy/kubernetes/base/controller-deployment.yaml
+++ b/deploy/kubernetes/base/controller-deployment.yaml
@@ -70,7 +70,7 @@ spec:
             periodSeconds: 10
             failureThreshold: 5
         - name: csi-provisioner
-          image: public.ecr.aws/csi-components/csi-provisioner:v6.3.0-eksbuild.2
+          image: public.ecr.aws/csi-components/csi-provisioner:v6.3.0-eksbuild.3
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)
@@ -90,7 +90,7 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
         - name: liveness-probe
-          image: public.ecr.aws/csi-components/livenessprobe:v2.19.0-eksbuild.3
+          image: public.ecr.aws/csi-components/livenessprobe:v2.19.0-eksbuild.4
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=/csi/csi.sock

--- a/deploy/kubernetes/base/node-daemonset.yaml
+++ b/deploy/kubernetes/base/node-daemonset.yaml
@@ -107,7 +107,7 @@ spec:
             periodSeconds: 2
             failureThreshold: 5
         - name: csi-driver-registrar
-          image: public.ecr.aws/csi-components/csi-node-driver-registrar:v2.17.0-eksbuild.3
+          image: public.ecr.aws/csi-components/csi-node-driver-registrar:v2.17.0-eksbuild.4
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)
@@ -131,7 +131,7 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
         - name: liveness-probe
-          image: public.ecr.aws/csi-components/livenessprobe:v2.19.0-eksbuild.3
+          image: public.ecr.aws/csi-components/livenessprobe:v2.19.0-eksbuild.4
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=/csi/csi.sock

--- a/deploy/kubernetes/overlays/stable/ecr/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/ecr/kustomization.yaml
@@ -8,10 +8,10 @@ images:
     newTag: v3.4.1
   - name: public.ecr.aws/csi-components/livenessprobe
     newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/livenessprobe
-    newTag: v2.19.0-eksbuild.3
+    newTag: v2.19.0-eksbuild.4
   - name: public.ecr.aws/csi-components/csi-node-driver-registrar
     newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-node-driver-registrar
-    newTag: v2.17.0-eksbuild.3
+    newTag: v2.17.0-eksbuild.4
   - name: public.ecr.aws/csi-components/csi-provisioner
     newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-provisioner
-    newTag: v6.3.0-eksbuild.2
+    newTag: v6.3.0-eksbuild.3

--- a/deploy/kubernetes/overlays/stable/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/kustomization.yaml
@@ -6,8 +6,8 @@ images:
   - name: public.ecr.aws/efs-csi-driver/amazon/aws-efs-csi-driver
     newTag: v3.4.1
   - name: public.ecr.aws/csi-components/livenessprobe
-    newTag: v2.19.0-eksbuild.3
+    newTag: v2.19.0-eksbuild.4
   - name: public.ecr.aws/csi-components/csi-node-driver-registrar
-    newTag: v2.17.0-eksbuild.3
+    newTag: v2.17.0-eksbuild.4
   - name: public.ecr.aws/csi-components/csi-provisioner
-    newTag: v6.3.0-eksbuild.2
+    newTag: v6.3.0-eksbuild.3


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

Bug fix (CVE remediation).

**What is this PR about? / Why do we need it?**

GHSA-hrxh-6v49-42gf (gRPC-Go: xDS RBAC and HTTP/2 Vulnerabilities, HIGH; google.golang.org/grpc < 1.82.1) was present in all three CSI sidecar images. Bump each to the latest published build that carries grpc 1.82.1:
  
  - csi-node-driver-registrar: v2.17.0-eksbuild.3 -> v2.17.0-eksbuild.4
  - livenessprobe: v2.19.0-eksbuild.3 -> v2.19.0-eksbuild.4
  - csi-provisioner: v6.3.0-eksbuild.2 -> v6.3.0-eksbuild.3

**What testing is done?** 

trivy scans of the three new sidecar tags return 0 HIGH/CRITICAL findings.