### PR TITLE
fix: emit un-prefixed volume handles for EFS access points

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -29,6 +29,8 @@ The following CSI interfaces are implemented:
 
 > **Note** When using static provisioning with an Amazon S3 file system, the `volumeHandle` in your PersistentVolume must include the `s3files:` prefix (e.g., `s3files:fs-01234567890abcdef0`).
 
+> **Note** Amazon EFS `volumeHandle`s do not need a filesystem-type prefix. The driver accepts both `fs-01234567890abcdef0` and `efs:fs-01234567890abcdef0`, and emits the un-prefixed form for dynamically provisioned volumes so that handles stay usable by consumers predating the typed format. Driver versions `v3.0.0` through `v3.4.2` emitted `efs:`-prefixed handles instead. Because `spec.csi.volumeHandle` is immutable, a PersistentVolume provisioned by one of those versions keeps its prefix and has to be recreated to take the un-prefixed form.
+
 > **Note** Do not install `amazon-efs-utils` directly on EKS worker nodes. The EFS CSI driver already packages `efs-utils` within its containers and manages the mount process. Installing `efs-utils` at the node level can cause unexpected mount behavior.
 
 > **Note** Amazon EFS and S3 Files are fully elastic and scalable file systems which automatically scale up or down based on usage, so there is no need to manage capacity. The actual storage capacity value in persistent volume and persistent volume claim is a placeholder value that must be specified (required by Kubernetes) but is not actually used. You can specify any valid value for the capacity.

--- a/examples/kubernetes/efs/access_points/README.md
+++ b/examples/kubernetes/efs/access_points/README.md
@@ -29,7 +29,7 @@ spec:
   storageClassName: efs-sc
   csi:
     driver: efs.csi.aws.com
-    volumeHandle: efs:[FileSystemId]::[AccessPointId]
+    volumeHandle: "[FileSystemId]::[AccessPointId]"
 ---
 apiVersion: v1
 kind: PersistentVolume
@@ -45,7 +45,7 @@ spec:
   storageClassName: efs-sc
   csi:
     driver: efs.csi.aws.com
-    volumeHandle: efs:[FileSystemId]::[AccessPointId]
+    volumeHandle: "[FileSystemId]::[AccessPointId]"
 ```
 In each PersistentVolume, replace both the `[FileSystemId]` and the `[AccessPointId]` in `spec.csi.volumeHandle`.
 You can find these values using the AWS CLI:
@@ -90,8 +90,8 @@ as this could subject you to
 [issue #167](https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/167).
 
 - It is possible to use a combination of [volume path](../volume_path) and access points
-  with a `volumeHandle` of the form `efs:[FileSystemId]:[Subpath]:[AccessPointId]`, e.g.
-  `volumeHandle: efs:fs-e8a95a42:/my/subpath:fsap-19f752f0068c22464`. In this case:
+  with a `volumeHandle` of the form `[FileSystemId]:[Subpath]:[AccessPointId]`, e.g.
+  `volumeHandle: fs-e8a95a42:/my/subpath:fsap-19f752f0068c22464`. In this case:
   - The `[Subpath]` will be _under_ the configured access point directory. For example,
     if you configured your access point with `/ap1`, the above would mount to
     `/ap1/my/subpath`.

--- a/examples/kubernetes/efs/access_points/specs/example.yaml
+++ b/examples/kubernetes/efs/access_points/specs/example.yaml
@@ -18,7 +18,7 @@ spec:
   storageClassName: efs-sc
   csi:
     driver: efs.csi.aws.com
-    volumeHandle: efs:fs-e8a95a42::fsap-068c22f0246419f75
+    volumeHandle: fs-e8a95a42::fsap-068c22f0246419f75
 ---
 apiVersion: v1
 kind: PersistentVolume
@@ -34,7 +34,7 @@ spec:
   storageClassName: efs-sc
   csi:
     driver: efs.csi.aws.com
-    volumeHandle: efs:fs-e8a95a42::fsap-19f752f0068c22464
+    volumeHandle: fs-e8a95a42::fsap-19f752f0068c22464
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/examples/kubernetes/efs/cross_account_mount/specs/pv-mounttargetip.yaml
+++ b/examples/kubernetes/efs/cross_account_mount/specs/pv-mounttargetip.yaml
@@ -18,6 +18,6 @@ spec:
   persistentVolumeReclaimPolicy: Retain
   csi:
     driver: efs.csi.aws.com
-    volumeHandle: efs:[Filesystem ID]
+    volumeHandle: "[Filesystem ID]"
     volumeAttributes:
       mounttargetip: "[MOUNT TARGET IP ADDRESS]"

--- a/examples/kubernetes/efs/cross_account_mount/specs/pv.yaml
+++ b/examples/kubernetes/efs/cross_account_mount/specs/pv.yaml
@@ -17,6 +17,6 @@ spec:
   persistentVolumeReclaimPolicy: Retain
   csi:
     driver: efs.csi.aws.com
-    volumeHandle: efs:[Filesystem ID]
+    volumeHandle: "[Filesystem ID]"
     volumeAttributes:
       crossaccount: "true"

--- a/examples/kubernetes/efs/dynamic_provisioning/README.md
+++ b/examples/kubernetes/efs/dynamic_provisioning/README.md
@@ -90,7 +90,7 @@ This example requires Kubernetes 1.17 or later and a driver version of 1.2.0 or 
 
    ```
    [...]
-   1 controller.go:737] successfully created PV pvc-5983ffec-96cf-40c1-9cd6-e5686ca84eca for PVC efs-claim and csi volume name efs:fs-95bcec92::fsap-02a88145b865d3a87
+   1 controller.go:737] successfully created PV pvc-5983ffec-96cf-40c1-9cd6-e5686ca84eca for PVC efs-claim and csi volume name fs-95bcec92::fsap-02a88145b865d3a87
    ```
 
    If you don't see the previous output, run the previous command using one of the other controller Pods.

--- a/examples/kubernetes/efs/encryption_in_transit/README.md
+++ b/examples/kubernetes/efs/encryption_in_transit/README.md
@@ -20,7 +20,7 @@ spec:
   storageClassName: efs-sc
   csi:
     driver: efs.csi.aws.com
-    volumeHandle: efs:[FileSystemId] 
+    volumeHandle: "[FileSystemId]"
     volumeAttributes:
       encryptInTransit: "true"
 ```

--- a/examples/kubernetes/efs/encryption_in_transit/specs/pv.yaml
+++ b/examples/kubernetes/efs/encryption_in_transit/specs/pv.yaml
@@ -12,6 +12,6 @@ spec:
   storageClassName: efs-sc
   csi:
     driver: efs.csi.aws.com
-    volumeHandle: efs:fs-4af69aab
+    volumeHandle: fs-4af69aab
     volumeAttributes:
       encryptInTransit: "true"

--- a/examples/kubernetes/efs/multiple_pods/specs/pv.yaml
+++ b/examples/kubernetes/efs/multiple_pods/specs/pv.yaml
@@ -12,4 +12,4 @@ spec:
   storageClassName: efs-sc
   csi:
     driver: efs.csi.aws.com
-    volumeHandle: efs:fs-4af69aab
+    volumeHandle: fs-4af69aab

--- a/examples/kubernetes/efs/statefulset/specs/example.yaml
+++ b/examples/kubernetes/efs/statefulset/specs/example.yaml
@@ -18,7 +18,7 @@ spec:
   storageClassName: efs-sc
   csi:
     driver: efs.csi.aws.com
-    volumeHandle: efs:fs-4af69aab
+    volumeHandle: fs-4af69aab
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/examples/kubernetes/efs/static_provisioning/README.md
+++ b/examples/kubernetes/efs/static_provisioning/README.md
@@ -18,7 +18,7 @@ spec:
   persistentVolumeReclaimPolicy: Retain
   csi:
     driver: efs.csi.aws.com
-    volumeHandle: efs:[FileSystemId] 
+    volumeHandle: "[FileSystemId]"
 ```
 Replace `VolumeHandle` value with `FileSystemId` of the EFS filesystem that needs to be mounted.
 
@@ -88,7 +88,7 @@ spec:
   persistentVolumeReclaimPolicy: Retain
   csi:
     driver: efs.csi.aws.com
-    volumeHandle:[FILESYSTEM ID]
+    volumeHandle: "[FILESYSTEM ID]"
     volumeAttributes:
       mounttargetip: "[MOUNT TARGET IP ADDRESS]"
 ```

--- a/examples/kubernetes/efs/static_provisioning/specs/pv.yaml
+++ b/examples/kubernetes/efs/static_provisioning/specs/pv.yaml
@@ -12,4 +12,4 @@ spec:
   persistentVolumeReclaimPolicy: Retain
   csi:
     driver: efs.csi.aws.com
-    volumeHandle: efs:fs-e8a95a42
+    volumeHandle: fs-e8a95a42

--- a/examples/kubernetes/efs/volume_path/README.md
+++ b/examples/kubernetes/efs/volume_path/README.md
@@ -19,7 +19,7 @@ spec:
   storageClassName: efs-sc
   csi:
     driver: efs.csi.aws.com
-    volumeHandle: efs:[FileSystemId]:[Path]
+    volumeHandle: "[FileSystemId]:[Path]"
 ```
 Replace `FileSystemId` of the EFS filesystem ID that needs to be mounted. And replace `Path` with a existing path on the filesystem.
 

--- a/examples/kubernetes/efs/volume_path/specs/example.yaml
+++ b/examples/kubernetes/efs/volume_path/specs/example.yaml
@@ -18,7 +18,7 @@ spec:
   storageClassName: efs-sc
   csi:
     driver: efs.csi.aws.com
-    volumeHandle: efs:fs-e8a95a42:/dir1
+    volumeHandle: fs-e8a95a42:/dir1
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -46,7 +46,7 @@ spec:
   storageClassName: efs-sc
   csi:
     driver: efs.csi.aws.com
-    volumeHandle: efs:fs-e8a95a42:/dir2
+    volumeHandle: fs-e8a95a42:/dir2
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -443,7 +443,7 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 	return &csi.CreateVolumeResponse{
 		Volume: &csi.Volume{
 			CapacityBytes:      volSize,
-			VolumeId:           fsType.String() + ":" + accessPointsOptions.FileSystemId + "::" + accessPoint.AccessPointId,
+			VolumeId:           buildVolumeId(fsType, accessPointsOptions.FileSystemId, accessPoint.AccessPointId),
 			VolumeContext:      volContext,
 			AccessibleTopology: topology,
 		},

--- a/pkg/driver/controller_test.go
+++ b/pkg/driver/controller_test.go
@@ -35,7 +35,7 @@ func TestCreateVolume(t *testing.T) {
 		volumeName          = "volumeName"
 		fsId                = "fs-abcd1234"
 		apId                = "fsap-abcd1234"
-		volumeId            = "efs:fs-abcd1234::fsap-abcd1234"
+		volumeId            = "fs-abcd1234::fsap-abcd1234"
 		capacityRange int64 = 5368709120
 		stdVolCap           = &csi.VolumeCapability{
 			AccessType: &csi.VolumeCapability_Mount{
@@ -707,7 +707,7 @@ func TestCreateVolume(t *testing.T) {
 
 					found := false
 					for _, ap := range accessPointArr {
-						if result.resp.Volume.VolumeId == fmt.Sprintf("efs:%s::%s", ap.FileSystemId, ap.AccessPointId) {
+						if result.resp.Volume.VolumeId == fmt.Sprintf("%s::%s", ap.FileSystemId, ap.AccessPointId) {
 							found = true
 							break
 						}
@@ -3390,7 +3390,7 @@ func TestCreateVolume(t *testing.T) {
 					t.Fatal("Volume is nil")
 				}
 
-				expectedVolumeId := "efs:" + fsId + "::" + apId
+				expectedVolumeId := fsId + "::" + apId
 				if res.Volume.VolumeId != expectedVolumeId {
 					t.Fatalf("Volume Id mismatched. Expected: %v, Actual: %v", expectedVolumeId, res.Volume.VolumeId)
 				}
@@ -3455,7 +3455,7 @@ func TestCreateVolume(t *testing.T) {
 					t.Fatal("Volume is nil")
 				}
 
-				expectedVolumeId := "efs:" + fsId + "::" + apId
+				expectedVolumeId := fsId + "::" + apId
 				if res.Volume.VolumeId != expectedVolumeId {
 					t.Fatalf("Volume Id mismatched. Expected: %v, Actual: %v", expectedVolumeId, res.Volume.VolumeId)
 				}
@@ -3519,7 +3519,7 @@ func TestCreateVolume(t *testing.T) {
 					t.Fatal("Volume is nil")
 				}
 
-				expectedVolumeId := "efs:" + fsId + "::" + apId
+				expectedVolumeId := fsId + "::" + apId
 				if res.Volume.VolumeId != expectedVolumeId {
 					t.Fatalf("Volume Id mismatched. Expected: %v, Actual: %v", expectedVolumeId, res.Volume.VolumeId)
 				}
@@ -5257,7 +5257,7 @@ func TestCreateDeleteVolumeRace(t *testing.T) {
 		apId                = "fsap-abcd1234"
 		fsId                = "fs-abcd1234"
 		endpoint            = "endpoint"
-		volumeId            = "efs:fs-abcd1234::fsap-abcd1234"
+		volumeId            = "fs-abcd1234::fsap-abcd1234"
 		volumeName          = "volumeName"
 		capacityRange int64 = 5368709120
 		stdVolCap           = &csi.VolumeCapability{

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -670,6 +670,18 @@ func parseVolumeId(volumeId string) (fsid, subpath, apid string, fsType util.Fil
 	return
 }
 
+// buildVolumeId renders the volume handle returned by CreateVolume, and is the
+// inverse of parseVolumeId. EFS keeps the legacy un-prefixed form because
+// handles are also read by mounters outside this driver that predate the typed
+// format. parseVolumeId reads an un-prefixed handle as EFS, so nothing in this
+// driver depends on the prefix being present.
+func buildVolumeId(fsType util.FileSystemType, fileSystemId, accessPointId string) string {
+	if fsType == util.FileSystemTypeEFS {
+		return fileSystemId + "::" + accessPointId
+	}
+	return fsType.String() + ":" + fileSystemId + "::" + accessPointId
+}
+
 // Check and avoid adding duplicate mount options
 func hasOption(options []string, opt string) bool {
 	for _, o := range options {

--- a/pkg/driver/node_test.go
+++ b/pkg/driver/node_test.go
@@ -1805,6 +1805,51 @@ func TestIsValidMountTargetIP(t *testing.T) {
 	}
 }
 
+func TestBuildVolumeId(t *testing.T) {
+	testCases := []struct {
+		name     string
+		fsType   util.FileSystemType
+		fsid     string
+		apid     string
+		expected string
+	}{
+		{
+			name:     "EFS omits the type prefix",
+			fsType:   util.FileSystemTypeEFS,
+			fsid:     "fs-abcd1234",
+			apid:     "fsap-abcd1234",
+			expected: "fs-abcd1234::fsap-abcd1234",
+		},
+		{
+			name:     "S3 Files carries the type prefix",
+			fsType:   util.FileSystemTypeS3Files,
+			fsid:     "fs-abcd1234",
+			apid:     "fsap-abcd1234",
+			expected: "s3files:fs-abcd1234::fsap-abcd1234",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := buildVolumeId(tc.fsType, tc.fsid, tc.apid)
+			if got != tc.expected {
+				t.Fatalf("buildVolumeId(%q, %q, %q) = %q, expected %q", tc.fsType, tc.fsid, tc.apid, got, tc.expected)
+			}
+
+			// parseVolumeId is the inverse, so every handle this driver emits must
+			// resolve back to the same file system, access point and type.
+			fsid, subpath, apid, fsType, err := parseVolumeId(got)
+			if err != nil {
+				t.Fatalf("parseVolumeId(%q) returned an error: %v", got, err)
+			}
+			if fsid != tc.fsid || apid != tc.apid || fsType != tc.fsType || subpath != "" {
+				t.Errorf("parseVolumeId(%q) = (%q, %q, %q, %q), expected (%q, \"\", %q, %q)",
+					got, fsid, subpath, apid, fsType, tc.fsid, tc.apid, tc.fsType)
+			}
+		})
+	}
+}
+
 func TestGetCsiNodeEfsPluginContainerMemoryLimitInBytes(t *testing.T) {
 	testCases := []struct {
 		name     string

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -168,7 +168,9 @@ func (e *efsDriver) CreateVolume(ctx context.Context, config *storageframework.P
 func (e *efsDriver) GetPersistentVolumeSource(readOnly bool, fsType string, volume storageframework.TestVolume) (*v1.PersistentVolumeSource, *v1.VolumeNodeAffinity) {
 	pvSource := v1.PersistentVolumeSource{
 		CSI: &v1.CSIPersistentVolumeSource{
-			Driver:       e.driverInfo.Name,
+			Driver: e.driverInfo.Name,
+			// Deliberately the type-prefixed spelling. makeEFSPV uses the
+			// un-prefixed one for EFS, so both accepted forms get exercised.
 			VolumeHandle: e.config.FSType.String() + ":" + e.config.GetFSID(),
 		},
 	}
@@ -893,8 +895,19 @@ func makeEFSPVC(namespace, name string) *v1.PersistentVolumeClaim {
 	}
 }
 
+// staticVolumeHandle spells the volume handle for a static PV. EFS uses the
+// legacy un-prefixed form, which is what the driver emits and what the examples
+// document. S3 Files keeps its prefix, since an un-prefixed handle is parsed as
+// EFS.
+func staticVolumeHandle(config FileSystemTestConfig) string {
+	if config.FSType == util.FileSystemTypeEFS {
+		return config.GetFSID()
+	}
+	return config.FSType.String() + ":" + config.GetFSID()
+}
+
 func makeEFSPV(name, path string, volumeAttributes map[string]string, config FileSystemTestConfig) *v1.PersistentVolume {
-	volumeHandle := config.FSType.String() + ":" + config.GetFSID()
+	volumeHandle := staticVolumeHandle(config)
 	if path != "" {
 		volumeHandle += ":" + path
 	}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

Bug fix. Regression introduced in v3.0.0.

**What is this PR about? / Why do we need it?**

Fixes #1947.

v3.0.0 added S3 Files support and began prefixing dynamically provisioned volume handles with the file system type, so an `efs-ap` volume became `efs:fs-xxxx::fsap-xxxx`. The prefix is redundant for EFS, because `parseVolumeId` already reads an un-prefixed handle as EFS, and it breaks handle consumers outside this driver. Pods on EKS Fargate mount EFS with a built-in mounter rather than the node DaemonSet, and #1947 reports that mounter rejecting the prefixed handle, so every dynamically provisioned EFS PVC binds and never mounts.

`CreateVolume` now emits `fs-xxxx::fsap-xxxx` for `efs-ap` and keeps the `s3files:` prefix for `s3files-ap`, where the type is not implied. Both forms stay accepted on the parse side, so PersistentVolumes provisioned by v3.0.0 through v3.4.2 keep working. `spec.csi.volumeHandle` is immutable, so those PVs retain the prefix and must be recreated to take the shorter form.

The same v3.0.0 commit rewrote the EFS examples to show the prefixed form for static PersistentVolumes, which is supported on Fargate. This PR restores them to the un-prefixed form, quotes the placeholder handles so that `volumeHandle: [FileSystemId]::[AccessPointId]` stays valid YAML, and records in `docs/README.md` which form the driver emits.

**What testing is done?**

`make test` and `make verify` pass.

- `TestBuildVolumeId` covers both file system types and asserts each emitted handle round-trips through `parseVolumeId` to the same file system, access point and type.
- `TestDeleteVolume` keeps its `efs:`-prefixed inputs, so the v3 format stays covered on the parse side.
- e2e now covers both spellings instead of only the prefixed one. `makeEFSPV` uses the un-prefixed form for EFS, and `GetPersistentVolumeSource` keeps the prefixed form. S3 Files keeps its prefix in both, since an un-prefixed handle is parsed as EFS.
- Every example spec and README YAML block was parsed to confirm `volumeHandle` resolves to a string.
