### PR TITLE
fix: stop NodeUnpublishVolume leaking a thread per retry on a dead mount

### DIFF
--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"net"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
@@ -57,6 +58,9 @@ type Driver struct {
 	volumeAttachLimit        int64
 	forceUnmountAfterTimeout bool
 	unmountTimeout           time.Duration
+	// inFlightUnpublishTargets holds target paths with a NodeUnpublishVolume in
+	// flight, so a kubelet retry cannot stack a handler behind a blocked one.
+	inFlightUnpublishTargets sync.Map
 	// metaDir is bind-mounted to /var/lib/kubelet/plugins/efs.csi.aws.com/mounts on the host.
 	metaDir string
 }

--- a/pkg/driver/mounter.go
+++ b/pkg/driver/mounter.go
@@ -15,6 +15,7 @@ package driver
 
 import (
 	"os"
+	"path/filepath"
 
 	mount_utils "k8s.io/mount-utils"
 )
@@ -52,8 +53,52 @@ func (m *NodeMounter) Stat(pathname string) (os.FileInfo, error) {
 	return os.Stat(pathname)
 }
 
+// GetDeviceName returns the device mounted at mountPath and the number of
+// /proc/mounts entries referring to it.
+//
+// It avoids mount_utils.GetDeviceNameFromMount, which resolves mountPath with
+// EvalSymlinks and so stats the mountpoint. That blocks uninterruptibly on an
+// unresponsive hard NFS mount. Symlinks are resolved on the parent only, and an
+// unmatched target yields refCount 0, which the caller reads as not mounted.
 func (m *NodeMounter) GetDeviceName(mountPath string) (string, int, error) {
-	return mount_utils.GetDeviceNameFromMount(m, mountPath)
+	mps, err := m.List()
+	if err != nil {
+		return "", 0, err
+	}
+
+	// Spellings that may appear in /proc/mounts. mountPath itself is never resolved.
+	cleanPath := filepath.Clean(mountPath)
+	candidates := []string{cleanPath}
+	if resolvedParent, err := filepath.EvalSymlinks(filepath.Dir(cleanPath)); err == nil {
+		if resolved := filepath.Join(resolvedParent, filepath.Base(cleanPath)); resolved != cleanPath {
+			candidates = append(candidates, resolved)
+		}
+	}
+
+	device := ""
+	for i := range mps {
+		for _, candidate := range candidates {
+			if mps[i].Path == candidate {
+				device = mps[i].Device
+				break
+			}
+		}
+		if device != "" {
+			break
+		}
+	}
+	if device == "" {
+		// Not mounted. Return 0 rather than counting entries with an empty Device.
+		return "", 0, nil
+	}
+
+	refCount := 0
+	for i := range mps {
+		if mps[i].Device == device {
+			refCount++
+		}
+	}
+	return device, refCount, nil
 }
 
 func (m *NodeMounter) IsLikelyNotMountPoint(target string) (bool, error) {

--- a/pkg/driver/mounter_test.go
+++ b/pkg/driver/mounter_test.go
@@ -1,0 +1,165 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package driver
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	mount_utils "k8s.io/mount-utils"
+)
+
+// newTestNodeMounter backs a NodeMounter with a fixed mount listing, reusing the
+// FakeMounterForceUnmounter adapter already defined in sanity_test.go.
+func newTestNodeMounter(mps []mount_utils.MountPoint) *NodeMounter {
+	return &NodeMounter{
+		MounterForceUnmounter: &FakeMounterForceUnmounter{
+			FakeMounter: mount_utils.NewFakeMounter(mps),
+		},
+	}
+}
+
+// TestGetDeviceName pins the property that makes the unmount pre-check
+// hang-safe: mount status is determined from the mount listing alone, never by
+// stat'ing the mountpoint. A stat against an unresponsive `hard` NFS mount
+// blocks in the kernel forever, which is what pinned ~9,800 OS threads on one
+// node. The subtest that pins that property is "the target itself is never
+// resolved"; a target path merely absent from the test host does not pin it,
+// because resolving a nonexistent path fails cheaply and harmlessly.
+func TestGetDeviceName(t *testing.T) {
+	const csiTarget = "/var/lib/kubelet/pods/uid-1/volumes/kubernetes.io~csi/pv-a/mount"
+
+	t.Run("mounted target is found and refcount counts entries sharing the device", func(t *testing.T) {
+		m := newTestNodeMounter([]mount_utils.MountPoint{
+			{Device: "127.0.0.1:/", Path: csiTarget, Type: "nfs4"},
+			{Device: "127.0.0.1:/", Path: "/var/lib/kubelet/pods/uid-2/volumes/kubernetes.io~csi/pv-a/mount", Type: "nfs4"},
+			{Device: "tmpfs", Path: "/run", Type: "tmpfs"},
+		})
+
+		device, refCount, err := m.GetDeviceName(csiTarget)
+		if err != nil {
+			t.Fatalf("GetDeviceName returned an error: %v", err)
+		}
+		if device != "127.0.0.1:/" {
+			t.Errorf("device = %q, expected %q", device, "127.0.0.1:/")
+		}
+		if refCount != 2 {
+			t.Errorf("refCount = %d, expected 2", refCount)
+		}
+	})
+
+	t.Run("unmounted target reports refcount zero", func(t *testing.T) {
+		m := newTestNodeMounter([]mount_utils.MountPoint{
+			{Device: "tmpfs", Path: "/run", Type: "tmpfs"},
+			// An entry with an empty Device pins the early return: without it, an
+			// unmatched target would count these and report a non-zero refCount.
+			{Device: "", Path: "/sys/fs/cgroup", Type: "cgroup2"},
+		})
+
+		device, refCount, err := m.GetDeviceName(csiTarget)
+		if err != nil {
+			t.Fatalf("GetDeviceName returned an error: %v", err)
+		}
+		if device != "" || refCount != 0 {
+			t.Errorf("got (%q, %d), expected (\"\", 0)", device, refCount)
+		}
+	})
+
+	t.Run("non-canonical spelling of the target still matches", func(t *testing.T) {
+		m := newTestNodeMounter([]mount_utils.MountPoint{
+			{Device: "127.0.0.1:/", Path: csiTarget, Type: "nfs4"},
+		})
+
+		_, refCount, err := m.GetDeviceName(csiTarget + "/")
+		if err != nil {
+			t.Fatalf("GetDeviceName returned an error: %v", err)
+		}
+		if refCount != 1 {
+			t.Errorf("refCount = %d, expected 1 for a trailing-slash spelling", refCount)
+		}
+	})
+
+	// A kubelet directory reached through a symlink (Bottlerocket layouts) must
+	// still match the resolved path in /proc/mounts. Only the parent may be
+	// resolved: "mount" deliberately does not exist under the real parent, so
+	// this case fails if the implementation ever resolves or stats the target.
+	t.Run("symlinked parent is resolved without touching the mountpoint", func(t *testing.T) {
+		realParent := t.TempDir()
+		linkParent := filepath.Join(t.TempDir(), "kubelet-link")
+		if err := os.Symlink(realParent, linkParent); err != nil {
+			t.Fatalf("failed to create symlink: %v", err)
+		}
+
+		m := newTestNodeMounter([]mount_utils.MountPoint{
+			{Device: "127.0.0.1:/", Path: filepath.Join(realParent, "mount"), Type: "nfs4"},
+		})
+
+		device, refCount, err := m.GetDeviceName(filepath.Join(linkParent, "mount"))
+		if err != nil {
+			t.Fatalf("GetDeviceName returned an error: %v", err)
+		}
+		if device != "127.0.0.1:/" || refCount != 1 {
+			t.Errorf("got (%q, %d), expected (%q, 1)", device, refCount, "127.0.0.1:/")
+		}
+	})
+
+	// The property that makes this hang-safe is that the target itself is never
+	// resolved. Here the target IS a symlink pointing elsewhere, and both the
+	// symlink and its destination appear in the listing with different devices. An
+	// implementation that resolved the target would return the destination's
+	// device, so this fails if the mountpoint is ever stat'ed again.
+	t.Run("the target itself is never resolved", func(t *testing.T) {
+		tmp := t.TempDir()
+		elsewhere := filepath.Join(tmp, "elsewhere")
+		if err := os.MkdirAll(elsewhere, 0o755); err != nil {
+			t.Fatalf("failed to create directory: %v", err)
+		}
+		target := filepath.Join(tmp, "mount")
+		if err := os.Symlink(elsewhere, target); err != nil {
+			t.Fatalf("failed to create symlink: %v", err)
+		}
+
+		m := newTestNodeMounter([]mount_utils.MountPoint{
+			{Device: "resolved-away", Path: elsewhere, Type: "nfs4"},
+			{Device: "127.0.0.1:/", Path: target, Type: "nfs4"},
+		})
+
+		device, refCount, err := m.GetDeviceName(target)
+		if err != nil {
+			t.Fatalf("GetDeviceName returned an error: %v", err)
+		}
+		if device != "127.0.0.1:/" || refCount != 1 {
+			t.Errorf("got (%q, %d), expected (%q, 1): the target path was resolved", device, refCount, "127.0.0.1:/")
+		}
+	})
+
+	t.Run("device shared with a bind-propagated entry is counted once per entry", func(t *testing.T) {
+		m := newTestNodeMounter([]mount_utils.MountPoint{
+			{Device: "127.0.0.1:/", Path: csiTarget, Type: "nfs4"},
+			{Device: "127.0.0.1:/", Path: "/mnt/data/kubelet/pods/uid-1/volumes/kubernetes.io~csi/pv-a/mount", Type: "nfs4"},
+		})
+
+		_, refCount, err := m.GetDeviceName(csiTarget)
+		if err != nil {
+			t.Fatalf("GetDeviceName returned an error: %v", err)
+		}
+		if refCount != 2 {
+			t.Errorf("refCount = %d, expected 2", refCount)
+		}
+	})
+}

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -359,6 +359,17 @@ func (d *Driver) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpublish
 		return nil, status.Error(codes.InvalidArgument, "Target path not provided")
 	}
 
+	// Unmounting an unresponsive hard NFS mount blocks for an unbounded time, and
+	// kubelet retries after its deadline while the abandoned handler runs on.
+	// Rejecting the duplicate keeps a wedged target to one stuck handler rather
+	// than one per retry.
+	guardKey := filepath.Clean(target)
+	if _, inFlight := d.inFlightUnpublishTargets.LoadOrStore(guardKey, struct{}{}); inFlight {
+		klog.Warningf("NodeUnpublishVolume: unpublish already in progress for %s, rejecting duplicate with ABORTED", guardKey)
+		return nil, status.Errorf(codes.Aborted, "An unpublish operation for target %q is already in progress", target)
+	}
+	defer d.inFlightUnpublishTargets.Delete(guardKey)
+
 	if d.forceUnmountAfterTimeout {
 		klog.V(5).Infof("NodeUnpublishVolume: will retry unmount %s with force after timeout %v", target, d.unmountTimeout)
 		err := d.mounter.UnmountWithForce(target, d.unmountTimeout)
@@ -366,9 +377,7 @@ func (d *Driver) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpublish
 			return nil, status.Errorf(codes.Internal, "Could not unmountWithForce %q: %v", target, err)
 		}
 	} else {
-		// Check if target directory is a mount point. GetDeviceNameFromMount
-		// given a mnt point, finds the device from /proc/mounts
-		// returns the device name, reference count, and error code
+		// Check whether the target is mounted, reading /proc/mounts without touching it.
 		_, refCount, err := d.mounter.GetDeviceName(target)
 		if err != nil {
 			format := "failed to check if volume is mounted: %v"
@@ -384,6 +393,9 @@ func (d *Driver) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpublish
 			return &csi.NodeUnpublishVolumeResponse{}, nil
 		}
 
+		// Still unbounded: umount of an unresponsive mount cannot be cancelled.
+		// Escalation to umount -f stays behind the forceUnmountAfterTimeout opt-in
+		// rather than becoming the default.
 		klog.V(5).Infof("NodeUnpublishVolume: unmounting %s", target)
 		err = d.mounter.Unmount(target)
 		if err != nil {

--- a/pkg/driver/node_test.go
+++ b/pkg/driver/node_test.go
@@ -35,6 +35,8 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/kubernetes-sigs/aws-efs-csi-driver/pkg/driver/mocks"
 	"github.com/kubernetes-sigs/aws-efs-csi-driver/pkg/util"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -1052,6 +1054,111 @@ func TestNodePublishUnpublishVolumeConcurrent(t *testing.T) {
 		}(i)
 	}
 	wg.Wait()
+}
+
+// TestNodeUnpublishVolumeDeduplicatesConcurrentCalls pins the per-target
+// in-flight guard. Unmounting an unresponsive mount can outlive kubelet's
+// client-side RPC deadline by an unbounded margin, and kubelet then retries
+// while the first handler is still blocked. Each retry must be rejected
+// immediately rather than stacking another handler goroutine and OS thread
+// behind the same blocked syscall.
+func TestNodeUnpublishVolumeDeduplicatesConcurrentCalls(t *testing.T) {
+	// awaitOrFail keeps a regression from deadlocking the package: gomock's
+	// unexpected-call Fatalf runs runtime.Goexit inside the helper goroutine, so a
+	// channel it was going to close is never closed. Without a deadline here the
+	// test would hang until the whole package times out instead of failing.
+	awaitOrFail := func(t *testing.T, c <-chan struct{}, what string) {
+		t.Helper()
+		select {
+		case <-c:
+		case <-time.After(10 * time.Second):
+			t.Fatalf("timed out waiting for %s; the handler probably did not reach the unmount", what)
+		}
+	}
+
+	for _, forceUnmount := range []bool{false, true} {
+		name := "default unmount path"
+		if forceUnmount {
+			name = "forceUnmountAfterTimeout path"
+		}
+		t.Run(name, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
+			mockMounter := mocks.NewMockMounter(mockCtrl)
+			driver := &Driver{
+				mounter:                  mockMounter,
+				metaDir:                  t.TempDir(),
+				forceUnmountAfterTimeout: forceUnmount,
+				unmountTimeout:           30 * time.Second,
+			}
+
+			req := &csi.NodeUnpublishVolumeRequest{VolumeId: volumeId, TargetPath: targetPath}
+
+			unmountStarted := make(chan struct{})
+			releaseUnmount := make(chan struct{})
+			block := func() error {
+				close(unmountStarted)
+				<-releaseUnmount
+				return nil
+			}
+
+			// The first call blocks in the unmount, as it would on a wedged mount.
+			// The guard must cover both branches, so each is exercised.
+			if forceUnmount {
+				mockMounter.EXPECT().UnmountWithForce(gomock.Eq(targetPath), gomock.Eq(30*time.Second)).
+					DoAndReturn(func(string, time.Duration) error { return block() })
+			} else {
+				mockMounter.EXPECT().GetDeviceName(gomock.Eq(targetPath)).Return("", 1, nil)
+				mockMounter.EXPECT().Unmount(gomock.Eq(targetPath)).DoAndReturn(func(string) error { return block() })
+			}
+
+			firstDone := make(chan error, 1)
+			go func() {
+				_, err := driver.NodeUnpublishVolume(context.Background(), req)
+				firstDone <- err
+			}()
+			awaitOrFail(t, unmountStarted, "the first unpublish to reach the unmount")
+
+			// A second call for the same target while the first is blocked must be
+			// rejected without reaching the mounter at all. No further expectations
+			// are registered, so gomock fails the test on any unexpected call.
+			_, err := driver.NodeUnpublishVolume(context.Background(), req)
+			if status.Code(err) != codes.Aborted {
+				t.Fatalf("duplicate in-flight unpublish: got code %v (%v), expected Aborted", status.Code(err), err)
+			}
+
+			// A spelling variant of the same target must also be rejected, so a
+			// trailing slash cannot bypass the guard.
+			_, err = driver.NodeUnpublishVolume(context.Background(), &csi.NodeUnpublishVolumeRequest{
+				VolumeId:   volumeId,
+				TargetPath: targetPath + "/",
+			})
+			if status.Code(err) != codes.Aborted {
+				t.Fatalf("non-canonical spelling of an in-flight target: got code %v (%v), expected Aborted", status.Code(err), err)
+			}
+
+			close(releaseUnmount)
+			select {
+			case err := <-firstDone:
+				if err != nil {
+					t.Fatalf("first NodeUnpublishVolume failed: %v", err)
+				}
+			case <-time.After(10 * time.Second):
+				t.Fatal("timed out waiting for the first unpublish to return")
+			}
+
+			// The guard must be released once the first call returns.
+			if !forceUnmount {
+				mockMounter.EXPECT().GetDeviceName(gomock.Eq(targetPath)).Return("", 0, nil)
+			} else {
+				mockMounter.EXPECT().UnmountWithForce(gomock.Eq(targetPath), gomock.Eq(30*time.Second)).Return(nil)
+			}
+			if _, err := driver.NodeUnpublishVolume(context.Background(), req); err != nil {
+				t.Fatalf("NodeUnpublishVolume after the guard was released failed: %v", err)
+			}
+		})
+	}
 }
 
 func TestNodeGetVolumeStats(t *testing.T) {


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

Bug fix.

**What is this PR about? / Why do we need it?**

`NodeUnpublishVolume` could leak one OS thread per kubelet retry, without limit, against a mount whose `efs-proxy` had died. In one reported incident a node accumulated 9,780 permanently blocked threads and stayed unusable for 12 days. The Go runtime aborts the process at 10,000 threads (`runtime/proc.go`, `sched.maxmcount`).

Two causes, both in the non-force path:

1. The pre-check called `NodeMounter.GetDeviceName`, which delegated to `mount_utils.GetDeviceNameFromMount`. That resolves the target with `filepath.EvalSymlinks`, so it stats the mountpoint itself. On an unresponsive `hard` NFS mount the stat blocks in the kernel uninterruptibly, and the handler does not consult the request context, so no handler reached the unmount.
2. Nothing bounded concurrency. kubelet abandons the call at its RPC deadline and retries, but the abandoned handler keeps running, so every retry added another permanently blocked thread. The existing in-flight tracker covers only `NodePublishVolume`.

This PR reimplements `GetDeviceName` to read `/proc/mounts` and resolve symlinks on the target's parent only, never the target, and adds a per-target in-flight guard that rejects a duplicate unpublish with `ABORTED`. kubelet retries that like any other failure.

Scope, stated plainly. This contains the failure rather than repairing it. The unmount itself is still unbounded, so one handler per wedged target can remain stuck and that volume stays unpublishable until the mount responds or the driver restarts. The guard is what holds the cost at one handler instead of one per retry. Escalating to `umount -f` stays behind the existing `--force-unmount-after-timeout` opt-in, which defaults to off, so operators choose force rather than receiving it by default.

Two paths with the same unbounded shape are not addressed here: `NodePublishVolume` stats the target through `MakeDir`, and `NodeGetVolumeStats` calls `os.Stat` on it directly.

**What testing is done?**

`make test` and `make verify` pass.

- `TestGetDeviceName` covers the mounted, unmounted, non-canonical and symlinked-parent cases. One subtest pins the property that matters: the target is itself a symlink whose destination is also in the mount listing under a different device, so the test fails if anything resolves the target again.
- `TestNodeUnpublishVolumeDeduplicatesConcurrentCalls` runs against both the default and the `forceUnmountAfterTimeout` branch. It asserts the duplicate is rejected with `ABORTED` without reaching the mounter, that a trailing-slash spelling is also rejected, and that the guard is released once the first call returns. Both channel waits have deadlines so a regression fails rather than hanging the package.
- Checked by mutation. Re-introducing a stat of the mountpoint, deleting the not-mounted early return, guarding only one branch, or reverting the unmount call each turn a test red.
