### PR TITLE
fix: restore DNS-name volume handles in static PVs

### DIFF
--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -57,6 +57,21 @@ var (
 	volumeIdCounterMu sync.Mutex
 	supportedFSTypes  = []string{util.FileSystemTypeEFS.String(), util.FileSystemTypeS3Files.String(), ""}
 	hexSuffixRegex    = regexp.MustCompile(`^[0-9a-f]{8,40}$`)
+	// dnsFileSystemIdRegex matches the DNS-name form of a file system ID used in
+	// static PV volumeHandles. It validates the structure of the name rather than
+	// enumerating known domains, covering:
+	//   EFS bare:        fs-9919e11b.efs.us-east-1.amazonaws.com
+	//   EFS AZ-prefixed: us-east-1a.fs-9919e11b.efs.us-east-1.amazonaws.com
+	//   S3 Files:        use1-az1.fs-0123456abcdef0189.s3files.us-east-1.on.aws
+	// An optional single leading AZ label may precede the strictly-validated
+	// fs-[0-9a-f]{8,40} id label. The surrounding DNS labels are matched
+	// case-insensitively (DNS names are case-insensitive), but the fs-<hex> id
+	// label itself is kept strictly lowercase hex so that the DNS branch does not
+	// accept ids (e.g. fs-ABCDEF12) that the bare-id branch would reject. The
+	// remaining domain is constrained to the DNS charset ([a-zA-Z0-9.-]) only (no
+	// commas, spaces, slashes, or '='), so a DNS-name volumeHandle cannot be used
+	// to inject additional mount options into the mount source passed to efs-utils.
+	dnsFileSystemIdRegex = regexp.MustCompile(`^([a-zA-Z0-9][a-zA-Z0-9-]*\.)?fs-[0-9a-f]{8,40}\.[a-zA-Z0-9][a-zA-Z0-9.-]*[a-zA-Z0-9]$`)
 )
 
 const (
@@ -563,7 +578,9 @@ func (d *Driver) validateFStype(volCaps []*csi.VolumeCapability) error {
 //   - Examples: `fs-abcd1234::`, `fs-abcd1234:`, `fs-abcd1234`, `fs-abcd1234:/path:fsap-xyz123`
 //
 // COMMON RULES:
-//   - The `{fileSystemID}` is required, and expected to be of the form `fs-...`
+//   - The `{fileSystemID}` is required. It may be either the bare id `fs-[0-9a-f]{8,40}`,
+//     or the mount-target DNS name form (e.g. `fs-abcd1234.efs.<region>.amazonaws.com`,
+//     optionally with a leading AZ label such as `us-east-1a.fs-abcd1234.efs.<region>.amazonaws.com`)
 //   - The `{mountPath}` and `{accessPointID}` are optional -- they may be empty or omitted entirely
 //   - The `{mountPath}`, if specified, is not required to be absolute
 //   - The `{accessPointID}` is expected to be of the form `fsap-...`
@@ -595,7 +612,7 @@ func parseVolumeId(volumeId string) (fsid, subpath, apid string, fsType util.Fil
 		// Validate and extract fsid
 		fsid = tokens[1]
 		if !isValidFileSystemId(fsid) {
-			err = status.Errorf(codes.InvalidArgument, "volume ID '%s' is invalid: Expected a file system ID of the form 'fs-[0-9a-f]{8,40}'", volumeId)
+			err = status.Errorf(codes.InvalidArgument, "volume ID '%s' is invalid: Expected a file system ID of the form 'fs-[0-9a-f]{8,40}' or a mount-target DNS name (e.g. 'fs-abcd1234.efs.<region>.amazonaws.com')", volumeId)
 			return
 		}
 
@@ -623,7 +640,7 @@ func parseVolumeId(volumeId string) (fsid, subpath, apid string, fsType util.Fil
 		// Extract fsid
 		fsid = tokens[0]
 		if !isValidFileSystemId(fsid) {
-			err = status.Errorf(codes.InvalidArgument, "volume ID '%s' is invalid: Expected a file system ID of the form 'fs-[0-9a-f]{8,40}'", volumeId)
+			err = status.Errorf(codes.InvalidArgument, "volume ID '%s' is invalid: Expected a file system ID of the form 'fs-[0-9a-f]{8,40}' or a mount-target DNS name (e.g. 'fs-abcd1234.efs.<region>.amazonaws.com')", volumeId)
 			return
 		}
 
@@ -693,7 +710,15 @@ func (d *Driver) writeEfsMeta(target string, meta efsVolumeMeta) {
 }
 
 func isValidFileSystemId(filesystemId string) bool {
-	return strings.HasPrefix(filesystemId, "fs-") && hexSuffixRegex.MatchString(filesystemId[3:])
+	// Accept either the bare id (fs-[0-9a-f]{8,40}) or the DNS-name form used in
+	// static PV volumeHandles (EFS bare/AZ-prefixed and S3 Files). The DNS-name
+	// form is passed through unchanged to efs-utils. Both forms keep the fs-<hex>
+	// id portion strictly validated and constrain the DNS charset to prevent
+	// mount-option injection.
+	if strings.HasPrefix(filesystemId, "fs-") && hexSuffixRegex.MatchString(filesystemId[3:]) {
+		return true
+	}
+	return dnsFileSystemIdRegex.MatchString(filesystemId)
 }
 
 func isValidAccessPointId(accesspointId string) bool {

--- a/pkg/driver/node_test.go
+++ b/pkg/driver/node_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/golang/mock/gomock"
 	"github.com/kubernetes-sigs/aws-efs-csi-driver/pkg/driver/mocks"
+	"github.com/kubernetes-sigs/aws-efs-csi-driver/pkg/util"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -127,6 +128,36 @@ func TestNodePublishVolume(t *testing.T) {
 			},
 			expectMakeDir:         true,
 			mountArgs:             []interface{}{volumeId + ":/", targetPath, "efs", []string{"tls"}},
+			mountSuccess:          true,
+			volMetricsOptIn:       true,
+			maxInflightMountCalls: UnsetMaxInflightMountCounts,
+		},
+		{
+			// DNS-name volumeHandle (static PV): the fsid is passed through
+			// unchanged as the efs-utils mount source, asserted via mountArgs[0].
+			name: "success: efs dns-name volume handle",
+			req: &csi.NodePublishVolumeRequest{
+				VolumeId:         "fs-9919e11b.efs.us-east-1.amazonaws.com",
+				VolumeCapability: stdVolCap,
+				TargetPath:       targetPath,
+			},
+			expectMakeDir:         true,
+			mountArgs:             []interface{}{"fs-9919e11b.efs.us-east-1.amazonaws.com:/", targetPath, "efs", []string{"tls"}},
+			mountSuccess:          true,
+			volMetricsOptIn:       true,
+			maxInflightMountCalls: UnsetMaxInflightMountCounts,
+		},
+		{
+			// AZ-prefixed DNS-name volumeHandle (static PV): the fsid, including
+			// the leading AZ label, is passed through unchanged as the mount source.
+			name: "success: efs dns-name az-prefixed volume handle",
+			req: &csi.NodePublishVolumeRequest{
+				VolumeId:         "us-east-1a.fs-9919e11b.efs.us-east-1.amazonaws.com",
+				VolumeCapability: stdVolCap,
+				TargetPath:       targetPath,
+			},
+			expectMakeDir:         true,
+			mountArgs:             []interface{}{"us-east-1a.fs-9919e11b.efs.us-east-1.amazonaws.com:/", targetPath, "efs", []string{"tls"}},
 			mountSuccess:          true,
 			volMetricsOptIn:       true,
 			maxInflightMountCalls: UnsetMaxInflightMountCounts,
@@ -549,7 +580,7 @@ func TestNodePublishVolume(t *testing.T) {
 			expectMakeDir: false,
 			expectError: errtyp{
 				code:    "InvalidArgument",
-				message: "volume ID 'invalid-id' is invalid: Expected a file system ID of the form 'fs-[0-9a-f]{8,40}'",
+				message: "volume ID 'invalid-id' is invalid: Expected a file system ID of the form 'fs-[0-9a-f]{8,40}' or a mount-target DNS name (e.g. 'fs-abcd1234.efs.<region>.amazonaws.com')",
 			},
 			maxInflightMountCalls: UnsetMaxInflightMountCounts,
 		},
@@ -648,7 +679,7 @@ func TestNodePublishVolume(t *testing.T) {
 			expectMakeDir: false,
 			expectError: errtyp{
 				code:    "InvalidArgument",
-				message: "volume ID 'efs:invalid-id' is invalid: Expected a file system ID of the form 'fs-[0-9a-f]{8,40}'",
+				message: "volume ID 'efs:invalid-id' is invalid: Expected a file system ID of the form 'fs-[0-9a-f]{8,40}' or a mount-target DNS name (e.g. 'fs-abcd1234.efs.<region>.amazonaws.com')",
 			},
 		},
 		{
@@ -719,7 +750,7 @@ func TestNodePublishVolume(t *testing.T) {
 			expectMakeDir: false,
 			expectError: errtyp{
 				code:    "InvalidArgument",
-				message: "volume ID 's3files:invalid-id' is invalid: Expected a file system ID of the form 'fs-[0-9a-f]{8,40}'",
+				message: "volume ID 's3files:invalid-id' is invalid: Expected a file system ID of the form 'fs-[0-9a-f]{8,40}' or a mount-target DNS name (e.g. 'fs-abcd1234.efs.<region>.amazonaws.com')",
 			},
 		},
 		{
@@ -1623,6 +1654,25 @@ func TestIsValidFileSystemId(t *testing.T) {
 		{"invalid: empty", "", false},
 		{"invalid: prefix only", "fs-", false},
 		{"invalid: attack with mount options", "fs-attacktest,exec,suid,dev", false},
+		// DNS-name form used in static PV volumeHandles. Validation is structural
+		// (optional AZ label, strict fs-<hex> id label, DNS-safe domain) rather
+		// than enumerating known domains, so EFS bare, EFS AZ-prefixed, and S3
+		// Files forms are all covered while still blocking mount-option injection.
+		{"valid: efs dns-name", "fs-9919e11b.efs.us-east-1.amazonaws.com", true},
+		{"valid: efs dns-name az-prefixed", "us-east-1a.fs-9919e11b.efs.us-east-1.amazonaws.com", true},
+		{"valid: s3files dns-name", "use1-az1.fs-0123456abcdef0189.s3files.us-east-1.on.aws", true},
+		{"valid: dns-name china", "fs-12345678.efs.cn-north-1.amazonaws.com.cn", true},
+		{"valid: dns-name fips", "fs-12345678.efs-fips.us-east-1.amazonaws.com", true},
+		{"invalid: injected mount options on s3files dns-name", "use1-az1.fs-0123456abcdef0189.s3files.us-east-1.on.aws,exec,suid,dev", false},
+		{"invalid: dns-name az-prefixed id too short", "us-east-1a.fs-1234567.efs.us-east-1.amazonaws.com", false},
+		{"invalid: dns-name az-prefixed non-hex id", "us-east-1a.fs-1234567G.efs.us-east-1.amazonaws.com", false},
+		// DNS labels are case-insensitive, so an uppercase domain must be accepted,
+		// but the fs-<hex> id label itself stays strictly lowercase hex: an
+		// uppercase id label is rejected in the DNS branch just as the bare id
+		// fs-ABCDEF12 is rejected in the bare-id branch.
+		{"valid: efs dns-name uppercase domain", "fs-9919e11b.EFS.us-east-1.amazonaws.com", true},
+		{"invalid: dns-name uppercase id label", "fs-ABCDEF12.efs.us-east-1.amazonaws.com", false},
+		{"invalid: bare id uppercase hex", "fs-ABCDEF12", false},
 	}
 
 	for _, tc := range testCases {
@@ -1630,6 +1680,64 @@ func TestIsValidFileSystemId(t *testing.T) {
 			result := isValidFileSystemId(tc.fsid)
 			if result != tc.expected {
 				t.Errorf("isValidFileSystemId(%q) = %v, expected %v", tc.fsid, result, tc.expected)
+			}
+		})
+	}
+}
+
+func TestParseVolumeIdDnsName(t *testing.T) {
+	// A DNS-name volumeHandle (used in static PVs) must parse successfully, keep
+	// the fsid byte-for-byte, and produce an unchanged efs-utils mount source.
+	// Both EFS (fs-<id> as the leading label) and S3 Files (fs-<id> as a middle
+	// label with a different domain) forms are covered.
+	testCases := []struct {
+		name            string
+		volumeId        string
+		expectedFsid    string
+		expectedFsType  util.FileSystemType
+		expectedSubpath string
+	}{
+		{
+			name:            "efs dns-name",
+			volumeId:        "fs-9919e11b.efs.us-east-1.amazonaws.com",
+			expectedFsid:    "fs-9919e11b.efs.us-east-1.amazonaws.com",
+			expectedFsType:  util.FileSystemTypeEFS,
+			expectedSubpath: "/",
+		},
+		{
+			name:            "s3files dns-name",
+			volumeId:        "s3files:use1-az1.fs-0123456abcdef0189.s3files.us-east-1.on.aws",
+			expectedFsid:    "use1-az1.fs-0123456abcdef0189.s3files.us-east-1.on.aws",
+			expectedFsType:  util.FileSystemTypeS3Files,
+			expectedSubpath: "/",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fsid, subpath, apid, fsType, err := parseVolumeId(tc.volumeId)
+			if err != nil {
+				t.Fatalf("parseVolumeId(%q) returned unexpected error: %v", tc.volumeId, err)
+			}
+			if fsid != tc.expectedFsid {
+				t.Errorf("parseVolumeId(%q) fsid = %q, expected %q (must be unchanged)", tc.volumeId, fsid, tc.expectedFsid)
+			}
+			if apid != "" {
+				t.Errorf("parseVolumeId(%q) apid = %q, expected empty", tc.volumeId, apid)
+			}
+			if fsType != tc.expectedFsType {
+				t.Errorf("parseVolumeId(%q) fsType = %q, expected %q", tc.volumeId, fsType, tc.expectedFsType)
+			}
+
+			// The efs-utils mount source is built in NodePublishVolume (asserted
+			// end-to-end via the gomock Mount expectation in TestNodePublishVolume).
+			// Here we only assert that parseVolumeId keeps the fsid unchanged and
+			// derives the subpath correctly, which are the inputs to that source.
+			if subpath == "" {
+				subpath = "/"
+			}
+			if subpath != tc.expectedSubpath {
+				t.Errorf("parseVolumeId(%q) subpath = %q, expected %q", tc.volumeId, subpath, tc.expectedSubpath)
 			}
 		})
 	}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Bug fix (regression introduced in v3.0.0).

**What is this PR about? / Why do we need it?**

v3.4.1 hardened `NodePublishVolume` against mount-option injection by strictly
validating the file system ID in a volume handle against `fs-[0-9a-f]{8,40}`.
That strict check also rejected the mount-target **DNS-name** form of the ID
that customers use in static PV `volumeHandle`s, e.g.
`fs-9919e11b.efs.us-east-1.amazonaws.com`. As a result, static PVs that worked
before v3.4.1 began failing at `NodePublishVolume` after upgrading.

This PR relaxes `isValidFileSystemId` (`pkg/driver/node.go`) to accept **either**:

- the bare id — still strictly validated as `fs-[0-9a-f]{8,40}`, or
- the DNS-name form — validated by a **structural** regex (`dnsFileSystemIdRegex`)
  that checks the shape of the name instead of enumerating known service domains:

  ```
  ^([a-z0-9][a-z0-9-]*\.)?fs-[0-9a-f]{8,40}\.[a-z0-9][a-z0-9.-]*[a-z0-9]$
  ```

An optional leading AZ label is allowed, the `fs-<hex>` id label stays strictly
validated, and the rest of the domain is constrained to the DNS charset
`[a-z0-9.-]` only. Because commas, spaces, slashes, and `=` cannot appear, a
DNS-name `volumeHandle` still cannot be used to inject additional mount options
into the source passed to efs-utils — the injection-safety property added in
v3.4.1 is preserved.

Covered forms:

- EFS bare: `fs-9919e11b.efs.us-east-1.amazonaws.com`
- EFS AZ-prefixed: `us-east-1a.fs-9919e11b.efs.us-east-1.amazonaws.com`
- S3 Files: `use1-az1.fs-0123456abcdef0189.s3files.us-east-1.on.aws`
- China / FIPS variants

The fsid is returned unchanged, so the efs-utils mount source is byte-for-byte
identical to pre-v3.4.1 behavior. This is a strict widening of accepted input;
there is no behavior change for bare-id volume handles and no API change.


**What testing is done?** 
Unit tests in `pkg/driver/node_test.go`:

- `TestIsValidFileSystemId` — positive cases (bare id, EFS bare, EFS
  AZ-prefixed, S3 Files, China, FIPS) and negative cases (injected mount
  options, too-short id label, non-hex id label, empty, prefix-only).
- `TestParseVolumeIdDnsName` — a DNS-name `volumeHandle` parses successfully
  and the fsid round-trips unchanged so the mount source is unaltered.