### PR TITLE
fix: synchronize access to volumeIdCounter map in node.go

### DIFF
--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -26,6 +26,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
@@ -44,9 +45,14 @@ var (
 		csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
 		csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER,
 	}
-	volumeIdCounter  = make(map[string]int)
-	supportedFSTypes = []string{util.FileSystemTypeEFS.String(), util.FileSystemTypeS3Files.String(), ""}
-	hexSuffixRegex   = regexp.MustCompile(`^[0-9a-f]{8,40}$`)
+	volumeIdCounter = make(map[string]int)
+	// volumeIdCounterMu guards concurrent access to volumeIdCounter, which is
+	// read/written/deleted from NodePublishVolume and NodeUnpublishVolume.
+	// Those handlers run concurrently as independent goroutines per gRPC
+	// call, so the map must be protected against concurrent access.
+	volumeIdCounterMu sync.Mutex
+	supportedFSTypes  = []string{util.FileSystemTypeEFS.String(), util.FileSystemTypeS3Files.String(), ""}
+	hexSuffixRegex    = regexp.MustCompile(`^[0-9a-f]{8,40}$`)
 )
 
 const (
@@ -267,11 +273,13 @@ func (d *Driver) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolu
 
 	//Increment volume Id counter
 	if d.volMetricsOptIn {
+		volumeIdCounterMu.Lock()
 		if value, ok := volumeIdCounter[req.GetVolumeId()]; ok {
 			volumeIdCounter[req.GetVolumeId()] = value + 1
 		} else {
 			volumeIdCounter[req.GetVolumeId()] = 1
 		}
+		volumeIdCounterMu.Unlock()
 	}
 
 	return &csi.NodePublishVolumeResponse{}, nil
@@ -321,6 +329,7 @@ func (d *Driver) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpublish
 	//TODO: If `du` is running on a volume, unmount waits for it to complete. We should stop `du` on unmount in the future for NodeUnpublish
 	//Decrement Volume ID counter and evict cache if counter is 0.
 	if d.volMetricsOptIn {
+		volumeIdCounterMu.Lock()
 		if value, ok := volumeIdCounter[req.GetVolumeId()]; ok {
 			value -= 1
 			if value < 1 {
@@ -331,6 +340,7 @@ func (d *Driver) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpublish
 				volumeIdCounter[req.GetVolumeId()] = value
 			}
 		}
+		volumeIdCounterMu.Unlock()
 	}
 
 	return &csi.NodeUnpublishVolumeResponse{}, nil

--- a/pkg/driver/node_test.go
+++ b/pkg/driver/node_test.go
@@ -25,6 +25,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -951,6 +952,70 @@ func TestNodeUnpublishVolume(t *testing.T) {
 			testResult(t, "NodeUnpublishVolume", ret, err, tc.expectError)
 		})
 	}
+}
+
+// TestNodePublishUnpublishVolumeConcurrent exercises concurrent
+// NodePublishVolume and NodeUnpublishVolume calls (with volMetricsOptIn
+// enabled) to guard against concurrent map read/write panics on the
+// package-level volumeIdCounter map. Run with `go test -race` to verify
+// there is no data race.
+func TestNodePublishUnpublishVolumeConcurrent(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mockMounter, driver, ctx := setup(mockCtrl, NewVolStatter(), true, UnsetMaxInflightMountCounts)
+
+	stdVolCap := &csi.VolumeCapability{
+		AccessType: &csi.VolumeCapability_Mount{
+			Mount: &csi.VolumeCapability_MountVolume{},
+		},
+		AccessMode: &csi.VolumeCapability_AccessMode{
+			Mode: csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER,
+		},
+	}
+
+	// The mounter calls happen for every goroutine with varying volume/target
+	// paths, so allow them to be called any number of times with any args.
+	mockMounter.EXPECT().MakeDir(gomock.Any()).Return(nil).AnyTimes()
+	mockMounter.EXPECT().Mount(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	mockMounter.EXPECT().GetDeviceName(gomock.Any()).Return("", 1, nil).AnyTimes()
+	mockMounter.EXPECT().Unmount(gomock.Any()).Return(nil).AnyTimes()
+
+	const numGoroutines = 50
+	const numVolumes = 5
+
+	var wg sync.WaitGroup
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+
+			// Reuse a small set of volume IDs across goroutines so that
+			// concurrent Publish/Unpublish calls for the *same* volume ID
+			// exercise the shared volumeIdCounter map entry as well.
+			volID := fmt.Sprintf("fs-abcd%04d", i%numVolumes)
+			target := fmt.Sprintf("/target/path/%d", i)
+
+			publishReq := &csi.NodePublishVolumeRequest{
+				VolumeId:         volID,
+				VolumeCapability: stdVolCap,
+				TargetPath:       target,
+			}
+			if _, err := driver.NodePublishVolume(ctx, publishReq); err != nil {
+				t.Errorf("NodePublishVolume failed: %v", err)
+				return
+			}
+
+			unpublishReq := &csi.NodeUnpublishVolumeRequest{
+				VolumeId:   volID,
+				TargetPath: target,
+			}
+			if _, err := driver.NodeUnpublishVolume(ctx, unpublishReq); err != nil {
+				t.Errorf("NodeUnpublishVolume failed: %v", err)
+			}
+		}(i)
+	}
+	wg.Wait()
 }
 
 func TestNodeGetVolumeStats(t *testing.T) {


### PR DESCRIPTION
volumeIdCounter is a package-level map read, written, and deleted from NodePublishVolume and NodeUnpublishVolume, both of which can run concurrently as independent goroutines per gRPC call when vol-metrics-opt-in is enabled. Unsynchronized concurrent access trips Go's runtime map-race detector and crashes efs-csi-node with a fatal error.

Add a dedicated sync.Mutex (volumeIdCounterMu) and lock it around the read-modify-write critical sections in both handlers.

Add a unit test that exercises concurrent NodePublishVolume and NodeUnpublishVolume calls across goroutines (with volMetricsOptIn enabled) and verified it reproduces the race without the fix and passes cleanly under go test -race with the fix applied.

**Is this a bug fix or adding new feature?**
bug fix 

**What is this PR about? / Why do we need it?**

  Fixes a `fatal error: concurrent map read and map write` panic in `efs-csi-node`, reported in #1937.

  `volumeIdCounter` in `pkg/driver/node.go` is a package-level `map[string]int` used to
  track per-volume publish/unpublish reference counts when volume metrics are enabled
  (`--vol-metrics-opt-in=true`). It was read/written/deleted directly from both
  `NodePublishVolume` and `NodeUnpublishVolume` with no synchronization. Since kubelet
  issues these RPCs concurrently (as independent goroutines) whenever multiple pods on a
  node mount/unmount EFS volumes around the same time, this triggers Go's runtime map-race
  detector and crashes the process, causing the daemonset to CrashLoopBackOff.

  This only affects deployments with `node.volMetricsOptIn: true` (default is `false`,
  where `volumeIdCounter` is never touched).

  The fix adds a dedicated `sync.Mutex` (`volumeIdCounterMu`) guarding every read, write,
  and delete of `volumeIdCounter` in `NodePublishVolume` and `NodeUnpublishVolume`. This
  mirrors the existing pattern in `vol_statter.go`, which already protects its own cache
  maps with a `sync.RWMutex`. The lock is held across the call into
  `d.volStatter.removeFromCache(...)` in the eviction path, which is safe since
  `VolStatter` uses its own independent mutex and never re-enters `volumeIdCounterMu`.

  Relates to #1937.


**What testing is done?** 
  - Added `TestNodePublishUnpublishVolumeConcurrent` in `pkg/driver/node_test.go`, which
    spins up 50 goroutines calling `NodePublishVolume`/`NodeUnpublishVolume` concurrently
    (with `volMetricsOptIn=true`) across a mix of shared and distinct volume IDs.
  - Verified the test reproduces the reported data race on `volumeIdCounter` when run with
    `go test -race` against the code *before* this fix, and passes cleanly *after* the fix.
  - `go build ./...` — passes.
  - `go vet ./...` — no issues.
  - `go test -race -count=1 ./pkg/...` — all packages pass, including all pre-existing
    `TestNodePublishVolume`/`TestNodeUnpublishVolume` subtests plus the new concurrency test.
  - `gofmt -s -l` on changed files — no issues.