### PR TITLE
quote controller.timeout value

### DIFF
--- a/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
+++ b/charts/aws-efs-csi-driver/templates/controller-deployment.yaml
@@ -170,7 +170,7 @@ spec:
             - --worker-threads={{ .Values.controller.workerThreads }}
             {{- end }}
             {{- if hasKey .Values.controller "timeout" }}
-            - --timeout={{ .Values.controller.timeout }}
+            - {{ printf "--timeout=%s" .Values.controller.timeout | quote }}
             {{- end }}
             {{- range .Values.sidecars.csiProvisioner.additionalArgs }}
             - {{ . }}


### PR DESCRIPTION
**What is this PR about? / Why do we need it?**
Ensures `controller.timeout` is rendered as a quoted YAML scalar in the helm chart to prevent unexpected rendering behavior when the value contains special characters
