### PR TITLE
Bump Go to 1.26.6 and update sidecar images to fix CVEs

### DIFF
--- a/charts/aws-efs-csi-driver/values.yaml
+++ b/charts/aws-efs-csi-driver/values.yaml
@@ -19,7 +19,7 @@ sidecars:
   livenessProbe:
     image:
       repository: public.ecr.aws/csi-components/livenessprobe
-      tag: v2.19.0-eksbuild.4
+      tag: v2.19.0-eksbuild.5
       pullPolicy: IfNotPresent
     resources: {}
     securityContext:
@@ -28,7 +28,7 @@ sidecars:
   nodeDriverRegistrar:
     image:
       repository: public.ecr.aws/csi-components/csi-node-driver-registrar
-      tag: v2.17.0-eksbuild.4
+      tag: v2.17.0-eksbuild.5
       pullPolicy: IfNotPresent
     resources: {}
     securityContext:
@@ -37,7 +37,7 @@ sidecars:
   csiProvisioner:
     image:
       repository: public.ecr.aws/csi-components/csi-provisioner
-      tag: v6.3.0-eksbuild.3
+      tag: v6.3.0-eksbuild.4
       pullPolicy: IfNotPresent
     resources: {}
     securityContext:

--- a/deploy/kubernetes/base/controller-deployment.yaml
+++ b/deploy/kubernetes/base/controller-deployment.yaml
@@ -70,7 +70,7 @@ spec:
             periodSeconds: 10
             failureThreshold: 5
         - name: csi-provisioner
-          image: public.ecr.aws/csi-components/csi-provisioner:v6.3.0-eksbuild.3
+          image: public.ecr.aws/csi-components/csi-provisioner:v6.3.0-eksbuild.4
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)
@@ -90,7 +90,7 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
         - name: liveness-probe
-          image: public.ecr.aws/csi-components/livenessprobe:v2.19.0-eksbuild.4
+          image: public.ecr.aws/csi-components/livenessprobe:v2.19.0-eksbuild.5
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=/csi/csi.sock

--- a/deploy/kubernetes/base/node-daemonset.yaml
+++ b/deploy/kubernetes/base/node-daemonset.yaml
@@ -107,7 +107,7 @@ spec:
             periodSeconds: 2
             failureThreshold: 5
         - name: csi-driver-registrar
-          image: public.ecr.aws/csi-components/csi-node-driver-registrar:v2.17.0-eksbuild.4
+          image: public.ecr.aws/csi-components/csi-node-driver-registrar:v2.17.0-eksbuild.5
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)
@@ -131,7 +131,7 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
         - name: liveness-probe
-          image: public.ecr.aws/csi-components/livenessprobe:v2.19.0-eksbuild.4
+          image: public.ecr.aws/csi-components/livenessprobe:v2.19.0-eksbuild.5
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=/csi/csi.sock

--- a/deploy/kubernetes/overlays/stable/ecr/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/ecr/kustomization.yaml
@@ -8,10 +8,10 @@ images:
     newTag: v3.4.1
   - name: public.ecr.aws/csi-components/livenessprobe
     newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/livenessprobe
-    newTag: v2.19.0-eksbuild.4
+    newTag: v2.19.0-eksbuild.5
   - name: public.ecr.aws/csi-components/csi-node-driver-registrar
     newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-node-driver-registrar
-    newTag: v2.17.0-eksbuild.4
+    newTag: v2.17.0-eksbuild.5
   - name: public.ecr.aws/csi-components/csi-provisioner
     newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-provisioner
-    newTag: v6.3.0-eksbuild.3
+    newTag: v6.3.0-eksbuild.4

--- a/deploy/kubernetes/overlays/stable/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/kustomization.yaml
@@ -6,8 +6,8 @@ images:
   - name: public.ecr.aws/efs-csi-driver/amazon/aws-efs-csi-driver
     newTag: v3.4.1
   - name: public.ecr.aws/csi-components/livenessprobe
-    newTag: v2.19.0-eksbuild.4
+    newTag: v2.19.0-eksbuild.5
   - name: public.ecr.aws/csi-components/csi-node-driver-registrar
-    newTag: v2.17.0-eksbuild.4
+    newTag: v2.17.0-eksbuild.5
   - name: public.ecr.aws/csi-components/csi-provisioner
-    newTag: v6.3.0-eksbuild.3
+    newTag: v6.3.0-eksbuild.4

--- a/go.mod
+++ b/go.mod
@@ -162,4 +162,4 @@ require (
 
 replace k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.33.2
 
-go 1.26.5
+go 1.26.6


### PR DESCRIPTION
Address CVEs in efs-csi-driver and sidecar images